### PR TITLE
Update pom.xml

### DIFF
--- a/pact/pact-runtime/pom.xml
+++ b/pact/pact-runtime/pom.xml
@@ -32,7 +32,7 @@
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>pact-array-datamodel</artifactId>
-			<version>0.2</version>
+			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The configured dependency version for pact-array-datamodel should be the same as the one of the enclosing project.
