### PR TITLE
Updated Maven artifacts version to 0.2-ozone.

### DIFF
--- a/nephele/nephele-clustermanager/pom.xml
+++ b/nephele/nephele-clustermanager/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>nephele</artifactId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/nephele/nephele-common/pom.xml
+++ b/nephele/nephele-common/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-common</artifactId>

--- a/nephele/nephele-compression-bzip2/pom.xml
+++ b/nephele/nephele-compression-bzip2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
       <artifactId>nephele</artifactId>
       <groupId>eu.stratosphere</groupId>
-      <version>0.2</version>
+      <version>0.2-ozone</version>
     </parent>
 
     <groupId>eu.stratosphere</groupId>

--- a/nephele/nephele-compression-lzma/pom.xml
+++ b/nephele/nephele-compression-lzma/pom.xml
@@ -7,7 +7,7 @@
     <parent>
       <artifactId>nephele</artifactId>
       <groupId>eu.stratosphere</groupId>
-      <version>0.2</version>
+      <version>0.2-ozone</version>
     </parent>
 
     <groupId>eu.stratosphere</groupId>

--- a/nephele/nephele-compression-snappy/pom.xml
+++ b/nephele/nephele-compression-snappy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
       <artifactId>nephele</artifactId>
       <groupId>eu.stratosphere</groupId>
-      <version>0.2</version>
+      <version>0.2-ozone</version>
     </parent>
 
     <groupId>eu.stratosphere</groupId>

--- a/nephele/nephele-compression-zlib/pom.xml
+++ b/nephele/nephele-compression-zlib/pom.xml
@@ -7,7 +7,7 @@
     <parent>
       <artifactId>nephele</artifactId>
       <groupId>eu.stratosphere</groupId>
-      <version>0.2</version>
+      <version>0.2-ozone</version>
     </parent>
 
     <groupId>eu.stratosphere</groupId>

--- a/nephele/nephele-examples/pom.xml
+++ b/nephele/nephele-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-examples</artifactId>

--- a/nephele/nephele-hdfs/pom.xml
+++ b/nephele/nephele-hdfs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-hdfs</artifactId>

--- a/nephele/nephele-management/pom.xml
+++ b/nephele/nephele-management/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-management</artifactId>

--- a/nephele/nephele-profiling/pom.xml
+++ b/nephele/nephele-profiling/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-profiling</artifactId>

--- a/nephele/nephele-queuescheduler/pom.xml
+++ b/nephele/nephele-queuescheduler/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>nephele</artifactId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 	
 	<modelVersion>4.0.0</modelVersion>

--- a/nephele/nephele-s3/pom.xml
+++ b/nephele/nephele-s3/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-s3</artifactId>

--- a/nephele/nephele-server/pom.xml
+++ b/nephele/nephele-server/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-server</artifactId>

--- a/nephele/nephele-visualization/pom.xml
+++ b/nephele/nephele-visualization/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele-visualization</artifactId>

--- a/nephele/pom.xml
+++ b/nephele/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>ozone</artifactId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>nephele</artifactId>

--- a/pact/pact-array-datamodel/pom.xml
+++ b/pact/pact-array-datamodel/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 	
 	<artifactId>pact-array-datamodel</artifactId>

--- a/pact/pact-clients/pom.xml
+++ b/pact/pact-clients/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>pact-clients</artifactId>

--- a/pact/pact-common/pom.xml
+++ b/pact/pact-common/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>pact-common</artifactId>

--- a/pact/pact-compiler/pom.xml
+++ b/pact/pact-compiler/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>pact-compiler</artifactId>

--- a/pact/pact-examples/pom.xml
+++ b/pact/pact-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>pact-examples</artifactId>

--- a/pact/pact-runtime/pom.xml
+++ b/pact/pact-runtime/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>pact-runtime</artifactId>

--- a/pact/pact-tests/pom.xml
+++ b/pact/pact-tests/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>pact-tests</artifactId>

--- a/pact/pom.xml
+++ b/pact/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>ozone</artifactId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>pact</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>eu.stratosphere</groupId>
 	<artifactId>ozone</artifactId>
-	<version>0.2</version>
+	<version>0.2-ozone</version>
 
 	<name>ozone</name>
 	<packaging>pom</packaging>

--- a/stratosphere-dist/pom.xml
+++ b/stratosphere-dist/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>ozone</artifactId>
-		<version>0.2</version>
+		<version>0.2-ozone</version>
 	</parent>
 
 	<artifactId>stratosphere-dist</artifactId>


### PR DESCRIPTION
Allows deploying Ozone to a local repository next to a vanilla Stratosphere distribution. Closes #27.
