### PR TITLE
Support for Cloudera Hadoop

### DIFF
--- a/nephele/nephele-hdfs/pom.xml
+++ b/nephele/nephele-hdfs/pom.xml
@@ -23,10 +23,23 @@
 			<version>${project.version}</version>
 		</dependency>
 
-
+		<!-- Ye Olde Hadoop
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-core</artifactId>
+		</dependency>
+		-->
+		
+		
+		<!-- Coudera Hadoop (no need for hadoop-core anymore) -->
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-hdfs</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/nephele/nephele-hdfs/src/main/java/eu/stratosphere/nephele/fs/hdfs/DistributedFileSystem.java
+++ b/nephele/nephele-hdfs/src/main/java/eu/stratosphere/nephele/fs/hdfs/DistributedFileSystem.java
@@ -16,6 +16,7 @@
 package eu.stratosphere.nephele.fs.hdfs;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URI;
 
 import org.apache.commons.logging.Log;
@@ -73,7 +74,18 @@ public final class DistributedFileSystem extends FileSystem {
 			LOG.debug("Cannot find hdfs-site configuration file");
 		}
 
-		final Class<?> clazz = conf.getClass(HDFS_IMPLEMENTATION_KEY, null);
+		Class<?> clazz = null;
+		try {
+			Method newApi = org.apache.hadoop.fs.FileSystem.class.getMethod("getFileSystemClass", String.class, Configuration.class);
+			clazz = (Class<?>) newApi.invoke("hdfs",conf);
+		} catch (Exception e) {
+			// if we can't find the FileSystem class using the new API,
+			// clazz will still be null, we assume we're running on an older Hadoop version
+		}
+		if (clazz == null) {
+			clazz = conf.getClass(HDFS_IMPLEMENTATION_KEY, null);
+		}
+
 		if (clazz == null) {
 			throw new IOException("No FileSystem found for " + HDFS_IMPLEMENTATION_KEY);
 		}

--- a/nephele/nephele-hdfs/src/main/java/eu/stratosphere/nephele/fs/hdfs/DistributedFileSystem.java
+++ b/nephele/nephele-hdfs/src/main/java/eu/stratosphere/nephele/fs/hdfs/DistributedFileSystem.java
@@ -75,9 +75,11 @@ public final class DistributedFileSystem extends FileSystem {
 		}
 
 		Class<?> clazz = null;
+		
+		// try to get the FileSystem implementation class Hadoop 2.0.0 style
 		try {
-			Method newApi = org.apache.hadoop.fs.FileSystem.class.getMethod("getFileSystemClass", String.class, Configuration.class);
-			clazz = (Class<?>) newApi.invoke("hdfs",conf);
+			Method newApi = org.apache.hadoop.fs.FileSystem.class.getMethod("getFileSystemClass", String.class, org.apache.hadoop.conf.Configuration.class);
+			clazz = (Class<?>) newApi.invoke(null, "hdfs",conf);
 		} catch (Exception e) {
 			// if we can't find the FileSystem class using the new API,
 			// clazz will still be null, we assume we're running on an older Hadoop version

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/splitassigner/DefaultInputSplitAssigner.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/splitassigner/DefaultInputSplitAssigner.java
@@ -98,7 +98,7 @@ public class DefaultInputSplitAssigner implements InputSplitAssigner {
 
 		InputSplit nextSplit = queue.poll();
 
-		if (LOG.isDebugEnabled()) {
+		if (LOG.isDebugEnabled() && nextSplit != null) {
 			LOG.debug("Assigning split " + nextSplit.getSplitNumber() + " to " + vertex);
 		}
 

--- a/pact/pact-runtime/pom.xml
+++ b/pact/pact-runtime/pom.xml
@@ -35,9 +35,17 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- Ye Olde Hadoop
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-core</artifactId>
+		</dependency>
+		 -->
+		
+		<!-- Coudera Hadoop (no need for hadoop-core anymore) -->
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
 		</dependency>
 
 	</dependencies>

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/util/TestBase2.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/util/TestBase2.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.junit.After;
 import org.junit.Assert;
@@ -155,7 +156,7 @@ public abstract class TestBase2 {
 		File f = new File(baseDir, fileName);
 		
 		if (f.exists()) {
-			Files.deleteRecursively(f);
+			deleteRecursively(f);
 		}
 		
 		File parentToDelete = f;
@@ -218,7 +219,7 @@ public abstract class TestBase2 {
 	private void deleteAllTempFiles() throws IOException {
 		for (File f : this.tempFiles) {
 			if (f.exists()) {
-				Files.deleteRecursively(f);
+				deleteRecursively(f);
 			}
 		}
 	}
@@ -403,6 +404,14 @@ public abstract class TestBase2 {
 			configs.add(c);
 		}
 		return configs;
+	}
+	
+	private static void deleteRecursively (File f) throws IOException {
+		if (f.isDirectory()) {
+			FileUtils.deleteDirectory(f);
+		} else {
+			f.delete();
+		}
 	}
 	
 	public void readAllResultLines(List<String> target, String resultPath) throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>r09</version>
+			<version>14.0.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,14 +120,13 @@
 			<scope>test</scope>
 		</dependency>
 		
-		<!-- Cloudera Hadoop
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-core</artifactId>
-			<version>2.0.0-mr1-cdh4.1.2</version>
-			<type>jar</type>
-			<scope>compile</scope>
-		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<!-- this section defines the module versions that are used if nothing else is specified. -->
+		<dependencies>
+			
+		<!-- Cloudera Hadoop -->
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
@@ -142,9 +141,9 @@
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
-		-->
 		
-		<!-- Ye'Olde Hadoop -->
+		
+		<!-- Ye'Olde Hadoop 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-core</artifactId>
@@ -152,12 +151,7 @@
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
-		
-	</dependencies>
-
-	<dependencyManagement>
-		<!-- this section defines the module versions that are used if nothing else is specified. -->
-		<dependencies>
+		-->
 			
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,19 @@
 
 	<pluginRepositories>
 	</pluginRepositories>
+	
+	<repositories>
+      <repository>
+        <id>cloudera-releases</id>
+        <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+        <releases>
+          <enabled>true</enabled>
+        </releases>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+      </repository>
+    </repositories>
 
 	<dependencies>
 	
@@ -107,18 +120,45 @@
 			<scope>test</scope>
 		</dependency>
 		
+		<!-- Cloudera Hadoop
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-core</artifactId>
+			<version>2.0.0-mr1-cdh4.1.2</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+			<version>2.0.0-cdh4.2.1</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-hdfs</artifactId>
+			<version>2.0.0-cdh4.2.1</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		-->
+		
+		<!-- Ye'Olde Hadoop -->
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-core</artifactId>
+			<version>0.20.203.0</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		
 	</dependencies>
 
 	<dependencyManagement>
 		<!-- this section defines the module versions that are used if nothing else is specified. -->
 		<dependencies>
-			<dependency>
-				<groupId>org.apache.hadoop</groupId>
-				<artifactId>hadoop-core</artifactId>
-				<version>0.20.203.0</version>
-				<type>jar</type>
-				<scope>compile</scope>
-			</dependency>
+			
 		</dependencies>
 	</dependencyManagement>
 

--- a/stratosphere-dist/src/main/assemblies/bin.xml
+++ b/stratosphere-dist/src/main/assemblies/bin.xml
@@ -22,7 +22,28 @@
 			<useTransitiveDependencies>true</useTransitiveDependencies>
 			<useProjectArtifact>false</useProjectArtifact>
 			<useProjectAttachments>false</useProjectAttachments>
-
+			<useTransitiveFiltering>true</useTransitiveFiltering>
+			
+			<excludes>
+				<exclude>**/*examples*.jar</exclude>
+				<exclude>**/*javadoc*</exclude>
+				<exclude>**/*sources*</exclude>
+				<exclude>eu.stratosphere:pact-clients:**</exclude>
+			</excludes>
+		</dependencySet>
+		
+		<dependencySet>
+			<outputDirectory>lib_clients</outputDirectory>
+			<unpack>false</unpack>
+			<useTransitiveDependencies>true</useTransitiveDependencies>
+			<useProjectArtifact>false</useProjectArtifact>
+			<useProjectAttachments>false</useProjectAttachments>
+			<useTransitiveFiltering>true</useTransitiveFiltering>
+			
+			<includes>
+				<include>eu.stratosphere:pact-clients:**</include>
+			</includes>
+			
 			<excludes>
 				<exclude>**/*examples*.jar</exclude>
 				<exclude>**/*javadoc*</exclude>

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-jobmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-jobmanager.sh
@@ -41,57 +41,10 @@ fi
 constructJobManagerClassPath() {
 
 	for jarfile in $NEPHELE_LIB_DIR/*.jar ; do
-
-		add=0
-
-		if [[ "$jarfile" =~ 'nephele-server' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-management' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-hdfs' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-s3' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-profiling' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-queuescheduler' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-clustermanager' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-array-datamodel' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-runtime' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-cli' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-logging' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-codec' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-configuration' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-lang' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'log4j' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'hadoop-core' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'aws-java-sdk' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'guava' ]]; then
-			add=1
-		fi
-
-		if [[ "$add" = "1" ]]; then
-			if [[ $NEPHELE_JM_CLASSPATH = "" ]]; then
-				NEPHELE_JM_CLASSPATH=$jarfile;
-			else
-				NEPHELE_JM_CLASSPATH=$NEPHELE_JM_CLASSPATH:$jarfile
-			fi
+		if [[ $NEPHELE_JM_CLASSPATH = "" ]]; then
+			NEPHELE_JM_CLASSPATH=$jarfile;
+		else
+			NEPHELE_JM_CLASSPATH=$NEPHELE_JM_CLASSPATH:$jarfile
 		fi
 	done
 

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-taskmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-taskmanager.sh
@@ -34,57 +34,10 @@ fi
 constructTaskManagerClassPath() {
 
 	for jarfile in $NEPHELE_LIB_DIR/*.jar ; do
-
-		add=0
-
-		if [[ "$jarfile" =~ 'nephele-server' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-management' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-hdfs' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-s3' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-profiling' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-queuescheduler' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-clustermanager' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-array-datamodel' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-runtime' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-cli' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-logging' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-codec' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-configuration' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-lang' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'log4j' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'hadoop-core' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'aws-java-sdk' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'guava' ]]; then
-			add=1
-		fi
-
-		if [[ "$add" = "1" ]]; then
-			if [[ $NEPHELE_TM_CLASSPATH = "" ]]; then
-				NEPHELE_TM_CLASSPATH=$jarfile;
-			else
-				NEPHELE_TM_CLASSPATH=$NEPHELE_TM_CLASSPATH:$jarfile
-			fi
+		if [[ $NEPHELE_TM_CLASSPATH = "" ]]; then
+			NEPHELE_TM_CLASSPATH=$jarfile;
+		else
+			NEPHELE_TM_CLASSPATH=$NEPHELE_TM_CLASSPATH:$jarfile
 		fi
 	done
 

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-visualization.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-visualization.sh
@@ -29,33 +29,10 @@ fi
 constructVisualizationClassPath() {
 
 	for jarfile in $NEPHELE_LIB_DIR/*.jar ; do
-
-		add=0
-
-		if [[ "$jarfile" =~ 'nephele-visualization' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-management' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-logging' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'log4j' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'x86_64' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jfreechart' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jcommon' ]]; then
-			add=1
-		fi
-
-		if [[ "$add" = "1" ]]; then
-			if [[ $NEPHELE_VS_CLASSPATH = "" ]]; then
-				NEPHELE_VS_CLASSPATH=$jarfile;
-			else
-				NEPHELE_VS_CLASSPATH=$NEPHELE_VS_CLASSPATH:$jarfile
-			fi
+		if [[ $NEPHELE_VS_CLASSPATH = "" ]]; then
+			NEPHELE_VS_CLASSPATH=$jarfile;
+		else
+			NEPHELE_VS_CLASSPATH=$NEPHELE_VS_CLASSPATH:$jarfile
 		fi
 	done
 

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/pact-client.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/pact-client.sh
@@ -31,55 +31,10 @@ JVM_ARGS="$JVM_ARGS -Xmx512m"
 constructPactCLIClientClassPath() {
 
 	for jarfile in $NEPHELE_LIB_DIR/*.jar ; do
-
-		add=0
-
-		if [[ "$jarfile" =~ 'nephele-server' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-management' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-hdfs' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-s3' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-clients' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-array-datamodel' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-runtime' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-compiler' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-cli' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-logging' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-codec' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-configuration' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-lang' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'log4j' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'hadoop-core' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'aws-java-sdk' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'guava' ]]; then
-			add=1
-		fi
-
-		if [[ "$add" = "1" ]]; then
-			if [[ $PACT_CC_CLASSPATH = "" ]]; then
-				PACT_CC_CLASSPATH=$jarfile;
-			else
-				PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile
-			fi
+		if [[ $PACT_CC_CLASSPATH = "" ]]; then
+			PACT_CC_CLASSPATH=$jarfile;
+		else
+			PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile
 		fi
 	done
 

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/pact-client.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/pact-client.sh
@@ -24,6 +24,8 @@ if [ "$NEPHELE_IDENT_STRING" = "" ]; then
         NEPHELE_IDENT_STRING="$USER"
 fi
 
+NEPHELE_LIB_CLIENTS_DIR=$NEPHELE_ROOT_DIR/lib_clients
+
 JVM_ARGS="$JVM_ARGS -Xmx512m"
 
 # auxilliary function to construct a lightweight classpath for the
@@ -39,6 +41,10 @@ constructPactCLIClientClassPath() {
 	done
 
 	for jarfile in $NEPHELE_LIB_DIR/dropins/*.jar ; do
+		PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile
+	done
+	
+	for jarfile in $NEPHELE_LIB_CLIENTS_DIR/*.jar ; do
 		PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile
 	done
 

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/pact-webfrontend.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/pact-webfrontend.sh
@@ -30,6 +30,8 @@ if [ "$NEPHELE_IDENT_STRING" = "" ]; then
         NEPHELE_IDENT_STRING="$USER"
 fi
 
+NEPHELE_LIB_CLIENTS_DIR=$NEPHELE_ROOT_DIR/lib_clients
+
 JVM_ARGS="$JVM_ARGS -Xmx512m"
 
 # auxilliary function to construct a lightweight classpath for the
@@ -37,80 +39,19 @@ JVM_ARGS="$JVM_ARGS -Xmx512m"
 constructPactWebFrontendClassPath() {
 
 	for jarfile in $NEPHELE_LIB_DIR/*.jar ; do
-
-		add=0
-
-		if [[ "$jarfile" =~ 'nephele-server' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-management' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-hdfs' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'nephele-s3' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-clients' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-common' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-array-datamodel' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-runtime' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'pact-compiler' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-cli' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-logging' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-codec' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-configuration' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-lang' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'log4j' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'hadoop-core' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'aws-java-sdk' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'guava' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-fileupload' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'commons-io' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jetty-continuation' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jetty-http' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jetty-io' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jetty-security' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jetty-server' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jetty-servlet' ]]; then
-			add=1
-		elif [[ "$jarfile" =~ 'jetty-util' ]]; then
-			add=1			
-		elif [[ "$jarfile" =~ 'servlet-api' ]]; then
-			add=1
-		fi
-
-		if [[ "$add" = "1" ]]; then
-			if [[ $PACT_WF_CLASSPATH = "" ]]; then
-				PACT_WF_CLASSPATH=$jarfile;
-			else
-				PACT_WF_CLASSPATH=$PACT_WF_CLASSPATH:$jarfile
-			fi
+		if [[ $PACT_WF_CLASSPATH = "" ]]; then
+			PACT_WF_CLASSPATH=$jarfile;
+		else
+			PACT_WF_CLASSPATH=$PACT_WF_CLASSPATH:$jarfile
 		fi
 	done
 
 	for jarfile in $NEPHELE_LIB_DIR/dropins/*.jar ; do
 		PACT_WF_CLASSPATH=$PACT_WF_CLASSPATH:$jarfile
+	done
+	
+	for jarfile in $NEPHELE_LIB_CLIENTS_DIR/*.jar ; do
+		PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile
 	done
 
 	echo $PACT_WF_CLASSPATH


### PR DESCRIPTION
# Cloudera Hadoop Support for Ozone

These changes allow to use and easily switch between different Hadoop versions.
## How to use:
- adjust the hadoop version in the main pom (samples for Hadoop 0.20.203.0 and 2.0.0-cdh4.2.1 are provided)
- adjust all poms that require Hadoop to use the correct jar names (hadoop-core changed to hadoop-common, hadoop-hdfs may need to be added)
## Side effects:

Different Hadoop versions use different jar names and have different dependencies that need to be added to the classpath.
Previously all jar names were explicitly listed in the application startup scripts. While this allows for tailor-made classpaths it is also a major maintenance overhead.
The behavior was changed so the startup scripts now add all jars from the <ozone_root>/lib folder to the classpath.
Jars required by pact-clients have been moved to lib_clients, to avoid unnecessary overhead for worker tasks.
In the end this means far less classpath management overhead while retaining a reasonably clean classpath.
