### PR TITLE
Fix Multiplexing Deadlock

### DIFF
--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/executiongraph/ExecutionGraph.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/executiongraph/ExecutionGraph.java
@@ -1402,8 +1402,11 @@ public class ExecutionGraph implements ExecutionListener {
 		for (int i = 0; i < lastStage.getNumberOfStageMembers(); ++i) {
 
 			final ExecutionGroupVertex groupVertex = lastStage.getStageMember(i);
+			
+			int currentConnectionID = 0;
+			
 			if (groupVertex.isOutputVertex()) {
-				groupVertex.calculateConnectionID(0, alreadyVisited);
+			  currentConnectionID = groupVertex.calculateConnectionID(currentConnectionID, alreadyVisited);
 			}
 		}
 	}

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/executiongraph/ExecutionGroupVertex.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/executiongraph/ExecutionGroupVertex.java
@@ -927,19 +927,25 @@ public final class ExecutionGroupVertex {
 	 *        the current connection ID
 	 * @param alreadyVisited
 	 *        the set of already visited group vertices
+	 * @return maximum assigned connectionID
 	 */
-	void calculateConnectionID(final int currentConnectionID, final Set<ExecutionGroupVertex> alreadyVisited) {
+	int calculateConnectionID(int currentConnectionID, final Set<ExecutionGroupVertex> alreadyVisited) {
 
 		if (!alreadyVisited.add(this)) {
-			return;
+			return currentConnectionID;
 		}
-
-		int nextConnectionID = currentConnectionID;
+		
 		for (final ExecutionGroupEdge backwardLink : this.backwardLinks) {
-			backwardLink.setConnectionID(nextConnectionID);
-			backwardLink.getSourceVertex().calculateConnectionID(nextConnectionID, alreadyVisited);
-			++nextConnectionID;
+		  
+			backwardLink.setConnectionID(currentConnectionID);
+			
+			++currentConnectionID;
+			
+			currentConnectionID = backwardLink.getSourceVertex()
+			    .calculateConnectionID(currentConnectionID, alreadyVisited);
 		}
+		
+		return currentConnectionID;
 	}
 
 	/**


### PR DESCRIPTION
This fixes #20 by assigning a unique connectionID (per stage) to every ExecutionEdge.
