### PR TITLE
Fix ArrayIndexOutOfBoundsException when reading test input > 32KB

### DIFF
--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/IntTupleDataInFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/IntTupleDataInFormat.java
@@ -26,7 +26,7 @@ public class IntTupleDataInFormat extends DelimitedInputFormat {
 	public static final int DELIMITER = '|';
 	
 	private final PactInteger key = new PactInteger();
-	private final short[] offsets = new short[MAX_COLUMNS];
+	private final int[] offsets = new int[MAX_COLUMNS];
 
 	@Override
 	public boolean readRecord(PactRecord target, byte[] line, int offset, int numBytes)
@@ -35,14 +35,14 @@ public class IntTupleDataInFormat extends DelimitedInputFormat {
 		int readPos = offset;
 
 		// allocate the offsets array
-		final short[] offsets = this.offsets;
-		offsets[0] = (short) offset;
+		final int[] offsets = this.offsets;
+		offsets[0] = offset;
 
 		int col = 1; // the column we are in
 
 		while (readPos < limit) {
 			if (line[readPos++] == DELIMITER) {
-				offsets[col++] = (short) (readPos);
+				offsets[col++] = readPos;
 			}
 		}
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/Tuple.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/Tuple.java
@@ -25,7 +25,7 @@ public class Tuple implements Value {
 
 	private byte[] bytes;
 
-	private short[] offsets;
+	private int[] offsets;
 
 	private int numCols;
 
@@ -49,7 +49,7 @@ public class Tuple implements Value {
 	 * @param cols
 	 *        The number of columns.
 	 */
-	public Tuple(byte[] bytes, short[] offsets, int cols) {
+	public Tuple(byte[] bytes, int[] offsets, int cols) {
 		this.bytes = bytes;
 		this.offsets = offsets;
 		this.numCols = cols;
@@ -105,7 +105,7 @@ public class Tuple implements Value {
 		
 		if (bytes == null) {
 			bytes = (byte[]) other.bytes.clone();
-			offsets = (short[]) other.offsets.clone();
+			offsets = (int[]) other.offsets.clone();
 			numCols = other.numCols;
 		} else {
 			int len = offsets[numCols];
@@ -125,14 +125,14 @@ public class Tuple implements Value {
 
 			// offsets
 			if (offsets.length < numCols + other.numCols + 1) {
-				short[] tmp = new short[numCols + other.numCols + 1];
+				int[] tmp = new int[numCols + other.numCols + 1];
 				System.arraycopy(offsets, 0, tmp, 0, numCols + 1);
 				offsets = tmp;
 			}
 
 			// other offsets
 			for (int i = 1; i < other.numCols + 1; i++) {
-				offsets[numCols + i] = (short) (other.offsets[i] + len);
+				offsets[numCols + i] = other.offsets[i] + len;
 			}
 
 			numCols += other.numCols;
@@ -172,12 +172,12 @@ public class Tuple implements Value {
 		// copy the columns to the beginning and adjust the offsets to the new array
 		for (int i = 0; i < k; i++) {
 			System.arraycopy(bytes, offsets[i], tmp, lenCount, lengths[i]);
-			offsets[i] = (short) lenCount;
+			offsets[i] = lenCount;
 			lenCount += lengths[i];
 		}
 
 		bytes = tmp;
-		offsets[numCols] = (short) tmp.length;
+		offsets[numCols] = tmp.length;
 	}
 
 	/**
@@ -395,7 +395,7 @@ public class Tuple implements Value {
 		}
 
 		if (offsets.length > numCols + 1) {
-			short[] tmp = new short[numCols + 1];
+			int[] tmp = new int[numCols + 1];
 			System.arraycopy(offsets, 0, tmp, 0, numCols + 1);
 			offsets = tmp;
 		}
@@ -410,7 +410,7 @@ public class Tuple implements Value {
 		int end;
 
 		if (numCols == 0) {
-			offsets = new short[5];
+			offsets = new int[5];
 			bytes = new byte[Math.max(256, attValue.length + 1)];
 			end = 0;
 		} else {
@@ -418,7 +418,7 @@ public class Tuple implements Value {
 
 			// increase offset array, if necessary
 			if (numCols + 1 >= offsets.length) {
-				short[] tmp = new short[offsets.length * 2];
+				int[] tmp = new int[offsets.length * 2];
 				System.arraycopy(offsets, 0, tmp, 0, numCols + 1);
 				offsets = tmp;
 			}
@@ -436,7 +436,7 @@ public class Tuple implements Value {
 		end += attValue.length;
 		bytes[end++] = '|';
 		numCols++;
-		offsets[numCols] = (short) end;
+		offsets[numCols] = end;
 	}
 
 	/**
@@ -448,7 +448,7 @@ public class Tuple implements Value {
 		int end;
 
 		if (numCols == 0) {
-			offsets = new short[5];
+			offsets = new int[5];
 			bytes = new byte[Math.max(256, attValue.length() + 1)];
 			end = 0;
 		} else {
@@ -456,7 +456,7 @@ public class Tuple implements Value {
 
 			// increase offset array, if necessary
 			if (numCols + 1 >= offsets.length) {
-				short[] tmp = new short[offsets.length * 2];
+				int[] tmp = new int[offsets.length * 2];
 				System.arraycopy(offsets, 0, tmp, 0, numCols + 1);
 				offsets = tmp;
 			}
@@ -475,7 +475,7 @@ public class Tuple implements Value {
 		}
 		bytes[end++] = '|';
 		numCols++;
-		offsets[numCols] = (short) end;
+		offsets[numCols] = end;
 	}
 	
 	/**
@@ -489,7 +489,7 @@ public class Tuple implements Value {
 		int end;
 
 		if (numCols == 0) {
-			offsets = new short[5];
+			offsets = new int[5];
 			bytes = new byte[Math.max(256, len)];
 			end = 0;
 		} else {
@@ -497,7 +497,7 @@ public class Tuple implements Value {
 
 			// increase offset array, if necessary
 			if (numCols + 1 >= offsets.length) {
-				short[] tmp = new short[offsets.length * 2];
+				int[] tmp = new int[offsets.length * 2];
 				System.arraycopy(offsets, 0, tmp, 0, numCols + 1);
 				offsets = tmp;
 			}
@@ -512,7 +512,7 @@ public class Tuple implements Value {
 
 		System.arraycopy(other.bytes, other.offsets[column], bytes, end, len);
 		numCols++;
-		offsets[numCols] = (short) (end + len);
+		offsets[numCols] = end + len;
 	}
 	
 	public void setContents(byte[] bytes, int offset, int len, char delimiter)
@@ -529,7 +529,7 @@ public class Tuple implements Value {
 		
 		// allocate the offsets array
 		if (this.offsets == null) {
-			this.offsets = new short[4];
+			this.offsets = new int[4];
 		}
 
 		int col = 1; // the column we are in
@@ -539,11 +539,11 @@ public class Tuple implements Value {
 		while (readPos < offset + len) {
 			if (bytes[readPos++] == delimiter) {
 				if (offsets.length <= col) {
-					short newOffsets[] = new short[this.offsets.length * 2];
+					int newOffsets[] = new int[this.offsets.length * 2];
 					System.arraycopy(this.offsets, 0, newOffsets, 0, this.offsets.length);
 					this.offsets = newOffsets;
 				}
-				this.offsets[col++] = (short) (readPos - startPos);
+				this.offsets[col++] = readPos - startPos;
 			}
 		}
 		
@@ -565,12 +565,12 @@ public class Tuple implements Value {
 
 			// read the offsets
 			numCols = in.readInt() + 1;
-			offsets = new short[numCols + 1];
+			offsets = new int[numCols + 1];
 			for (int i = 1; i < numCols; i++) {
-				offsets[i] = in.readShort();
+				offsets[i] = in.readInt();
 			}
 			// set last offset
-			offsets[numCols] = (short) numBytes;
+			offsets[numCols] = numBytes;
 		} else {
 			numCols = 0;
 		}
@@ -588,7 +588,7 @@ public class Tuple implements Value {
 			// exclude first and last
 			out.writeInt(numCols - 1);
 			for (int i = 1; i < numCols; i++) {
-				out.writeShort(offsets[i]);
+				out.writeInt(offsets[i]);
 			}
 		}
 	}

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/tests/TupleTest.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/tests/TupleTest.java
@@ -32,7 +32,7 @@ public class TupleTest {
 	public void testTupleByteArrayShortArrayInt() {
 		
 		String tupleStr = "attr1|attr2|3|4|attr5|";
-		short[] offsets = {0,6,12,14,16,22};
+		int[] offsets = {0,6,12,14,16,22};
 		Tuple t1 = new Tuple(tupleStr.getBytes(),offsets,5);
 		
 		Assert.assertTrue(t1.getBytes().length == tupleStr.getBytes().length);
@@ -65,7 +65,7 @@ public class TupleTest {
 		Assert.assertTrue(t.getNumberOfColumns() == 3);
 		
 		String tupleStr = "attr1|attr2|3|4|attr5|";
-		short[] offsets = {0,6,12,14,16,22};
+		int[] offsets = {0,6,12,14,16,22};
 		t = new Tuple(tupleStr.getBytes(),offsets,5);
 		
 		Assert.assertTrue(t.getNumberOfColumns() == 5);
@@ -95,7 +95,7 @@ public class TupleTest {
 		Assert.assertTrue(ret1[exp1.getBytes().length+1] == 0);
 		
 		String tupleStr = "attr1|attr2|3|4|attr5|";
-		short[] offsets = {0,6,12,14,16,22};
+		int[] offsets = {0,6,12,14,16,22};
 		Tuple t2 = new Tuple(tupleStr.getBytes(),offsets,5);
 		
 		byte[] ret2 = t2.getBytes();
@@ -124,7 +124,7 @@ public class TupleTest {
 		Assert.assertTrue(t.getColumnLength(2) == 14);
 		
 		String tupleStr = "attr1|attr2|3|4|attr5|";
-		short[] offsets = {0,6,12,14,16,22};
+		int[] offsets = {0,6,12,14,16,22};
 		t = new Tuple(tupleStr.getBytes(),offsets,5);
 		
 		Assert.assertTrue(t.getColumnLength(0) == 5);
@@ -521,7 +521,7 @@ public class TupleTest {
 		Assert.assertTrue(t.getBytes().length == 13);
 		
 		byte[] ba = new byte[1024];
-		short[] of = {0};
+		int[] of = {0};
 		t = new Tuple(ba, of, 0);
 		
 		Assert.assertTrue(t.getBytes().length == 1024);
@@ -529,7 +529,7 @@ public class TupleTest {
 		Assert.assertTrue(t.getBytes().length == 0);
 		
 		ba = "attr1|attr2|3|4|attr5|thisdoesnotbelongtothetuple".getBytes();
-		short[] of2 = {0,6,12,14,16,22};
+		int[] of2 = {0,6,12,14,16,22};
 		t = new Tuple(ba, of2, 5);
 		
 		Assert.assertTrue(t.getBytes().length == ba.length);
@@ -651,7 +651,7 @@ public class TupleTest {
 		}
 		
 		byte[] ba = "attr1|attr2|3|4|attr5|thisdoesnotbelongtothetuple".getBytes();
-		short[] of2 = {0,6,12,14,16,22};
+		int[] of2 = {0,6,12,14,16,22};
 		t = new Tuple(ba, of2, 5);
 		
 		try {
@@ -736,7 +736,7 @@ public class TupleTest {
 		Assert.assertTrue(t.toString().equals("Hello world!|2ndValue|"));
 		
 		byte[] ba = "attr1|attr2|3|4|attr5|thisdoesnotbelongtothetuple".getBytes();
-		short[] of2 = {0,6,12,14,16,22};
+		int[] of2 = {0,6,12,14,16,22};
 		t = new Tuple(ba, of2, 5);
 		
 		Assert.assertTrue(t.toString().equals("attr1|attr2|3|4|attr5|"));


### PR DESCRIPTION
This fixes a bug, where tests in `pact-tests` using `Tuple` or `IntTupleDataInFormat` would throw `ArrayIndexOutOfBoundsException` on input > 32 KB.

I used TPCH-9 query from `pact-tests` to reliably reproduce the multiplexing deadlock (see issue #20) even on small scale (because of the relatively long processing pipeline).
