### PR TITLE
Smaller backports of 0.2.1 APIs

### DIFF
--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/io/AbstractID.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/io/AbstractID.java
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  *
- * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -22,8 +22,10 @@ import java.io.IOException;
 import eu.stratosphere.nephele.util.StringUtils;
 
 /**
- * ID is an abstract base class to provide statistically unique and serializable identification numbers in Nephele.
+ * ID is an abstract base class for providing statistically unique identification numbers in Nephele.
  * Every component that requires these kinds of IDs provides its own concrete type.
+ * <p>
+ * This class is thread-safe.
  * 
  * @author warneke
  */
@@ -63,12 +65,49 @@ public abstract class AbstractID implements IOReadableWritable {
 	}
 
 	/**
+	 * Constructs a new abstract ID.
+	 * 
+	 * @param lowerPart
+	 *        the lower bytes of the ID
+	 * @param upperPart
+	 *        the higher bytes of the ID
+	 */
+	protected AbstractID(final long lowerPart, final long upperPart) {
+
+		this.lowerPart = lowerPart;
+		this.upperPart = upperPart;
+	}
+
+	/**
+	 * Creates a new abstract ID from the given one. The given and the newly created abtract ID will be identical, i.e.
+	 * a comparison by <code>equals</code> will return <code>true</code> and both objects will have the same hash code.
+	 * 
+	 * @param id
+	 *        the abstract ID to copy
+	 */
+	protected AbstractID(final AbstractID id) {
+
+		this.lowerPart = id.lowerPart;
+		this.upperPart = id.upperPart;
+	}
+
+	/**	
 	 * Constructs a new random ID from a uniform distribution.
 	 */
 	public AbstractID() {
 
-		this.lowerPart = (long) (Math.random() * Long.MAX_VALUE);
-		this.upperPart = (long) (Math.random() * Long.MAX_VALUE);
+		this.lowerPart = generateRandomBytes();
+		this.upperPart = generateRandomBytes();
+	}
+
+	/**
+	 * Generates a uniformly distributed random positive long.
+	 * 
+	 * @return a uniformly distributed random positive long
+	 */
+	protected static long generateRandomBytes() {
+
+		return (long) (Math.random() * Long.MAX_VALUE);
 	}
 
 	/**
@@ -108,7 +147,7 @@ public abstract class AbstractID implements IOReadableWritable {
 			ba[offset + SIZE_OF_LONG - 1 - i] = (byte) ((l & (0xffL << shift)) >>> shift);
 		}
 	}
-
+	
 	/**
 	 * Sets an ID from another ID by copying its internal byte representation.
 	 * 

--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/ipc/Client.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/ipc/Client.java
@@ -627,7 +627,7 @@ public class Client {
 	 * Construct an IPC client whose values are of the given {@link Writable} class.
 	 */
 	public Client(final SocketFactory factory) {
-		this.maxIdleTime = 10000;
+		this.maxIdleTime = 1000;
 		this.maxRetries = 10;
 		this.tcpNoDelay = false;
 		this.pingInterval = DEFAULT_PING_INTERVAL;

--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/jobgraph/JobID.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/jobgraph/JobID.java
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  *
- * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -18,12 +18,14 @@ package eu.stratosphere.nephele.jobgraph;
 import eu.stratosphere.nephele.io.AbstractID;
 
 /**
- * A <code>JobID</code> is a statistically unique identification number that unambiguously
- * identifies a job configuration.
+ * A class for statistically unique job IDs.
+ * <p>
+ * This class is thread-safe.
  * 
  * @author warneke
  */
 public final class JobID extends AbstractID {
+
 	/**
 	 * Constructs a new random ID from a uniform distribution.
 	 */
@@ -32,12 +34,49 @@ public final class JobID extends AbstractID {
 	}
 
 	/**
-	 * Constructs a new ID with a specific bytes value.
+	 * Constructs a new job ID.
+	 * 
+	 * @param lowerPart
+	 *        the lower bytes of the ID
+	 * @param upperPart
+	 *        the higher bytes of the ID
+	 */
+	private JobID(final long lowerPart, final long upperPart) {
+		super(lowerPart, upperPart);
+	}
+
+	/**
+	 * Constructs a new job ID from the given bytes.
 	 * 
 	 * @param bytes
-	 *        the ID in byte representation
+	 *        the bytes to initialize the job ID with
 	 */
 	public JobID(final byte[] bytes) {
 		super(bytes);
+	}
+
+	/**
+	 * Generates a new statistically unique job ID.
+	 * 
+	 * @return a new statistically unique job ID
+	 */
+	public static JobID generate() {
+
+		final long lowerPart = AbstractID.generateRandomBytes();
+		final long upperPart = AbstractID.generateRandomBytes();
+
+		return new JobID(lowerPart, upperPart);
+	}
+
+	/**
+	 * Constructs a new job ID and initializes it with the given bytes.
+	 * 
+	 * @param bytes
+	 *        the bytes to initialize the new job ID with
+	 * @return the new job ID
+	 */
+	public static JobID fromByteArray(final byte[] bytes) {
+
+		return new JobID(bytes);
 	}
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalInstanceManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalInstanceManager.java
@@ -247,11 +247,11 @@ public class LocalInstanceManager implements InstanceManager {
 
 		// Stop the internal instance of the task manager
 		if (this.localTaskManagerThread != null) {
-			// Interrupt the thread running the task manager
-			this.localTaskManagerThread.interrupt();
 
 			while (!this.localTaskManagerThread.isTaskManagerShutDown()) {
 				try {
+					// Interrupt the thread running the task manager
+					this.localTaskManagerThread.interrupt();
 					Thread.sleep(100);
 				} catch (InterruptedException e) {
 					break;

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/GenericDataSink.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/GenericDataSink.java
@@ -161,7 +161,7 @@ public class GenericDataSink extends Contract
 	 * 
 	 * @param input		The contracts will be set as inputs.
 	 */
-	public void setInputs(List<Contract> inputs) {
+	public void setInputs(List<? extends Contract> inputs) {
 		this.input.clear();
 		this.input.addAll(inputs);
 	}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactString.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactString.java
@@ -41,7 +41,7 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * @see java.lang.String
  * @see java.lang.CharSequence
  */
-public class PactString implements Key, NormalizableKey, CharSequence, CopyableValue<PactString> {
+public class PactString implements Key, NormalizableKey, CharSequence, CopyableValue<PactString>, Appendable {
 	
 	private static final char[] EMPTY_STRING = new char[0];
 	
@@ -75,7 +75,7 @@ public class PactString implements Key, NormalizableKey, CharSequence, CopyableV
 	 * 
 	 * @param value The string containing the value for this PactString.
 	 */
-	public PactString(String value) {
+	public PactString(CharSequence value) {
 		this.value = EMPTY_STRING;
 		setValue(value);
 	}
@@ -140,7 +140,7 @@ public class PactString implements Key, NormalizableKey, CharSequence, CopyableV
 	 * 
 	 * @param value The new string value.
 	 */
-	public void setValue(String value) {
+	public void setValue(CharSequence value) {
 		if (value == null)
 			throw new NullPointerException("Value must not be null");
 		
@@ -168,7 +168,7 @@ public class PactString implements Key, NormalizableKey, CharSequence, CopyableV
 		System.arraycopy(value.value, 0, this.value, 0, value.len);
 		this.hashCode = 0;
 	}
-	
+
 	/**
 	 * Sets the value of the PactString to a substring of the given string.
 	 * 
@@ -186,6 +186,28 @@ public class PactString implements Key, NormalizableKey, CharSequence, CopyableV
 		ensureSize(len);
 		this.len = len;
 		System.arraycopy(value.value, offset, this.value, 0, len);
+		this.hashCode = 0;
+	}
+	
+	/**
+	 * Sets the value of the PactString to a substring of the given string.
+	 * 
+	 * @param value The new string value.
+	 * @param offset The position to start the substring.
+	 * @param len The length of the substring.
+	 */
+	public void setValue(CharSequence value, int offset, int len) {
+		if (value == null)
+			throw new NullPointerException();
+		
+		if (offset < 0 || len < 0 || offset > value.length() - len)
+			throw new IndexOutOfBoundsException();
+
+		ensureSize(len);
+		this.len = len;		
+		for (int i = 0; i < len; i++) 
+			this.value[i] = value.charAt(offset + i);
+		this.len = len;
 		this.hashCode = 0;
 	}
 	
@@ -402,7 +424,66 @@ public class PactString implements Key, NormalizableKey, CharSequence, CopyableV
 		return startsWith(prefix, 0);
 	}
 	
-	
+	// --------------------------------------------------------------------------------------------
+	// Appendable Methods
+	// --------------------------------------------------------------------------------------------
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Appendable#append(char)
+	 */
+	@Override
+	public Appendable append(char c) {
+		grow(this.len + 1);
+		this.value[this.len++] = c;
+		return this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Appendable#append(java.lang.CharSequence)
+	 */
+	@Override
+	public Appendable append(CharSequence csq) {
+		append(csq, 0, csq.length());
+		return this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Appendable#append(java.lang.CharSequence, int, int)
+	 */
+	@Override
+	public Appendable append(CharSequence csq, int start, int end) {
+		final int otherLen = end - start;
+		grow(this.len + otherLen);
+		for (int pos = start; pos < len; pos++)
+			this.value[this.len + pos] = csq.charAt(pos);
+		this.len += otherLen;
+		return this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Appendable#append(java.lang.CharSequence)
+	 */
+	public Appendable append(PactString csq) {
+		append(csq, 0, csq.length());
+		return this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Appendable#append(java.lang.CharSequence, int, int)
+	 */
+	public Appendable append(PactString csq, int start, int end) {
+		final int otherLen = end - start;
+		grow(this.len + otherLen);
+		System.arraycopy(csq.value, start, this.value, this.len, otherLen);
+		this.len += otherLen;
+		return this;
+	}
+		
 	// --------------------------------------------------------------------------------------------
 	//                            Serialization / De-Serialization
 	// --------------------------------------------------------------------------------------------
@@ -652,6 +733,17 @@ public class PactString implements Key, NormalizableKey, CharSequence, CopyableV
 	private final void ensureSize(int size) {
 		if (this.value.length < size) {
 			this.value = new char[size];
+		}
+	}
+	
+	/**
+	 * Grow and retain content.
+	 */
+	private final void grow(int size) {
+		if (this.value.length < size) {
+			char[] value = new char[ Math.max(this.value.length * 3 / 2, size)];
+			System.arraycopy(this.value, 0, value, 0, this.len);
+			this.value = value;
 		}
 	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/ContractUtil.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/ContractUtil.java
@@ -1,0 +1,181 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.pact.generic.contract;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import eu.stratosphere.pact.common.contract.GenericDataSink;
+import eu.stratosphere.pact.common.contract.GenericDataSource;
+import eu.stratosphere.pact.common.io.FileInputFormat;
+import eu.stratosphere.pact.common.io.FileOutputFormat;
+import eu.stratosphere.pact.generic.io.InputFormat;
+import eu.stratosphere.pact.generic.io.OutputFormat;
+import eu.stratosphere.pact.generic.stub.GenericCoGrouper;
+import eu.stratosphere.pact.generic.stub.GenericCrosser;
+import eu.stratosphere.pact.generic.stub.GenericMapper;
+import eu.stratosphere.pact.generic.stub.GenericMatcher;
+import eu.stratosphere.pact.generic.stub.GenericReducer;
+
+/**
+ * Convenience methods when dealing with {@link Contract}s.
+ * 
+ * @author Arvid Heise
+ */
+public class ContractUtil {
+	private final static Map<Class<?>, Class<? extends Contract>> STUB_CONTRACTS =
+		new LinkedHashMap<Class<?>, Class<? extends Contract>>();
+
+	static {
+		STUB_CONTRACTS.put(GenericMapper.class, GenericMapContract.class);
+		STUB_CONTRACTS.put(GenericReducer.class, GenericReduceContract.class);
+		STUB_CONTRACTS.put(GenericCoGrouper.class, GenericCoGroupContract.class);
+		STUB_CONTRACTS.put(GenericCrosser.class, GenericCrossContract.class);
+		STUB_CONTRACTS.put(GenericMatcher.class, GenericMatchContract.class);
+		STUB_CONTRACTS.put(FileInputFormat.class, GenericDataSource.class);
+		STUB_CONTRACTS.put(FileOutputFormat.class, GenericDataSink.class);
+		STUB_CONTRACTS.put(InputFormat.class, GenericDataSource.class);
+		STUB_CONTRACTS.put(OutputFormat.class, GenericDataSink.class);
+	}
+
+	/**
+	 * Returns the associated {@link Contract} type for the given {@link Stub} class.
+	 * 
+	 * @param stubClass
+	 *        the stub class
+	 * @return the associated Contract type
+	 */
+	@SuppressWarnings({ "unchecked" })
+	public static Class<? extends Contract> getContractClass(final Class<?> stubClass) {
+		if (stubClass == null)
+			return null;
+		final Class<?> contract = STUB_CONTRACTS.get(stubClass);
+		if (contract != null)
+			return (Class<? extends Contract>) contract;
+		Iterator<Entry<Class<?>, Class<? extends Contract>>> stubContracts = STUB_CONTRACTS.entrySet().iterator();
+		while (stubContracts.hasNext()) {
+			Map.Entry<Class<?>, Class<? extends Contract>> entry = stubContracts.next();
+			if (entry.getKey().isAssignableFrom(stubClass))
+				return entry.getValue();
+		}
+		return null;
+
+	}
+
+	/**
+	 * Returns the number of inputs for the given {@link Contract} type.<br>
+	 * Currently, it can be 0, 1, or 2.
+	 * 
+	 * @param contractClass
+	 *        the type of the Contract
+	 * @return the number of input contracts
+	 */
+	public static int getNumInputs(final Class<? extends Contract> contractType) {
+
+		if (GenericDataSource.class.isAssignableFrom(contractType))
+			return 0;
+		if (GenericDataSink.class.isAssignableFrom(contractType)
+			|| SingleInputContract.class.isAssignableFrom(contractType))
+			return 1;
+		if (DualInputContract.class.isAssignableFrom(contractType))
+			return 2;
+		throw new IllegalArgumentException("not supported");
+	}
+
+	/**
+	 * Returns a list of all inputs for the given {@link Contract}.<br>
+	 * Currently, the list can have 0, 1, or 2 elements.
+	 * 
+	 * @param contract
+	 *        the Contract whose inputs should be returned
+	 * @return all input contracts to this contract
+	 */
+	public static List<List<Contract>> getInputs(final Contract contract) {
+		ArrayList<List<Contract>> inputs = new ArrayList<List<Contract>>();
+
+		if (contract instanceof GenericDataSink)
+			inputs.add(new ArrayList<Contract>(((GenericDataSink) contract).getInputs()));
+		else if (contract instanceof SingleInputContract)
+			inputs.add(new ArrayList<Contract>(((SingleInputContract<?>) contract).getInputs()));
+		else if (contract instanceof DualInputContract) {
+			inputs.add(new ArrayList<Contract>(((DualInputContract<?>) contract).getFirstInputs()));
+			inputs.add(new ArrayList<Contract>(((DualInputContract<?>) contract).getSecondInputs()));
+		}
+		return inputs;
+	}
+
+	public static List<Contract> getFlatInputs(final Contract contract) {
+		if (contract instanceof GenericDataSink)
+			return ((GenericDataSink) contract).getInputs();
+		if (contract instanceof SingleInputContract)
+			return ((SingleInputContract<?>) contract).getInputs();
+		if (contract instanceof DualInputContract) {
+			ArrayList<Contract> inputs = new ArrayList<Contract>();
+			inputs.addAll(((DualInputContract<?>) contract).getFirstInputs());
+			inputs.addAll(((DualInputContract<?>) contract).getSecondInputs());
+			return inputs;
+		}
+
+		return new ArrayList<Contract>();
+	}
+
+	/**
+	 * Sets the inputs of the given {@link Contract}.<br>
+	 * Currently, the list can have 0, 1, or 2 elements and the number of elements must match the type of the contract.
+	 * 
+	 * @param contract
+	 *        the Contract whose inputs should be set
+	 * @param inputs
+	 *        all input contracts to this contract
+	 */
+	public static void setInputs(final Contract contract, final List<List<Contract>> inputs) {
+		if (contract instanceof GenericDataSink) {
+			if (inputs.size() != 1)
+				throw new IllegalArgumentException("wrong number of inputs");
+			((GenericDataSink) contract).setInputs(inputs.get(0));
+		} else if (contract instanceof SingleInputContract) {
+			if (inputs.size() != 1)
+				throw new IllegalArgumentException("wrong number of inputs");
+			((SingleInputContract<?>) contract).setInputs(inputs.get(0));
+		} else if (contract instanceof DualInputContract) {
+			if (inputs.size() != 2)
+				throw new IllegalArgumentException("wrong number of inputs");
+			((DualInputContract<?>) contract).setFirstInputs(inputs.get(0));
+			((DualInputContract<?>) contract).setSecondInputs(inputs.get(1));
+		}
+	}
+
+	/**
+	 * Swaps two inputs of the given contract.
+	 * 
+	 * @param contract
+	 *        the contract
+	 * @param input1
+	 *        the first input index
+	 * @param input2
+	 *        the second input index
+	 */
+	public static void swapInputs(Contract contract, int input1, int input2) {
+		final List<List<Contract>> inputs = new ArrayList<List<Contract>>(getInputs(contract));
+		Collections.swap(inputs, input1, input2);
+		setInputs(contract, inputs);
+	}
+}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryOutputFormat.java
@@ -12,7 +12,7 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.pact.common.io;
+package eu.stratosphere.pact.generic.io;
 
 import java.io.DataOutput;
 import java.io.DataOutputStream;
@@ -21,12 +21,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import eu.stratosphere.nephele.configuration.Configuration;
-import eu.stratosphere.pact.common.type.PactRecord;
+import eu.stratosphere.nephele.types.Record;
 
 /**
  * @author Arvid Heise
  */
-public abstract class BinaryOutputFormat extends FileOutputFormat {
+public abstract class BinaryOutputFormat<T extends Record> extends FileOutputFormat<T> {
 	/**
 	 * The config parameter which defines the fixed length of a record.
 	 */
@@ -52,7 +52,8 @@ public abstract class BinaryOutputFormat extends FileOutputFormat {
 		this.dataOutputStream.close();
 		super.close();
 	}
-
+	
+	@SuppressWarnings("unused") 
 	protected void complementBlockInfo(BlockInfo blockInfo) throws IOException {
 	}
 
@@ -92,14 +93,14 @@ public abstract class BinaryOutputFormat extends FileOutputFormat {
 		this.dataOutputStream = new DataOutputStream(this.blockBasedInput);
 	}
 
-	protected abstract void serialize(PactRecord record, DataOutput dataOutput) throws IOException;
+	protected abstract void serialize(T record, DataOutput dataOutput) throws IOException;
 
 	/*
 	 * (non-Javadoc)
 	 * @see eu.stratosphere.pact.common.io.OutputFormat#writeRecord(eu.stratosphere.pact.common.type.PactRecord)
 	 */
 	@Override
-	public void writeRecord(PactRecord record) throws IOException {
+	public void writeRecord(T record) throws IOException {
 		this.blockBasedInput.startRecord();
 		this.serialize(record, this.dataOutputStream);
 	}
@@ -172,7 +173,7 @@ public abstract class BinaryOutputFormat extends FileOutputFormat {
 
 			for (int remainingLength = len, offset = off; remainingLength > 0;) {
 				int blockLen = Math.min(remainingLength, this.maxPayloadSize - this.blockPos);
-				out.write(b, offset, blockLen);
+				this.out.write(b, offset, blockLen);
 
 				this.blockPos += blockLen;
 				if (this.blockPos >= this.maxPayloadSize)

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BlockInfo.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BlockInfo.java
@@ -12,7 +12,7 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.pact.common.io;
+package eu.stratosphere.pact.generic.io;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FormatUtil.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FormatUtil.java
@@ -28,8 +28,7 @@ import eu.stratosphere.nephele.fs.FileInputSplit;
 import eu.stratosphere.nephele.fs.FileStatus;
 import eu.stratosphere.nephele.fs.FileSystem;
 import eu.stratosphere.nephele.fs.Path;
-import eu.stratosphere.nephele.template.GenericInputSplit;
-import eu.stratosphere.nephele.types.Record;
+import eu.stratosphere.nephele.template.InputSplit;
 import eu.stratosphere.pact.common.util.ReflectionUtil;
 
 /**
@@ -56,7 +55,7 @@ public class FormatUtil {
 	 * @throws IOException
 	 *         if an I/O error occurred while accessing the file or initializing the InputFormat.
 	 */
-	public static <T extends Record, F extends FileInputFormat<T>> F openInput(
+	public static <T, F extends FileInputFormat<T>> F openInput(
 			Class<F> inputFormatClass, String path, Configuration configuration) throws IOException {
 		configuration = configuration == null ? new Configuration() : configuration;
 
@@ -92,7 +91,7 @@ public class FormatUtil {
 	 *         if an I/O error occurred while accessing the files or initializing the InputFormat.
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T extends Record, F extends FileInputFormat<T>> List<F> openAllInputs(
+	public static <T, F extends FileInputFormat<T>> List<F> openAllInputs(
 			Class<F> inputFormatClass, String path, Configuration configuration) throws IOException {
 		Path nephelePath = new Path(path);
 		FileSystem fs = nephelePath.getFileSystem();
@@ -120,13 +119,13 @@ public class FormatUtil {
 	 * @throws IOException
 	 *         if an I/O error occurred while accessing the file or initializing the InputFormat.
 	 */
-	public static <T extends Record, F extends GenericInputFormat<T>> F openInput(
+	public static <T, IS extends InputSplit, F extends InputFormat<T, IS>> F openInput(
 			Class<F> inputFormatClass, Configuration configuration) throws IOException {
 		configuration = configuration == null ? new Configuration() : configuration;
 
 		final F inputFormat = ReflectionUtil.newInstance(inputFormatClass);
 		inputFormat.configure(configuration);
-		final GenericInputSplit[] splits = inputFormat.createInputSplits(1);
+		final IS[] splits = inputFormat.createInputSplits(1);
 		inputFormat.open(splits[0]);
 		return inputFormat;
 	}
@@ -147,7 +146,7 @@ public class FormatUtil {
 	 * @throws IOException
 	 *         if an I/O error occurred while accessing the file or initializing the OutputFormat.
 	 */
-	public static <T extends Record, F extends FileOutputFormat<T>> F openOutput(
+	public static <T, F extends FileOutputFormat<? extends T>> F openOutput(
 			Class<F> outputFormatClass, String pathString, Configuration configuration) throws IOException {
 		final F outputFormat = ReflectionUtil.newInstance(outputFormatClass);
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/GenericInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/GenericInputFormat.java
@@ -46,7 +46,7 @@ public abstract class GenericInputFormat<OT> implements InputFormat<OT, GenericI
 	 * @see eu.stratosphere.pact.common.io.InputFormat#getStatistics()
 	 */
 	@Override
-	public BaseStatistics getStatistics(BaseStatistics cachedStatistics) {
+	public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
 		// no statistics available, by default.
 		return cachedStatistics;
 	}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialInputFormat.java
@@ -34,6 +34,6 @@ public class SequentialInputFormat<T extends Record> extends BinaryInputFormat<T
 	 */
 	@Override
 	protected void deserialize(Record record, DataInput dataInput) throws IOException {
-		record.read(dataInput);
+		record.read(dataInput);		
 	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialInputFormat.java
@@ -12,29 +12,28 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.pact.common.io;
+package eu.stratosphere.pact.generic.io;
 
-import java.io.DataOutput;
+import java.io.DataInput;
 import java.io.IOException;
 
-import eu.stratosphere.pact.common.type.PactRecord;
+import eu.stratosphere.nephele.types.Record;
 
 /**
- * Stores complete {@link PactRecord}s in an efficient binary format which is deserializable without configuration.
+ * Reads the {@link Record}s from the native format which is deserializable without configuration.
  * 
  * @author Arvid Heise
- * @see BlockBasedOutputFormat
- * @see SequentialInputFormat
+ * @see SequentialOutputFormat
  */
-public class SequentialOutputFormat extends BinaryOutputFormat {
+public class SequentialInputFormat<T extends Record> extends BinaryInputFormat<T> {
 	/*
 	 * (non-Javadoc)
 	 * @see
-	 * eu.stratosphere.pact.testing.ioformats.BlockBasedOutputFormat#serialize(eu.stratosphere.pact.common.type.PactRecord
-	 * , java.io.DataOutput)
+	 * eu.stratosphere.pact.testing.ioformats.BlockBasedInputFormat#deserialize(eu.stratosphere.pact.common.type.PactRecord
+	 * , java.io.DataInput)
 	 */
 	@Override
-	protected void serialize(PactRecord record, DataOutput dataOutputStream) throws IOException {
-		record.write(dataOutputStream);
+	protected void deserialize(Record record, DataInput dataInput) throws IOException {
+		record.read(dataInput);
 	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialOutputFormat.java
@@ -12,28 +12,29 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.pact.common.io;
+package eu.stratosphere.pact.generic.io;
 
-import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 
-import eu.stratosphere.pact.common.type.PactRecord;
+import eu.stratosphere.nephele.types.Record;
 
 /**
- * Reads the {@link PactRecord}s from the native format which is deserializable without configuration.
+ * Stores complete {@link Record}s in an efficient binary format which is deserializable without configuration.
  * 
  * @author Arvid Heise
- * @see SequentialOutputFormat
+ * @see BlockBasedOutputFormat
+ * @see SequentialInputFormat
  */
-public class SequentialInputFormat extends BinaryInputFormat {
+public class SequentialOutputFormat extends BinaryOutputFormat<Record> {
 	/*
 	 * (non-Javadoc)
 	 * @see
-	 * eu.stratosphere.pact.testing.ioformats.BlockBasedInputFormat#deserialize(eu.stratosphere.pact.common.type.PactRecord
-	 * , java.io.DataInput)
+	 * eu.stratosphere.pact.testing.ioformats.BlockBasedOutputFormat#serialize(eu.stratosphere.pact.common.type.PactRecord
+	 * , java.io.DataOutput)
 	 */
 	@Override
-	protected void deserialize(PactRecord record, DataInput dataInput) throws IOException {
-		record.read(dataInput);
+	protected void serialize(Record record, DataOutput dataOutputStream) throws IOException {
+		record.write(dataOutputStream);
 	}
 }

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/contract/ContractUtilTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/contract/ContractUtilTest.java
@@ -1,0 +1,167 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.pact.generic.contract;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import eu.stratosphere.pact.common.contract.GenericDataSink;
+import eu.stratosphere.pact.common.contract.GenericDataSource;
+import eu.stratosphere.pact.common.io.DelimitedInputFormat;
+import eu.stratosphere.pact.common.io.DelimitedOutputFormat;
+import eu.stratosphere.pact.common.stubs.CoGroupStub;
+import eu.stratosphere.pact.common.stubs.Collector;
+import eu.stratosphere.pact.common.stubs.CrossStub;
+import eu.stratosphere.pact.common.stubs.MapStub;
+import eu.stratosphere.pact.common.stubs.MatchStub;
+import eu.stratosphere.pact.common.stubs.ReduceStub;
+import eu.stratosphere.pact.common.stubs.Stub;
+import eu.stratosphere.pact.common.type.PactRecord;
+
+/**
+ * Tests {@link ContractUtil}.
+ * 
+ * @author Arvid Heise
+ */
+public class ContractUtilTest {
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnCoGroupForCoGroupStub() {
+		final Class<?> result = ContractUtil.getContractClass(CoGrouper.class);
+		assertEquals(GenericCoGroupContract.class, result);
+	}
+
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnCrossForCrossStub() {
+		final Class<?> result = ContractUtil.getContractClass(Crosser.class);
+		assertEquals(GenericCrossContract.class, result);
+	}
+
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnMapForMapStub() {
+		final Class<?> result = ContractUtil.getContractClass(Mapper.class);
+		assertEquals(GenericMapContract.class, result);
+	}
+
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnMatchForMatchStub() {
+		final Class<?> result = ContractUtil.getContractClass(Matcher.class);
+		assertEquals(GenericMatchContract.class, result);
+	}
+
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnNullForStub() {
+		final Class<?> result = ContractUtil.getContractClass(Stub.class);
+		assertEquals(null, result);
+	}
+
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnReduceForReduceStub() {
+		final Class<?> result = ContractUtil.getContractClass(Reducer.class);
+		assertEquals(GenericReduceContract.class, result);
+	}
+
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnSinkForOutputFormat() {
+		final Class<?> result = ContractUtil.getContractClass(DelimitedOutputFormat.class);
+		assertEquals(GenericDataSink.class, result);
+	}
+
+	/**
+	 * Test {@link ContractUtil#getContractClass(Class)}
+	 */
+	@Test
+	public void getContractClassShouldReturnSourceForInputFormat() {
+		final Class<?> result = ContractUtil.getContractClass(DelimitedInputFormat.class);
+		assertEquals(GenericDataSource.class, result);
+	}
+
+	static class CoGrouper extends CoGroupStub {
+		/* (non-Javadoc)
+		 * @see eu.stratosphere.pact.common.stubs.CoGroupStub#coGroup(java.util.Iterator, java.util.Iterator, eu.stratosphere.pact.common.stubs.Collector)
+		 */
+		@Override
+		public void coGroup(Iterator<PactRecord> records1, Iterator<PactRecord> records2, Collector<PactRecord> out) {
+		}
+	}
+
+	static class Crosser extends CrossStub {
+		/*
+		 * (non-Javadoc)
+		 * @see eu.stratosphere.pact.common.stubs.CrossStub#cross(eu.stratosphere.pact.common.type.PactRecord,
+		 * eu.stratosphere.pact.common.type.PactRecord, eu.stratosphere.pact.common.stubs.Collector)
+		 */
+		@Override
+		public void cross(PactRecord record1, PactRecord record2, Collector<PactRecord> out) {
+		}
+	}
+
+	static class Mapper extends MapStub {
+		/*
+		 * (non-Javadoc)
+		 * @see eu.stratosphere.pact.common.stubs.MapStub#map(eu.stratosphere.pact.common.type.PactRecord,
+		 * eu.stratosphere.pact.common.stubs.Collector)
+		 */
+		@Override
+		public void map(PactRecord record, Collector<PactRecord> out) throws Exception {
+		}
+	}
+
+	static class Matcher extends MatchStub {
+		/*
+		 * (non-Javadoc)
+		 * @see eu.stratosphere.pact.common.stubs.MatchStub#match(eu.stratosphere.pact.common.type.PactRecord,
+		 * eu.stratosphere.pact.common.type.PactRecord, eu.stratosphere.pact.common.stubs.Collector)
+		 */
+		@Override
+		public void match(PactRecord value1, PactRecord value2, Collector<PactRecord> out) throws Exception {
+		}
+	}
+
+	static class Reducer extends ReduceStub {
+		/*
+		 * (non-Javadoc)
+		 * @see eu.stratosphere.pact.common.stubs.ReduceStub#reduce(java.util.Iterator,
+		 * eu.stratosphere.pact.common.stubs.Collector)
+		 */
+		@Override
+		public void reduce(Iterator<PactRecord> records, Collector<PactRecord> out) throws Exception {
+		}
+	}
+}

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/SequentialFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/SequentialFormatTest.java
@@ -12,7 +12,7 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.pact.common.io;
+package eu.stratosphere.pact.generic.io;
 
 import java.io.DataOutputStream;
 import java.io.File;
@@ -34,6 +34,7 @@ import org.junit.runners.Parameterized.Parameters;
 import eu.stratosphere.nephele.configuration.Configuration;
 import eu.stratosphere.nephele.fs.FileInputSplit;
 import eu.stratosphere.nephele.fs.Path;
+import eu.stratosphere.nephele.types.Record;
 import eu.stratosphere.pact.common.io.statistics.BaseStatistics;
 import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactInteger;
@@ -67,7 +68,7 @@ public class SequentialFormatTest {
 
 	private int degreeOfParallelism;
 
-	private BlockInfo info = new SequentialInputFormat().createBlockInfo();
+	private BlockInfo info = new SequentialInputFormat<Record>().createBlockInfo();
 
 	private int[] rawDataSizes;
 
@@ -89,12 +90,12 @@ public class SequentialFormatTest {
 	@Before
 	public void calcRawDataSize() throws IOException {
 		int recordIndex = 0;
-		for (int fileIndex = 0; fileIndex < degreeOfParallelism; fileIndex++) {
+		for (int fileIndex = 0; fileIndex < this.degreeOfParallelism; fileIndex++) {
 			ByteCounter byteCounter = new ByteCounter();
 			DataOutputStream out = new DataOutputStream(byteCounter);
-			for (int fileCount = 0; fileCount < getNumberOfTuplesPerFile(fileIndex); fileCount++, recordIndex++)
-				getRecord(recordIndex).write(out);
-			rawDataSizes[fileIndex] = byteCounter.getLength();
+			for (int fileCount = 0; fileCount < this.getNumberOfTuplesPerFile(fileIndex); fileCount++, recordIndex++)
+				this.getRecord(recordIndex).write(out);
+			this.rawDataSizes[fileIndex] = byteCounter.getLength();
 		}
 	}
 
@@ -103,26 +104,27 @@ public class SequentialFormatTest {
 	 */
 	@Test
 	public void checkInputSplits() throws IOException {
-		FileInputSplit[] inputSplits = createInputFormat().createInputSplits(0);
+		FileInputSplit[] inputSplits = this.createInputFormat().createInputSplits(0);
 		Arrays.sort(inputSplits, new InputSplitSorter());
 
 		int splitIndex = 0;
-		for (int fileIndex = 0; fileIndex < degreeOfParallelism; fileIndex++) {
+		for (int fileIndex = 0; fileIndex < this.degreeOfParallelism; fileIndex++) {
 			List<FileInputSplit> sameFileSplits = new ArrayList<FileInputSplit>();
 			Path lastPath = inputSplits[splitIndex].getPath();
-			for (; splitIndex < inputSplits.length; splitIndex++)
+			for (; splitIndex < inputSplits.length; splitIndex++) {
 				if (!inputSplits[splitIndex].getPath().equals(lastPath))
 					break;
-				else
-					sameFileSplits.add(inputSplits[splitIndex]);
+				sameFileSplits.add(inputSplits[splitIndex]);
+			}
 
-			Assert.assertEquals(getExpectedBlockCount(fileIndex), sameFileSplits.size());
+			Assert.assertEquals(this.getExpectedBlockCount(fileIndex), sameFileSplits.size());
 
-			long lastBlockLength = rawDataSizes[fileIndex] % (blockSize - info.getInfoSize()) + info.getInfoSize();
+			long lastBlockLength =
+				this.rawDataSizes[fileIndex] % (this.blockSize - this.info.getInfoSize()) + this.info.getInfoSize();
 			for (int index = 0; index < sameFileSplits.size(); index++) {
-				Assert.assertEquals(blockSize * index, sameFileSplits.get(index).getStart());
+				Assert.assertEquals(this.blockSize * index, sameFileSplits.get(index).getStart());
 				if (index < sameFileSplits.size() - 1)
-					Assert.assertEquals(blockSize, sameFileSplits.get(index).getLength());
+					Assert.assertEquals(this.blockSize, sameFileSplits.get(index).getLength());
 			}
 			Assert.assertEquals(lastBlockLength, sameFileSplits.get(sameFileSplits.size() - 1).getLength());
 		}
@@ -133,7 +135,7 @@ public class SequentialFormatTest {
 	 */
 	@Test
 	public void checkRead() throws IOException {
-		SequentialInputFormat input = createInputFormat();
+		SequentialInputFormat<PactRecord> input = this.createInputFormat();
 		FileInputSplit[] inputSplits = input.createInputSplits(0);
 		Arrays.sort(inputSplits, new InputSplitSorter());
 		int readCount = 0;
@@ -142,32 +144,32 @@ public class SequentialFormatTest {
 			PactRecord record = new PactRecord();
 			while (!input.reachedEnd())
 				if (input.nextRecord(record)) {
-					checkEquals(getRecord(readCount), record);
+					this.checkEquals(this.getRecord(readCount), record);
 					readCount++;
 				}
 		}
-		Assert.assertEquals(numberOfTuples, readCount);
+		Assert.assertEquals(this.numberOfTuples, readCount);
 	}
 
 	/**
 	 * Tests the statistics of the given format.
 	 */
 	@Test
-	public void checkStatistics() throws IOException {
-		SequentialInputFormat input = createInputFormat();
+	public void checkStatistics() {
+		SequentialInputFormat<PactRecord> input = this.createInputFormat();
 		BaseStatistics statistics = input.getStatistics(null);
-		Assert.assertEquals(numberOfTuples, statistics.getNumberOfRecords());
+		Assert.assertEquals(this.numberOfTuples, statistics.getNumberOfRecords());
 	}
 
 	@After
 	public void cleanup() {
-		deleteRecursively(tempFile);
+		this.deleteRecursively(this.tempFile);
 	}
 
 	private void deleteRecursively(File file) {
 		if (file.isDirectory())
 			for (File subFile : file.listFiles())
-				deleteRecursively(subFile);
+				this.deleteRecursively(subFile);
 		else
 			file.delete();
 	}
@@ -177,57 +179,59 @@ public class SequentialFormatTest {
 	 */
 	@Before
 	public void writeTuples() throws IOException {
-		tempFile = File.createTempFile("SequentialInputFormat", null);
-		tempFile.deleteOnExit();
+		this.tempFile = File.createTempFile("SequentialInputFormat", null);
+		this.tempFile.deleteOnExit();
 		Configuration configuration = new Configuration();
-		configuration.setLong(SequentialOutputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
-		if (degreeOfParallelism == 1) {
+		configuration.setLong(BinaryOutputFormat.BLOCK_SIZE_PARAMETER_KEY, this.blockSize);
+		if (this.degreeOfParallelism == 1) {
 			SequentialOutputFormat output =
-				FormatUtil.openOutput(SequentialOutputFormat.class, "file://" + tempFile.getAbsolutePath(),
+				FormatUtil.openOutput(SequentialOutputFormat.class, "file://" + this.tempFile.getAbsolutePath(),
 					configuration);
-			for (int index = 0; index < numberOfTuples; index++)
-				output.writeRecord(getRecord(index));
+			for (int index = 0; index < this.numberOfTuples; index++)
+				output.writeRecord(this.getRecord(index));
 			output.close();
 		} else {
-			tempFile.delete();
-			tempFile.mkdir();
+			this.tempFile.delete();
+			this.tempFile.mkdir();
 			int recordIndex = 0;
-			for (int fileIndex = 0; fileIndex < degreeOfParallelism; fileIndex++) {
+			for (int fileIndex = 0; fileIndex < this.degreeOfParallelism; fileIndex++) {
 				SequentialOutputFormat output =
-					FormatUtil.openOutput(SequentialOutputFormat.class, "file://" + tempFile.getAbsolutePath() + "/"
+					FormatUtil.openOutput(SequentialOutputFormat.class, "file://" + this.tempFile.getAbsolutePath() +
+						"/"
 						+ (fileIndex + 1), configuration);
-				for (int fileCount = 0; fileCount < getNumberOfTuplesPerFile(fileIndex); fileCount++, recordIndex++)
-					output.writeRecord(getRecord(recordIndex));
+				for (int fileCount = 0; fileCount < this.getNumberOfTuplesPerFile(fileIndex); fileCount++, recordIndex++)
+					output.writeRecord(this.getRecord(recordIndex));
 				output.close();
 			}
 		}
 	}
 
-	private int getNumberOfTuplesPerFile(int fileIndex) {
-		return numberOfTuples / degreeOfParallelism;
+	private int getNumberOfTuplesPerFile(@SuppressWarnings("unused") int fileIndex) {
+		return this.numberOfTuples / this.degreeOfParallelism;
 	}
 
 	/**
 	 * Tests if the length of the file matches the expected value.
 	 */
 	@Test
-	public void checkLength() throws IOException {
-		File[] files = tempFile.isDirectory() ? tempFile.listFiles() : new File[] { tempFile };
+	public void checkLength() {
+		File[] files = this.tempFile.isDirectory() ? this.tempFile.listFiles() : new File[] { this.tempFile };
 		Arrays.sort(files);
-		for (int fileIndex = 0; fileIndex < degreeOfParallelism; fileIndex++) {
-			long lastBlockLength = rawDataSizes[fileIndex] % (blockSize - info.getInfoSize());
+		for (int fileIndex = 0; fileIndex < this.degreeOfParallelism; fileIndex++) {
+			long lastBlockLength = this.rawDataSizes[fileIndex] % (this.blockSize - this.info.getInfoSize());
 			long expectedLength =
-				(getExpectedBlockCount(fileIndex) - 1) * blockSize + info.getInfoSize() + lastBlockLength;
+				(this.getExpectedBlockCount(fileIndex) - 1) * this.blockSize + this.info.getInfoSize() +
+					lastBlockLength;
 			Assert.assertEquals(expectedLength, files[fileIndex].length());
 		}
 	}
 
-	protected SequentialInputFormat createInputFormat() throws IOException {
+	protected SequentialInputFormat<PactRecord> createInputFormat() {
 		Configuration configuration = new Configuration();
-		configuration.setString(FileInputFormat.FILE_PARAMETER_KEY, "file://" + tempFile.getAbsolutePath());
-		configuration.setLong(SequentialInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
+		configuration.setString(FileInputFormat.FILE_PARAMETER_KEY, "file://" + this.tempFile.getAbsolutePath());
+		configuration.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, this.blockSize);
 
-		final SequentialInputFormat inputFormat = new SequentialInputFormat();
+		final SequentialInputFormat<PactRecord> inputFormat = new SequentialInputFormat<PactRecord>();
 		inputFormat.configure(configuration);
 		return inputFormat;
 	}
@@ -249,7 +253,8 @@ public class SequentialFormatTest {
 	}
 
 	private int getExpectedBlockCount(int fileIndex) {
-		int expectedBlockCount = (int) Math.ceil((double) rawDataSizes[fileIndex] / (blockSize - info.getInfoSize()));
+		int expectedBlockCount =
+			(int) Math.ceil((double) this.rawDataSizes[fileIndex] / (this.blockSize - this.info.getInfoSize()));
 		return expectedBlockCount;
 	}
 
@@ -258,7 +263,7 @@ public class SequentialFormatTest {
 		ArrayList<Object[]> params = new ArrayList<Object[]>();
 		for (int dop = 1; dop <= 2; dop++) {
 			// numberOfTuples, blockSize, dop
-			params.add(new Object[] { 100, SequentialOutputFormat.NATIVE_BLOCK_SIZE, dop });
+			params.add(new Object[] { 100, BinaryOutputFormat.NATIVE_BLOCK_SIZE, dop });
 			params.add(new Object[] { 100, 1000, dop });
 			params.add(new Object[] { 100, 1 << 20, dop });
 			params.add(new Object[] { 10000, 1000, dop });
@@ -286,7 +291,7 @@ public class SequentialFormatTest {
 
 		@Override
 		public void write(int b) throws IOException {
-			length++;
+			this.length++;
 		}
 	}
 }

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/DataSinkTask.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/DataSinkTask.java
@@ -120,7 +120,7 @@ public class DataSinkTask<IT> extends AbstractOutputTask
 
 			// work!
 			// special case the pact record / file variant
-			if (record.getClass() == PactRecord.class && format instanceof FileOutputFormat) {
+			if (record.getClass() == PactRecord.class && format instanceof eu.stratosphere.pact.common.io.FileOutputFormat) {
 				@SuppressWarnings("unchecked")
 				final MutableObjectIterator<PactRecord> pi = (MutableObjectIterator<PactRecord>) reader;
 				final PactRecord pr = (PactRecord) record;


### PR DESCRIPTION
Please add those commits to ozone, so that we can directly link to 0.2-ozone in Sopremo.
Most of these patches either backport small parts of 0.2.1 (to Nephele) or fix some settings.
Message me for further informations.
