### PR TITLE
Fixed bad assembly of dropin libs in the stratosphere-bin shell scripts.

### DIFF
--- a/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-jobmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-jobmanager.sh
@@ -48,9 +48,10 @@ constructJobManagerClassPath() {
 		fi
 	done
 
-	for jarfile in $NEPHELE_LIB_DIR/dropins/*.jar ; do
+	for jarfile in $NEPHELE_LIB_DIR/dropin/*.jar ; do
 		NEPHELE_JM_CLASSPATH=$NEPHELE_JM_CLASSPATH:$jarfile
 	done
+	NEPHELE_JM_CLASSPATH=$NEPHELE_JM_CLASSPATH:$NEPHELE_LIB_DIR/dropin/
 
 	echo $NEPHELE_JM_CLASSPATH
 }

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-taskmanager.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-taskmanager.sh
@@ -41,9 +41,10 @@ constructTaskManagerClassPath() {
 		fi
 	done
 
-	for jarfile in $NEPHELE_LIB_DIR/dropins/*.jar ; do
+	for jarfile in $NEPHELE_LIB_DIR/dropin/*.jar ; do
 		NEPHELE_TM_CLASSPATH=$NEPHELE_TM_CLASSPATH:$jarfile
 	done
+	NEPHELE_TM_CLASSPATH=$NEPHELE_TM_CLASSPATH:$NEPHELE_LIB_DIR/dropin/
 
 	echo $NEPHELE_TM_CLASSPATH
 }

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/pact-client.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/pact-client.sh
@@ -40,9 +40,10 @@ constructPactCLIClientClassPath() {
 		fi
 	done
 
-	for jarfile in $NEPHELE_LIB_DIR/dropins/*.jar ; do
+	for jarfile in $NEPHELE_LIB_DIR/dropin/*.jar ; do
 		PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile
 	done
+	PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$NEPHELE_LIB_DIR/dropin/
 	
 	for jarfile in $NEPHELE_LIB_CLIENTS_DIR/*.jar ; do
 		PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile

--- a/stratosphere-dist/src/main/stratosphere-bin/bin/pact-webfrontend.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/pact-webfrontend.sh
@@ -46,12 +46,13 @@ constructPactWebFrontendClassPath() {
 		fi
 	done
 
-	for jarfile in $NEPHELE_LIB_DIR/dropins/*.jar ; do
+	for jarfile in $NEPHELE_LIB_DIR/dropin/*.jar ; do
 		PACT_WF_CLASSPATH=$PACT_WF_CLASSPATH:$jarfile
 	done
+	PACT_WF_CLASSPATH=$PACT_WF_CLASSPATH:$NEPHELE_LIB_DIR/dropin/
 	
 	for jarfile in $NEPHELE_LIB_CLIENTS_DIR/*.jar ; do
-		PACT_CC_CLASSPATH=$PACT_CC_CLASSPATH:$jarfile
+		PACT_WF_CLASSPATH=$PACT_WF_CLASSPATH:$jarfile
 	done
 
 	echo $PACT_WF_CLASSPATH


### PR DESCRIPTION
The jarfile loop for the dropins folder doesn't work because of bad folder name (`dropins`, should be `dropin`).

The push request also fixes a bad bash variable name in `pact-webfrontend.sh`.

In addition, I suggest to add the folder itself to the java classpath for extra, non JAR file resources that need to be included in the classpath (e.g. license files for vendor libraries).
