### PR TITLE
Reducer without grouping key ("ALL_GROUP") fails in optimizer

### DIFF
--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/fs/FileSystem.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/fs/FileSystem.java
@@ -190,7 +190,7 @@ public abstract class FileSystem {
 		synchronized (SYNCHRONIZATION_OBJECT) {
 
 			if (uri.getScheme() == null) {
-				throw new IOException("FileSystem: Scheme is null");
+				throw new IOException("FileSystem: Scheme is null. file:// or hdfs:// are schemes.");
 			}
 
 			final FSKey key = new FSKey(uri.getScheme(), uri.getAuthority());

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/DelimitedInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/DelimitedInputFormat.java
@@ -72,7 +72,7 @@ public abstract class DelimitedInputFormat extends FileInputFormat {
 	 */
 	private static int MAX_SAMPLE_LEN;
 	
-	protected static final void loadGloablConfigParams() {
+	protected static final void loadGlobalConfigParams() {
 		int maxSamples = GlobalConfiguration.getInteger(PactConfigConstants.DELIMITED_FORMAT_MAX_LINE_SAMPLES_KEY,
 				PactConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_LINE_SAMPLES);
 		int minSamples = GlobalConfiguration.getInteger(PactConfigConstants.DELIMITED_FORMAT_MIN_LINE_SAMPLES_KEY,
@@ -111,7 +111,7 @@ public abstract class DelimitedInputFormat extends FileInputFormat {
 		MAX_SAMPLE_LEN = maxLen;
 	}
 	
-	static { loadGloablConfigParams(); }
+	static { loadGlobalConfigParams(); }
 	
 	// ------------------------------------- Config Keys ------------------------------------------
 	

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/ReduceCompilerBugTest.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/ReduceCompilerBugTest.java
@@ -1,0 +1,44 @@
+package eu.stratosphere.pact.compiler;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import eu.stratosphere.pact.common.contract.FileDataSink;
+import eu.stratosphere.pact.common.contract.FileDataSource;
+import eu.stratosphere.pact.common.contract.ReduceContract;
+import eu.stratosphere.pact.common.plan.Plan;
+import eu.stratosphere.pact.compiler.plan.candidate.OptimizedPlan;
+import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
+import eu.stratosphere.pact.compiler.util.DummyInputFormat;
+import eu.stratosphere.pact.compiler.util.DummyOutputFormat;
+import eu.stratosphere.pact.compiler.util.IdentityReduce;
+
+
+/**
+ * This test case has been created to validate a bug that occurred when
+ * the ReduceContract was used without a grouping key.
+ */
+public class ReduceCompilerBugTest extends CompilerTestBase  {
+
+	@Test
+	public void testReduce() {
+		// construct the plan
+		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
+		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class).name("Reduce1").input(source).build();
+		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		sink.setInput(reduce1);
+		Plan plan = new Plan(sink, "Test Temp Task");
+		plan.setDefaultParallelism(DEFAULT_PARALLELISM);
+		
+		
+		try {
+			OptimizedPlan oPlan = compileNoStats(plan);
+			NepheleJobGraphGenerator jobGen = new NepheleJobGraphGenerator();
+			jobGen.compileJobGraph(oPlan);
+		} catch(CompilerException ce) {
+			ce.printStackTrace();
+			fail("The pact compiler is unable to compile this plan correctly");
+		}
+	}
+}


### PR DESCRIPTION
This pull request contains a test case that validates a bug with the pact-optimizer.

(The test obviously fails, because I did not include a fix for the bug!)
I also fixed a little typo and made an error message a bit more understandable by giving an example.
