### PR TITLE
Minor bugfix for TextInputFormat + Testcase

### DIFF
--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/TextInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/TextInputFormat.java
@@ -94,8 +94,8 @@ public class TextInputFormat extends DelimitedInputFormat {
 				byteWrapper = ByteBuffer.wrap(bytes, 0, bytes.length);
 				this.byteWrapper = byteWrapper;
 			}
-			byteWrapper.position(offset);
 			byteWrapper.limit(offset + numBytes);
+			byteWrapper.position(offset);
 				
 			try {
 				CharBuffer result = this.decoder.decode(byteWrapper);

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/TextInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/TextInputFormatTest.java
@@ -1,0 +1,53 @@
+package eu.stratosphere.pact.common.io;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import org.junit.Test;
+
+import eu.stratosphere.nephele.configuration.Configuration;
+import eu.stratosphere.nephele.fs.FileInputSplit;
+import eu.stratosphere.pact.common.type.PactRecord;
+
+public class TextInputFormatTest {
+	
+	/**
+	 * The TextInputFormat seems to fail reading more than one record. I guess its
+	 * an off by one error.
+	 * 
+	 * The easiest workaround is to setParameter(TextInputFormat.CHARSET_NAME, "ASCII");
+	 * @throws IOException
+	 */
+	@Test
+	public void testPositionBug() throws IOException {
+		// create input file
+		File tempFile = File.createTempFile("TextInputFormatTest", null);
+		tempFile.setWritable(true);
+		PrintStream ps = new  PrintStream(tempFile);
+		ps.println("First line");
+		ps.println("Second line");
+		ps.close();
+		tempFile.deleteOnExit();
+		
+		TextInputFormat inputFormat = new TextInputFormat();
+		Configuration parameters = new Configuration();
+		parameters.setString(FileInputFormat.FILE_PARAMETER_KEY, "file://"+tempFile.getAbsolutePath() ); 
+		inputFormat.configure(parameters);
+		FileInputSplit[] splits = inputFormat.createInputSplits(1);
+		assertTrue("expected at least one input split", splits.length >= 1);
+		inputFormat.open(splits[0]);
+		PactRecord r = new PactRecord();
+		assertTrue("Expecting first record here",inputFormat.nextRecord(r ));
+		try {
+			assertTrue("Expecting second record here",inputFormat.nextRecord(r ));
+		} catch(IllegalArgumentException iae) {
+			iae.printStackTrace();
+			fail("TextInputFormat is unable to read the file");
+		}
+		assertFalse("The input file is over", inputFormat.nextRecord(r));
+		
+	}
+}


### PR DESCRIPTION
I found this bug during the development of customer use-cases.

I guess its an easy fix but I want to focus on the use-cases right now (and I have a workaround).

The integration test will obviously fail for this pull request because it contains a test case for an unfixed bug.
