### PR TITLE
AvroInputFormat for Ozone

### DIFF
--- a/pact/pact-common/pom.xml
+++ b/pact/pact-common/pom.xml
@@ -21,6 +21,11 @@
 			<artifactId>nephele-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+		  <groupId>org.apache.avro</groupId>
+		  <artifactId>avro</artifactId>
+		  <version>1.7.5</version>
+		</dependency>
 	</dependencies>
 
 	<reporting>
@@ -28,8 +33,26 @@
 		</plugins>
 	</reporting>
 
+
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro-maven-plugin</artifactId>
+				<version>1.7.5</version>
+				<executions>
+					<execution>
+						<phase>generate-test-sources</phase>
+						<goals>
+							<goal>schema</goal>
+						</goals>
+						<configuration>
+							<sourceDirectory>${project.basedir}/src/test/resources/avro</sourceDirectory>
+							<outputDirectory>${project.basedir}/src/test/java/</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/avro/AvroInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/avro/AvroInputFormat.java
@@ -1,0 +1,111 @@
+package eu.stratosphere.pact.common.io.avro;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+
+import eu.stratosphere.nephele.fs.FileInputSplit;
+import eu.stratosphere.pact.common.io.FileInputFormat;
+import eu.stratosphere.pact.common.type.PactRecord;
+import eu.stratosphere.pact.common.type.Value;
+import eu.stratosphere.pact.common.type.base.PactBoolean;
+import eu.stratosphere.pact.common.type.base.PactInteger;
+import eu.stratosphere.pact.common.type.base.PactString;
+
+/**
+ * Input format to read Avro files.
+ * 
+ * The input format currently supports only flat avro schemas. So
+ * there is no support for complex types except for nullable
+ * primitve fields, e.g. ["string", null]
+ * (See http://avro.apache.org/docs/current/spec.html#schema_complex)
+ *
+ */
+public class AvroInputFormat extends FileInputFormat {
+
+	private DataFileReader<GenericRecord> dataFileReader;
+	private GenericRecord reuseAvroRecord = null;
+	
+	@Override
+	public void open(FileInputSplit split) throws IOException {
+		super.open(split);
+		DatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>();
+		dataFileReader = new DataFileReader<GenericRecord>(new FSDataInputStreamWrapper(stream, (int)split.getLength()), datumReader);
+		
+	}
+	@Override
+	public boolean reachedEnd() throws IOException {
+		return !dataFileReader.hasNext();
+	}
+
+	@Override
+	public boolean nextRecord(PactRecord record) throws IOException {
+		if(!dataFileReader.hasNext()) {
+			return false;
+		}
+		if(record == null){
+			throw new IllegalArgumentException("Empty PactRecord given");
+		}
+		reuseAvroRecord = dataFileReader.next(reuseAvroRecord);
+		List<Field> fields = reuseAvroRecord.getSchema().getFields();
+		for(Field field : fields) {
+			final Value value = convertAvroToPactValue(field, reuseAvroRecord.get(field.pos()));
+			record.setField(field.pos(), value);
+		}
+		return true;
+	}
+	/**
+	 * Converts an Avro GenericRecord to a Value.
+	 * @return
+	 */
+	private final Value convertAvroToPactValue(Field field, Object avroRecord) {
+		if(avroRecord == null) {
+			return null;
+		}
+		Type type = checkTypeConstraintsAndGetType(field.schema());
+		switch(type) {
+			case STRING:
+				return new PactString((CharSequence) avroRecord);
+			case INT:
+				return new PactInteger((Integer) avroRecord);
+			case BOOLEAN:
+				return new PactBoolean((Boolean) avroRecord) ;
+			default:
+				throw new RuntimeException("Implement type "+type+" for AvroInputFormat!");
+		}
+	}
+	
+	private final Type checkTypeConstraintsAndGetType(Schema schema) {
+		Type type = schema.getType();
+		if(type == Type.ARRAY || type == Type.ENUM || type == Type.RECORD || type == Type.MAP ) {
+			throw new RuntimeException("The given Avro file contains complex data types");
+		}
+		
+		if( type == Type.UNION) {
+			List<Schema> types = schema.getTypes();
+			if(types.size() > 2) {
+				throw new RuntimeException("The given Avro file contains a union that has more than two elements");
+			}
+			if(types.get(0).getType() == Type.UNION || types.get(1).getType() == Type.UNION ) {
+				throw new RuntimeException("The given Avro file contains a nested union");
+			}
+			if(types.get(0).getType() == Type.NULL) {
+				return types.get(1).getType();
+			} else {
+				if(types.get(1).getType() != Type.NULL) {
+					throw new RuntimeException("The given Avro file is contains a union with two non-null types.");
+				}
+				return types.get(0).getType();
+			}
+		}
+		return type;
+	}
+
+}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/avro/FSDataInputStreamWrapper.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/avro/FSDataInputStreamWrapper.java
@@ -1,0 +1,51 @@
+package eu.stratosphere.pact.common.io.avro;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.apache.avro.file.SeekableInput;
+
+import eu.stratosphere.nephele.fs.FSDataInputStream;
+
+/**
+ * Code copy pasted from org.apache.avro.mapred.FSInput (which is Apache
+ * licenced as well)
+ * 
+ * The wrapper keeps track of the position!
+ * 
+ */
+public class FSDataInputStreamWrapper implements Closeable, SeekableInput {
+	private final FSDataInputStream stream;
+	private final long len;
+	private long pos;
+
+	FSDataInputStreamWrapper(final FSDataInputStream stream, final int len) {
+		this.stream = stream;
+		this.len = len;
+		this.pos = 0;
+	}
+
+	public long length() {
+		return len;
+	}
+
+	public int read(byte[] b, int off, int len) throws IOException {
+		int read;
+		read = stream.read(b, off, len);
+		pos += read;
+		return read;
+	}
+
+	public void seek(long p) throws IOException {
+		stream.seek(p);
+		pos = p;
+	}
+
+	public long tell() throws IOException {
+		return pos;
+	}
+
+	public void close() throws IOException {
+		stream.close();
+	}
+}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/InputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/InputFormat.java
@@ -123,12 +123,12 @@ public interface InputFormat<OT, T extends InputSplit> {
 	public abstract boolean reachedEnd() throws IOException;
 	
 	/**
-	 * Tries to read the next pair from the input. By using the return value invalid records in the
+	 * Tries to read the next record from the input. By using the return value invalid records in the
 	 * input can be skipped.
 	 * <p>
 	 * When this method is called, the input format it guaranteed to be opened.
 	 * 
-	 * @param record Record into which the next key / value pair will be stored.
+	 * @param record Type to store the next record.
 	 * @return Indicates whether the record could be successfully read. A return value of <i>true</i>
 	 *         indicates that the read was successful, a return value of false indicates that the
 	 *         current record was not read successfully and should be skipped.

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/AvroInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/AvroInputFormatTest.java
@@ -1,0 +1,83 @@
+package eu.stratosphere.pact.common.io;
+
+import java.io.File;
+import java.io.IOException;
+
+import junit.framework.Assert;
+
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import eu.stratosphere.nephele.configuration.Configuration;
+import eu.stratosphere.nephele.fs.FileInputSplit;
+import eu.stratosphere.pact.common.io.avro.AvroInputFormat;
+import eu.stratosphere.pact.common.io.avro.generated.User;
+import eu.stratosphere.pact.common.type.PactRecord;
+import eu.stratosphere.pact.common.type.base.PactString;
+
+
+/**
+ * Test the avro input format.
+ * (The testcase is mostly the getting started tutorial of avro)
+ * http://avro.apache.org/docs/current/gettingstartedjava.html
+ * 
+ */
+public class AvroInputFormatTest {
+	
+	private File testFile;
+	
+	private final AvroInputFormat format = new AvroInputFormat();
+	final static String TEST_NAME = "Alyssa";
+	@Before
+	public void createFiles() throws IOException {
+		testFile = File.createTempFile("AvroInputFormatTest", null);
+		User user1 = new User();
+		user1.setName(TEST_NAME);
+		user1.setFavoriteNumber(256);
+
+		// Construct via builder
+		User user2 = User.newBuilder()
+		             .setName("Charlie")
+		             .setFavoriteColor("blue")
+		             .setFavoriteNumber(null)
+		             .build();
+		DatumWriter<User> userDatumWriter = new SpecificDatumWriter<User>(User.class);
+		DataFileWriter<User> dataFileWriter = new DataFileWriter<User>(userDatumWriter);
+		dataFileWriter.create(user1.getSchema(), testFile);
+		dataFileWriter.append(user1);
+		dataFileWriter.append(user2);
+		dataFileWriter.close();
+	}
+	
+	@Test
+	public void testDeserialisation() throws IOException {
+		Configuration parameters = new Configuration();
+		parameters.setString(FileInputFormat.FILE_PARAMETER_KEY, "file://"+testFile.getAbsolutePath());
+		format.configure(parameters);
+		FileInputSplit[] splits = format.createInputSplits(1);
+		Assert.assertEquals(splits.length, 1);
+		format.open(splits[0]);
+		PactRecord record = new PactRecord();
+		Assert.assertTrue(format.nextRecord(record));
+		PactString name = record.getField(0, PactString.class);
+		Assert.assertNotNull("empty record", name);
+		Assert.assertEquals("name not equal",name.getValue(), TEST_NAME);
+		
+		Assert.assertFalse("expecting second element", format.reachedEnd());
+		Assert.assertTrue("expecting second element", format.nextRecord(record));
+		
+		Assert.assertFalse(format.nextRecord(record));
+		Assert.assertTrue(format.reachedEnd());
+		
+		format.close();
+	}
+	
+	@After
+	public void deleteFiles() {
+		testFile.delete();
+	}
+}

--- a/pact/pact-common/src/test/resources/avro/user.avsc
+++ b/pact/pact-common/src/test/resources/avro/user.avsc
@@ -1,0 +1,9 @@
+{"namespace": "eu.stratosphere.pact.common.io.avro.generated",
+ "type": "record",
+ "name": "User",
+ "fields": [
+     {"name": "name", "type": "string"},
+     {"name": "favorite_number",  "type": ["int", "null"]},
+     {"name": "favorite_color", "type": ["string", "null"]}
+ ]
+}


### PR DESCRIPTION
This pull request contains an early prototype of an AvroInputFormat. Avro is a data serialization system that is widely used with Apache Hadoop. Many processing systems such as Hive or Pig support it.
I need to add support for Avro to Ozone because of customer requirements.

Please note that this pull request is not ready to merge: The test case is not done yet and the only a few primitive datatypes are supported (string, boolean, int).

I'd like to discuss the following questions (with you)
1) Do we want Avro Support in Ozone
2) Should we map the avro types to PactRecords or should we add the avro types to the system?

1) Pro: Widely used, easy to implement
Con: New dependencies; in the course of the implementation of Hive for ozone, we will most likely use HCatalog as a generic interface to many input file formats, including Avro. So one HCatalog is integrated, the AvroInputFormat would be redundant 

2) Avro supports complex data types (http://avro.apache.org/docs/current/spec.html#schema_complex) which we can't map into our current data model (that's at least what I understand).
My current approach is to forbid nested or complex data structures with Avro and translate every AvroRecord into a PactRecord, preserving the order of the fields.

If we agree to add the InputFormat the ozone, I'll extend the test cases and type conversion to all primitive data types .
