### PR TITLE
Remove pact-examples dependency in pact-clients.

### DIFF
--- a/pact/pact-clients/pom.xml
+++ b/pact/pact-clients/pom.xml
@@ -30,13 +30,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>eu.stratosphere</groupId>
-			<artifactId>pact-examples</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.2</version>

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/clients/examples/LocalExecutorTest.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/clients/examples/LocalExecutorTest.java
@@ -12,7 +12,7 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.pact.client;
+package eu.stratosphere.pact.clients.examples;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -20,6 +20,7 @@ import java.io.FileWriter;
 import org.junit.Assert;
 import org.junit.Test;
 
+import eu.stratosphere.pact.client.LocalExecutor;
 import eu.stratosphere.pact.example.wordcount.WordCount;
 
 


### PR DESCRIPTION
pact-clients was dependent on pact-examples in order to run
LocalExecuterTest. The problem with that was, that this prevented the
use of the LocalExecuter within the pact-examples module (circular
dependency). Hence the LocalExecuterTest was moved to the pact-test
module and the pact-examples depedency was removed from pact-clients.
