### PR TITLE
Switch to using objects instead of classes for usercode

### DIFF
--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/fs/Path.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/fs/Path.java
@@ -24,6 +24,7 @@ package eu.stratosphere.nephele.fs;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -35,7 +36,8 @@ import eu.stratosphere.nephele.util.StringUtils;
  * Names a file or directory in a {@link FileSystem}. Path strings use slash as
  * the directory separator. A path string is absolute if it begins with a slash.
  */
-public class Path implements IOReadableWritable {
+public class Path implements IOReadableWritable, Serializable {
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The directory separator, a slash.

--- a/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/contract/ReduceWithKeyContract.java
+++ b/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/contract/ReduceWithKeyContract.java
@@ -18,6 +18,8 @@ package eu.stratosphere.pact.array.contract;
 import eu.stratosphere.pact.array.stubs.ReduceWithKeyStub;
 import eu.stratosphere.pact.common.stubs.ReduceStub;
 import eu.stratosphere.pact.generic.contract.GenericReduceContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
 
 /**
  * MapContract represents a Pact with a Map Input Contract.
@@ -31,8 +33,13 @@ import eu.stratosphere.pact.generic.contract.GenericReduceContract;
  */
 public class ReduceWithKeyContract extends GenericReduceContract<ReduceWithKeyStub>
 {
-	public ReduceWithKeyContract(Class <? extends ReduceWithKeyStub> udf, int keyPosition, String name) {
-		super(udf, new int[] {keyPosition}, name);
+	public ReduceWithKeyContract(Class<? extends ReduceWithKeyStub> udf, int keyPosition, String name) {
+		super(new UserCodeClassWrapper<ReduceWithKeyStub>(udf), new int[] {keyPosition}, name);
+		getParameters().setInteger(ReduceWithKeyStub.KEY_INDEX_PARAM_KEY, keyPosition);
+	}
+	
+	public ReduceWithKeyContract(ReduceWithKeyStub udf, int keyPosition, String name) {
+		super(new UserCodeObjectWrapper<ReduceWithKeyStub>(udf), new int[] {keyPosition}, name);
 		getParameters().setInteger(ReduceWithKeyStub.KEY_INDEX_PARAM_KEY, keyPosition);
 	}
 }

--- a/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/example/WordCountArrayTuples.java
+++ b/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/example/WordCountArrayTuples.java
@@ -121,7 +121,7 @@ public class WordCountArrayTuples implements PlanAssembler, PlanAssemblerDescrip
 		String dataInput = (args.length > 1 ? args[1] : "");
 		String output    = (args.length > 2 ? args[2] : "");
 
-		FileDataSource source = new FileDataSource(StringInputFormat.class, dataInput, "Input Lines");
+		FileDataSource source = new FileDataSource(new StringInputFormat(), dataInput, "Input Lines");
 		source.setParameter(TextInputFormat.CHARSET_NAME, "ASCII");		// comment out this line for UTF-8 inputs
 		
 		GenericMapContract<TokenizeLine> mapper = new GenericMapContract<TokenizeLine>(TokenizeLine.class, "Tokenize Lines");
@@ -130,7 +130,7 @@ public class WordCountArrayTuples implements PlanAssembler, PlanAssemblerDescrip
 		GenericReduceContract<CountWords> reducer = new GenericReduceContract<CountWords>(CountWords.class, new int[] {0}, "Count Words");
 		reducer.setInput(mapper);
 		
-		FileDataSink out = new FileDataSink(StringIntOutputFormat.class, output, reducer, "Word Counts");
+		FileDataSink out = new FileDataSink(new StringIntOutputFormat(), output, reducer, "Word Counts");
 		StringIntOutputFormat.configureArrayFormat(out)
 			.recordDelimiter('\n')
 			.fieldDelimiter(' ')

--- a/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/io/ArrayOutputFormat.java
+++ b/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/io/ArrayOutputFormat.java
@@ -29,6 +29,8 @@ import eu.stratosphere.pact.generic.io.FileOutputFormat;
  */
 public abstract class ArrayOutputFormat extends FileOutputFormat<Value[]> implements ArrayModelOutputFormat
 {
+	private static final long serialVersionUID = 1L;
+
 	private static final String RECORD_DELIMITER_PARAMETER = "pact.output.array.delimiter";
 	
 	private static final String FIELD_DELIMITER_PARAMETER = "pact.output.array.field-delimiter";

--- a/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/io/StringInputFormat.java
+++ b/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/io/StringInputFormat.java
@@ -36,6 +36,8 @@ import eu.stratosphere.pact.generic.io.DelimitedInputFormat;
  */
 public class StringInputFormat extends DelimitedInputFormat<Value[]>
 {
+	private static final long serialVersionUID = 1L;
+
 	public static final String CHARSET_NAME = "textformat.charset";
 	
 	public static final String DEFAULT_CHARSET_NAME = "UTF-8";

--- a/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/io/StringIntOutputFormat.java
+++ b/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/io/StringIntOutputFormat.java
@@ -24,6 +24,8 @@ import eu.stratosphere.pact.common.type.base.PactString;
  */
 public class StringIntOutputFormat extends ArrayOutputFormat
 {
+	private static final long serialVersionUID = 1L;
+	
 	@SuppressWarnings("unchecked")
 	private static final Class<? extends Value>[] types = new Class[] {PactString.class, PactInteger.class};
 	

--- a/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/util/AsciiUtils.java
+++ b/pact/pact-array-datamodel/src/main/java/eu/stratosphere/pact/array/util/AsciiUtils.java
@@ -15,6 +15,8 @@
 
 package eu.stratosphere.pact.array.util;
 
+import java.io.Serializable;
+
 import eu.stratosphere.pact.common.type.base.PactString;
 import eu.stratosphere.pact.common.util.MutableObjectIterator;
 
@@ -73,8 +75,10 @@ public final class AsciiUtils
 	 * The tokenizer is designed to have a resettable state and operate on mutable objects,
 	 * sparing object allocation and garbage collection overhead.
 	 */
-	public static final class WhitespaceTokenizer implements MutableObjectIterator<PactString>
+	public static final class WhitespaceTokenizer implements MutableObjectIterator<PactString>, Serializable
 	{		
+		private static final long serialVersionUID = 1L;
+		
 		private PactString toTokenize;		// the string to tokenize
 		private int pos;					// the current position in the string
 		private int limit;					// the limit in the string's character data

--- a/pact/pact-common/pom.xml
+++ b/pact/pact-common/pom.xml
@@ -22,6 +22,11 @@
 			<artifactId>nephele-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+        </dependency>
 	</dependencies>
 
 	<reporting>

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/CoGroupContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/CoGroupContract.java
@@ -27,6 +27,9 @@ import eu.stratosphere.pact.common.stubs.MatchStub;
 import eu.stratosphere.pact.common.type.Key;
 import eu.stratosphere.pact.generic.contract.Contract;
 import eu.stratosphere.pact.generic.contract.GenericCoGroupContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 
 /**
  * CrossContract represents a Match InputContract of the PACT Programming Model.
@@ -67,9 +70,22 @@ public class CoGroupContract extends GenericCoGroupContract<CoGroupStub> impleme
 	 * @param keyColumn1 The position of the key in the first input's records.
 	 * @param keyColumn2 The position of the key in the second input's records.
 	 */
+	public static Builder builder(CoGroupStub udf, Class<? extends Key> keyClass,
+			int keyColumn1, int keyColumn2) {
+		return new Builder(new UserCodeObjectWrapper<CoGroupStub>(udf), keyClass, keyColumn1, keyColumn2);
+	}
+	
+	/**
+	 * Creates a Builder with the provided {@link CoGroupStub} implementation.
+	 * 
+	 * @param udf The {@link CoGroupStub} implementation for this CoGroup contract.
+	 * @param keyClass The class of the key data type.
+	 * @param keyColumn1 The position of the key in the first input's records.
+	 * @param keyColumn2 The position of the key in the second input's records.
+	 */
 	public static Builder builder(Class<? extends CoGroupStub> udf, Class<? extends Key> keyClass,
 			int keyColumn1, int keyColumn2) {
-		return new Builder(udf, keyClass, keyColumn1, keyColumn2);
+		return new Builder(new UserCodeClassWrapper<CoGroupStub>(udf), keyClass, keyColumn1, keyColumn2);
 	}
 	
 	/**
@@ -168,12 +184,12 @@ public class CoGroupContract extends GenericCoGroupContract<CoGroupStub> impleme
 	
 	@Override
 	public boolean isCombinableFirst() {
-		return super.isCombinableFirst() || getUserCodeClass().getAnnotation(CombinableFirst.class) != null;
+		return super.isCombinableFirst() || getUserCodeAnnotation(CombinableFirst.class) != null;
 	}
 	
 	@Override
 	public boolean isCombinableSecond() {
-		return super.isCombinableSecond() || getUserCodeClass().getAnnotation(CombinableSecond.class) != null;
+		return super.isCombinableSecond() || getUserCodeAnnotation(CombinableSecond.class) != null;
 	}
 	
 	@Retention(RetentionPolicy.RUNTIME)
@@ -192,7 +208,7 @@ public class CoGroupContract extends GenericCoGroupContract<CoGroupStub> impleme
 	public static class Builder {
 		
 		/* The required parameters */
-		private final Class<? extends CoGroupStub> udf;
+		private final UserCodeWrapper<CoGroupStub> udf;
 		private final List<Class<? extends Key>> keyClasses;
 		private final List<Integer> keyColumns1;
 		private final List<Integer> keyColumns2;
@@ -212,7 +228,7 @@ public class CoGroupContract extends GenericCoGroupContract<CoGroupStub> impleme
 		 * @param keyColumn1 The position of the key in the first input's records.
 		 * @param keyColumn2 The position of the key in the second input's records.
 		 */
-		protected Builder(Class<? extends CoGroupStub> udf, Class<? extends Key> keyClass,
+		protected Builder(UserCodeWrapper<CoGroupStub> udf, Class<? extends Key> keyClass,
 				int keyColumn1, int keyColumn2)
 		{
 			this.udf = udf;
@@ -237,7 +253,7 @@ public class CoGroupContract extends GenericCoGroupContract<CoGroupStub> impleme
 		 * @param keyColumn1 The position of the key in the first input's records.
 		 * @param keyColumn2 The position of the key in the second input's records.
 		 */
-		protected Builder(Class<? extends CoGroupStub> udf) {
+		protected Builder(UserCodeWrapper<CoGroupStub> udf) {
 			this.udf = udf;
 			this.keyClasses = new ArrayList<Class<? extends Key>>();
 			this.keyColumns1 = new ArrayList<Integer>();

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/CrossContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/CrossContract.java
@@ -22,6 +22,9 @@ import eu.stratosphere.pact.common.stubs.CrossStub;
 import eu.stratosphere.pact.common.type.Key;
 import eu.stratosphere.pact.generic.contract.Contract;
 import eu.stratosphere.pact.generic.contract.GenericCrossContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 
 
 /**
@@ -45,8 +48,17 @@ public class CrossContract extends GenericCrossContract<CrossStub> implements Re
 	 * 
 	 * @param udf The {@link CrossStub} implementation for this Cross contract.
 	 */
+	public static Builder builder(CrossStub udf) {
+		return new Builder(new UserCodeObjectWrapper<CrossStub>(udf));
+	}
+	
+	/**
+	 * Creates a Builder with the provided {@link CrossStub} implementation.
+	 * 
+	 * @param udf The {@link CrossStub} implementation for this Cross contract.
+	 */
 	public static Builder builder(Class<? extends CrossStub> udf) {
-		return new Builder(udf);
+		return new Builder(new UserCodeClassWrapper<CrossStub>(udf));
 	}
 	
 	/**
@@ -75,7 +87,7 @@ public class CrossContract extends GenericCrossContract<CrossStub> implements Re
 	public static class Builder {
 		
 		/* The required parameters */
-		private final Class<? extends CrossStub> udf;
+		private final UserCodeWrapper<CrossStub> udf;
 		
 		/* The optional parameters */
 		private List<Contract> inputs1;
@@ -87,7 +99,7 @@ public class CrossContract extends GenericCrossContract<CrossStub> implements Re
 		 * 
 		 * @param udf The {@link CrossStub} implementation for this Cross contract.
 		 */
-		private Builder(Class<? extends CrossStub> udf) {
+		private Builder(UserCodeWrapper<CrossStub> udf) {
 			this.udf = udf;
 			this.inputs1 = new ArrayList<Contract>();
 			this.inputs2 = new ArrayList<Contract>();

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/FileDataSink.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/FileDataSink.java
@@ -35,17 +35,6 @@ public class FileDataSink extends GenericDataSink
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation
-	 * and a default name, writing to the file indicated by the given path.
-	 * 
-	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
-	 * @param filePath The path to the file to write the contents to.
-	 */
-	public FileDataSink(Class<? extends FileOutputFormat<?>> c, String filePath) {
-		this(c, filePath, DEFAULT_NAME);
-	}
-	
-	/**
 	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation 
 	 * and the given name, writing to the file indicated by the given path.
 	 * 
@@ -53,12 +42,24 @@ public class FileDataSink extends GenericDataSink
 	 * @param filePath The path to the file to write the contents to.
 	 * @param name The given name for the sink, used in plans, logs and progress messages.
 	 */
-	public FileDataSink(Class<? extends FileOutputFormat<?>> c, String filePath, String name) {
-		super(c, name);
+	public FileDataSink(FileOutputFormat<?> f, String filePath, String name) {
+		super(f, name);
 		this.filePath = filePath;
 		this.parameters.setString(FileOutputFormat.FILE_PARAMETER_KEY, filePath);
 	}
 
+	/**
+	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation
+	 * and a default name, writing to the file indicated by the given path.
+	 * 
+	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
+	 * @param filePath The path to the file to write the contents to.
+	 */
+	public FileDataSink(FileOutputFormat<?> f, String filePath) {
+		this(f, filePath, DEFAULT_NAME);
+	}
+	
+	
 	/**
 	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation the default name,
 	 * writing to the file indicated by the given path. It uses the given contract as its input.
@@ -67,8 +68,8 @@ public class FileDataSink extends GenericDataSink
 	 * @param filePath The path to the file to write the contents to.
 	 * @param input The contract to use as the input.
 	 */
-	public FileDataSink(Class<? extends FileOutputFormat<?>> c, String filePath, Contract input) {
-		this(c, filePath, input, DEFAULT_NAME);
+	public FileDataSink(FileOutputFormat<?> f, String filePath, Contract input) {
+		this(f, filePath, input, DEFAULT_NAME);
 	}
 	
 	/**
@@ -79,8 +80,8 @@ public class FileDataSink extends GenericDataSink
 	 * @param filePath The path to the file to write the contents to.
 	 * @param input The contracts to use as the input.
 	 */
-	public FileDataSink(Class<? extends FileOutputFormat<?>> c, String filePath, List<Contract> input) {
-		this(c, filePath, input, DEFAULT_NAME);
+	public FileDataSink(FileOutputFormat<?> f, String filePath, List<Contract> input) {
+		this(f, filePath, input, DEFAULT_NAME);
 	}
 
 	/**
@@ -92,8 +93,8 @@ public class FileDataSink extends GenericDataSink
 	 * @param input The contract to use as the input.
 	 * @param name The given name for the sink, used in plans, logs and progress messages.
 	 */
-	public FileDataSink(Class<? extends FileOutputFormat<?>> c, String filePath, Contract input, String name) {
-		this(c, filePath, name);
+	public FileDataSink(FileOutputFormat<?> f, String filePath, Contract input, String name) {
+		this(f, filePath, name);
 		addInput(input);
 	}
 
@@ -106,8 +107,85 @@ public class FileDataSink extends GenericDataSink
 	 * @param input The contracts to use as the input.
 	 * @param name The given name for the sink, used in plans, logs and progress messages.
 	 */
-	public FileDataSink(Class<? extends FileOutputFormat<?>> c, String filePath, List<Contract> input, String name) {
-		this(c, filePath, name);
+	public FileDataSink(FileOutputFormat<?> f, String filePath, List<Contract> input, String name) {
+		this(f, filePath, name);
+		addInputs(input);
+	}
+	
+	/**
+	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation 
+	 * and the given name, writing to the file indicated by the given path.
+	 * 
+	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
+	 * @param filePath The path to the file to write the contents to.
+	 * @param name The given name for the sink, used in plans, logs and progress messages.
+	 */
+	public FileDataSink(Class<? extends FileOutputFormat<?>> f, String filePath, String name) {
+		super(f, name);
+		this.filePath = filePath;
+		this.parameters.setString(FileOutputFormat.FILE_PARAMETER_KEY, filePath);
+	}
+	
+	/**
+	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation
+	 * and a default name, writing to the file indicated by the given path.
+	 * 
+	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
+	 * @param filePath The path to the file to write the contents to.
+	 */
+	public FileDataSink(Class<? extends FileOutputFormat<?>> f, String filePath) {
+		this(f, filePath, DEFAULT_NAME);
+	}
+
+	/**
+	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation the default name,
+	 * writing to the file indicated by the given path. It uses the given contract as its input.
+	 * 
+	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
+	 * @param filePath The path to the file to write the contents to.
+	 * @param input The contract to use as the input.
+	 */
+	public FileDataSink(Class<? extends FileOutputFormat<?>> f, String filePath, Contract input) {
+		this(f, filePath, input, DEFAULT_NAME);
+	}
+	
+	/**
+	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation the default name,
+	 * writing to the file indicated by the given path. It uses the given contracts as its input.
+	 * 
+	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
+	 * @param filePath The path to the file to write the contents to.
+	 * @param input The contracts to use as the input.
+	 */
+	public FileDataSink(Class<? extends FileOutputFormat<?>> f, String filePath, List<Contract> input) {
+		this(f, filePath, input, DEFAULT_NAME);
+	}
+
+	/**
+	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation and the given name,
+	 * writing to the file indicated by the given path. It uses the given contract as its input.
+	 * 
+	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
+	 * @param filePath The path to the file to write the contents to.
+	 * @param input The contract to use as the input.
+	 * @param name The given name for the sink, used in plans, logs and progress messages.
+	 */
+	public FileDataSink(Class<? extends FileOutputFormat<?>> f, String filePath, Contract input, String name) {
+		this(f, filePath, name);
+		addInput(input);
+	}
+
+	/**
+	 * Creates a FileDataSink with the provided {@link FileOutputFormat} implementation and the given name,
+	 * writing to the file indicated by the given path. It uses the given contracts as its input.
+	 * 
+	 * @param c The {@link FileOutputFormat} implementation used to encode the data.
+	 * @param filePath The path to the file to write the contents to.
+	 * @param input The contracts to use as the input.
+	 * @param name The given name for the sink, used in plans, logs and progress messages.
+	 */
+	public FileDataSink(Class<? extends FileOutputFormat<?>> f, String filePath, List<Contract> input, String name) {
+		this(f, filePath, name);
 		addInputs(input);
 	}
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/FileDataSource.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/FileDataSource.java
@@ -35,8 +35,8 @@ public class FileDataSource extends GenericDataSource<FileInputFormat<?>>
 	 * @param filePath The file location. The file path must be a fully qualified URI, including the address schema.
 	 * @param name The given name for the Pact, used in plans, logs and progress messages.
 	 */
-	public FileDataSource(Class<? extends FileInputFormat<?>> clazz, String filePath, String name) {
-		super(clazz, name);
+	public FileDataSource(FileInputFormat<?> f, String filePath, String name) {
+		super(f, name);
 		this.filePath = filePath;
 		this.parameters.setString(FileInputFormat.FILE_PARAMETER_KEY, filePath);
 	}
@@ -47,8 +47,31 @@ public class FileDataSource extends GenericDataSource<FileInputFormat<?>>
 	 * @param clazz The class describing the input format for the file.
 	 * @param filePath The file location. The file path must be a fully qualified URI, including the address schema.
 	 */
-	public FileDataSource(Class<? extends FileInputFormat<?>> clazz, String file) {
-		this(clazz, file, DEFAULT_NAME);
+	public FileDataSource(FileInputFormat<?> f, String file) {
+		this(f, file, DEFAULT_NAME);
+	}
+	
+	/**
+	 * Creates a new instance for the given file using the given file input format.
+	 * 
+	 * @param clazz The class describing the input format for the file.
+	 * @param filePath The file location. The file path must be a fully qualified URI, including the address schema.
+	 * @param name The given name for the Pact, used in plans, logs and progress messages.
+	 */
+	public FileDataSource(Class<? extends FileInputFormat<?>> f, String filePath, String name) {
+		super(f, name);
+		this.filePath = filePath;
+		this.parameters.setString(FileInputFormat.FILE_PARAMETER_KEY, filePath);
+	}
+
+	/**
+	 * Creates a new instance for the given file using the given input format. The contract has the default name.
+	 * 
+	 * @param clazz The class describing the input format for the file.
+	 * @param filePath The file location. The file path must be a fully qualified URI, including the address schema.
+	 */
+	public FileDataSource(Class<? extends FileInputFormat<?>> f, String file) {
+		this(f, file, DEFAULT_NAME);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/GenericDataSink.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/GenericDataSink.java
@@ -20,6 +20,9 @@ import java.util.List;
 
 import eu.stratosphere.pact.common.util.Visitor;
 import eu.stratosphere.pact.generic.contract.Contract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 import eu.stratosphere.pact.generic.io.OutputFormat;
 
 /**
@@ -27,13 +30,12 @@ import eu.stratosphere.pact.generic.io.OutputFormat;
  * contract. The way the data is stored is handled by the {@link OutputFormat}.
  * 
  */
-public class GenericDataSink extends Contract 
-{
+public class GenericDataSink extends Contract {
 	private static String DEFAULT_NAME = "<Unnamed Generic Data Sink>";
 
 	// --------------------------------------------------------------------------------------------
 	
-	protected final Class<? extends OutputFormat<?>> clazz;
+	protected final UserCodeWrapper<? extends OutputFormat<?>> formatWrapper;
 
 	private List<Contract> input = new ArrayList<Contract>();
 
@@ -46,27 +48,28 @@ public class GenericDataSink extends Contract
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation
-	 * and a default name.
-	 * 
-	 * @param c The {@link OutputFormat} implementation used to sink the data.
-	 */
-	public GenericDataSink(Class<? extends OutputFormat<?>> c) {
-		this(c, DEFAULT_NAME);
-	}
-	
-	/**
 	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation 
 	 * and the given name. 
 	 * 
 	 * @param c The {@link OutputFormat} implementation used to sink the data.
 	 * @param name The given name for the sink, used in plans, logs and progress messages.
 	 */
-	public GenericDataSink(Class<? extends OutputFormat<?>> c, String name) {
+	public GenericDataSink(OutputFormat<?> f, String name) {
 		super(name);
-		this.clazz = c;
+		this.formatWrapper = new UserCodeObjectWrapper<OutputFormat<?>>(f);
 	}
 
+	
+	/**
+	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation
+	 * and a default name.
+	 * 
+	 * @param c The {@link OutputFormat} implementation used to sink the data.
+	 */
+	public GenericDataSink(OutputFormat<?> f) {
+		this(f, DEFAULT_NAME);
+	}
+	
 	/**
 	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation the default name.
 	 * It uses the given contract as its input.
@@ -74,8 +77,8 @@ public class GenericDataSink extends Contract
 	 * @param c The {@link OutputFormat} implementation used to sink the data.
 	 * @param input The contract to use as the input.
 	 */
-	public GenericDataSink(Class<? extends OutputFormat<?>> c, Contract input) {
-		this(c, input, DEFAULT_NAME);
+	public GenericDataSink(OutputFormat<?> f, Contract input) {
+		this(f, input, DEFAULT_NAME);
 	}
 	
 	/**
@@ -85,8 +88,8 @@ public class GenericDataSink extends Contract
 	 * @param c The {@link OutputFormat} implementation used to sink the data.
 	 * @param input The contracts to use as the input.
 	 */
-	public GenericDataSink(Class<? extends OutputFormat<?>> c, List<Contract> input) {
-		this(c, input, DEFAULT_NAME);
+	public GenericDataSink(OutputFormat<?> f, List<Contract> input) {
+		this(f, input, DEFAULT_NAME);
 	}
 
 	/**
@@ -97,8 +100,8 @@ public class GenericDataSink extends Contract
 	 * @param input The contract to use as the input.
 	 * @param name The given name for the sink, used in plans, logs and progress messages.
 	 */
-	public GenericDataSink(Class<? extends OutputFormat<?>> c, Contract input, String name) {
-		this(c, name);
+	public GenericDataSink(OutputFormat<?> f, Contract input, String name) {
+		this(f, name);
 		addInput(input);
 	}
 
@@ -110,8 +113,79 @@ public class GenericDataSink extends Contract
 	 * @param input The contracts to use as the input.
 	 * @param name The given name for the sink, used in plans, logs and progress messages.
 	 */
-	public GenericDataSink(Class<? extends OutputFormat<?>> c, List<Contract> input, String name) {
-		this(c, name);
+	public GenericDataSink(OutputFormat<?> f, List<Contract> input, String name) {
+		this(f, name);
+		addInputs(input);
+	}
+	
+	/**
+	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation 
+	 * and the given name. 
+	 * 
+	 * @param c The {@link OutputFormat} implementation used to sink the data.
+	 * @param name The given name for the sink, used in plans, logs and progress messages.
+	 */
+	public GenericDataSink(Class<? extends OutputFormat<?>> f, String name) {
+		super(name);
+		this.formatWrapper = new UserCodeClassWrapper<OutputFormat<?>>(f);
+	}
+
+	
+	/**
+	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation
+	 * and a default name.
+	 * 
+	 * @param c The {@link OutputFormat} implementation used to sink the data.
+	 */
+	public GenericDataSink(Class<? extends OutputFormat<?>> f) {
+		this(f, DEFAULT_NAME);
+	}
+	
+	/**
+	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation the default name.
+	 * It uses the given contract as its input.
+	 * 
+	 * @param c The {@link OutputFormat} implementation used to sink the data.
+	 * @param input The contract to use as the input.
+	 */
+	public GenericDataSink(Class<? extends OutputFormat<?>> f, Contract input) {
+		this(f, input, DEFAULT_NAME);
+	}
+	
+	/**
+	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation the default name.
+	 * It uses the given contracts as its input.
+	 * 
+	 * @param c The {@link OutputFormat} implementation used to sink the data.
+	 * @param input The contracts to use as the input.
+	 */
+	public GenericDataSink(Class<? extends OutputFormat<?>> f, List<Contract> input) {
+		this(f, input, DEFAULT_NAME);
+	}
+
+	/**
+	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation and the given name.
+	 * It uses the given contract as its input.
+	 * 
+	 * @param c The {@link OutputFormat} implementation used to sink the data.
+	 * @param input The contract to use as the input.
+	 * @param name The given name for the sink, used in plans, logs and progress messages.
+	 */
+	public GenericDataSink(Class<? extends OutputFormat<?>> f, Contract input, String name) {
+		this(f, name);
+		addInput(input);
+	}
+
+	/**
+	 * Creates a GenericDataSink with the provided {@link OutputFormat} implementation and the given name.
+	 * It uses the given contracts as its input.
+	 * 
+	 * @param c The {@link OutputFormat} implementation used to sink the data.
+	 * @param input The contracts to use as the input.
+	 * @param name The given name for the sink, used in plans, logs and progress messages.
+	 */
+	public GenericDataSink(Class<? extends OutputFormat<?>> f, List<Contract> input, String name) {
+		this(f, name);
 		addInputs(input);
 	}
 
@@ -261,9 +335,9 @@ public class GenericDataSink extends Contract
 	 * 
 	 * @return The output format class.
 	 */
-	public Class<? extends OutputFormat<?>> getFormatClass()
+	public UserCodeWrapper<? extends OutputFormat<?>> getFormatWrapper()
 	{
-		return this.clazz;
+		return this.formatWrapper;
 	}
 	
 	/**
@@ -276,9 +350,9 @@ public class GenericDataSink extends Contract
 	 * @see eu.stratosphere.pact.generic.contract.Contract#getUserCodeClass()
 	 */
 	@Override
-	public Class<? extends OutputFormat<?>> getUserCodeClass()
+	public UserCodeWrapper<? extends OutputFormat<?>> getUserCodeWrapper()
 	{
-		return this.clazz;
+		return this.formatWrapper;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/GenericDataSource.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/GenericDataSource.java
@@ -20,6 +20,9 @@ import java.lang.annotation.Annotation;
 import eu.stratosphere.pact.common.stubs.StubAnnotation;
 import eu.stratosphere.pact.common.util.Visitor;
 import eu.stratosphere.pact.generic.contract.Contract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 import eu.stratosphere.pact.generic.io.InputFormat;
 
 /**
@@ -31,7 +34,7 @@ public class GenericDataSource<T extends InputFormat<?, ?>> extends Contract imp
 	
 	private static final String DEFAULT_NAME = "<Unnamed Generic Data Source>";
 	
-	protected final Class<? extends T> clazz;
+	protected final UserCodeWrapper<? extends T> formatWrapper;
 	
 	protected String statisticsKey;
 
@@ -41,9 +44,9 @@ public class GenericDataSource<T extends InputFormat<?, ?>> extends Contract imp
 	 * @param clazz The Class for the specific input format
 	 * @param name The given name for the Pact, used in plans, logs and progress messages.
 	 */
-	public GenericDataSource(Class<? extends T> clazz, String name) {
+	public GenericDataSource(T format, String name) {
 		super(name);
-		this.clazz = clazz;
+		this.formatWrapper = new UserCodeObjectWrapper<T>(format);
 	}
 	
 	/**
@@ -51,9 +54,30 @@ public class GenericDataSource<T extends InputFormat<?, ?>> extends Contract imp
 	 * 
 	 * @param clazz The Class for the specific input format
 	 */
-	public GenericDataSource(Class<? extends T> clazz) {
+	public GenericDataSource(T format) {
 		super(DEFAULT_NAME);
-		this.clazz = clazz;
+		this.formatWrapper = new UserCodeObjectWrapper<T>(format);
+	}
+	
+	/**
+	 * Creates a new instance for the given file using the given input format.
+	 * 
+	 * @param clazz The Class for the specific input format
+	 * @param name The given name for the Pact, used in plans, logs and progress messages.
+	 */
+	public GenericDataSource(Class<? extends T> format, String name) {
+		super(name);
+		this.formatWrapper = new UserCodeClassWrapper<T>(format);
+	}
+	
+	/**
+	 * Creates a new instance for the given file using the given input format, using the default name.
+	 * 
+	 * @param clazz The Class for the specific input format
+	 */
+	public GenericDataSource(Class<? extends T> format) {
+		super(DEFAULT_NAME);
+		this.formatWrapper = new UserCodeClassWrapper<T>(format);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -85,8 +109,8 @@ public class GenericDataSource<T extends InputFormat<?, ?>> extends Contract imp
 	 * 
 	 * @return The class describing the input format.
 	 */
-	public Class<? extends T> getFormatClass() {
-		return this.clazz;
+	public UserCodeWrapper<? extends T> getFormatWrapper() {
+		return this.formatWrapper;
 	}
 	
 	/**
@@ -99,8 +123,8 @@ public class GenericDataSource<T extends InputFormat<?, ?>> extends Contract imp
 	 * @see eu.stratosphere.pact.generic.contract.Contract#getUserCodeClass()
 	 */
 	@Override
-	public Class<?> getUserCodeClass() {
-		return this.clazz;
+	public UserCodeWrapper<? extends T> getUserCodeWrapper() {
+		return this.formatWrapper;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/MapContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/MapContract.java
@@ -22,6 +22,9 @@ import eu.stratosphere.pact.common.stubs.MapStub;
 import eu.stratosphere.pact.common.type.Key;
 import eu.stratosphere.pact.generic.contract.Contract;
 import eu.stratosphere.pact.generic.contract.GenericMapContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 
 /**
  * MapContract represents a Pact with a Map Input Contract.
@@ -44,8 +47,17 @@ public class MapContract extends GenericMapContract<MapStub> implements RecordCo
 	 * 
 	 * @param udf The {@link MapStub} implementation for this Map contract.
 	 */
+	public static Builder builder(MapStub udf) {
+		return new Builder(new UserCodeObjectWrapper<MapStub>(udf));
+	}
+	
+	/**
+	 * Creates a Builder with the provided {@link MapStub} implementation.
+	 * 
+	 * @param udf The {@link MapStub} implementation for this Map contract.
+	 */
 	public static Builder builder(Class<? extends MapStub> udf) {
-		return new Builder(udf);
+		return new Builder(new UserCodeClassWrapper<MapStub>(udf));
 	}
 	
 	/**
@@ -73,7 +85,7 @@ public class MapContract extends GenericMapContract<MapStub> implements RecordCo
 	public static class Builder {
 		
 		/* The required parameters */
-		private final Class<? extends MapStub> udf;
+		private final UserCodeWrapper<MapStub> udf;
 		
 		/* The optional parameters */
 		private List<Contract> inputs;
@@ -84,7 +96,7 @@ public class MapContract extends GenericMapContract<MapStub> implements RecordCo
 		 * 
 		 * @param udf The {@link MapStub} implementation for this Map contract.
 		 */
-		private Builder(Class<? extends MapStub> udf) {
+		private Builder(UserCodeWrapper<MapStub> udf) {
 			this.udf = udf;
 			this.inputs = new ArrayList<Contract>();
 		}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/MatchContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/MatchContract.java
@@ -22,6 +22,9 @@ import eu.stratosphere.pact.common.stubs.MatchStub;
 import eu.stratosphere.pact.common.type.Key;
 import eu.stratosphere.pact.generic.contract.Contract;
 import eu.stratosphere.pact.generic.contract.GenericMatchContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 
 
 /**
@@ -54,8 +57,20 @@ public class MatchContract extends GenericMatchContract<MatchStub> implements Re
 	 * @param keyColumn1 The position of the key in the first input's records.
 	 * @param keyColumn2 The position of the key in the second input's records.
 	 */
+	public static Builder builder(MatchStub udf, Class<? extends Key> keyClass, int keyColumn1, int keyColumn2) {
+		return new Builder(new UserCodeObjectWrapper<MatchStub>(udf), keyClass, keyColumn1, keyColumn2);
+	}
+	
+	/**
+	 * Creates a Builder with the provided {@link MatchStub} implementation
+	 * 
+	 * @param udf The {@link MatchStub} implementation for this Match contract.
+	 * @param keyClass The class of the key data type.
+	 * @param keyColumn1 The position of the key in the first input's records.
+	 * @param keyColumn2 The position of the key in the second input's records.
+	 */
 	public static Builder builder(Class<? extends MatchStub> udf, Class<? extends Key> keyClass, int keyColumn1, int keyColumn2) {
-		return new Builder(udf, keyClass, keyColumn1, keyColumn2);
+		return new Builder(new UserCodeClassWrapper<MatchStub>(udf), keyClass, keyColumn1, keyColumn2);
 	}
 	
 	/**
@@ -86,7 +101,7 @@ public class MatchContract extends GenericMatchContract<MatchStub> implements Re
 	public static class Builder {
 		
 		/* The required parameters */
-		private final Class<? extends MatchStub> udf;
+		private final UserCodeWrapper<MatchStub> udf;
 		private final List<Class<? extends Key>> keyClasses;
 		private final List<Integer> keyColumns1;
 		private final List<Integer> keyColumns2;
@@ -105,7 +120,7 @@ public class MatchContract extends GenericMatchContract<MatchStub> implements Re
 		 * @param keyColumn1 The position of the key in the first input's records.
 		 * @param keyColumn2 The position of the key in the second input's records.
 		 */
-		protected Builder(Class<? extends MatchStub> udf, Class<? extends Key> keyClass, int keyColumn1, int keyColumn2) {
+		protected Builder(UserCodeWrapper<MatchStub> udf, Class<? extends Key> keyClass, int keyColumn1, int keyColumn2) {
 			this.udf = udf;
 			this.keyClasses = new ArrayList<Class<? extends Key>>();
 			this.keyClasses.add(keyClass);
@@ -123,7 +138,7 @@ public class MatchContract extends GenericMatchContract<MatchStub> implements Re
 		 * 
 		 * @param udf The {@link MatchStub} implementation for this Match contract.
 		 */
-		protected Builder(Class<? extends MatchStub> udf) {
+		protected Builder(UserCodeWrapper<MatchStub> udf) {
 			this.udf = udf;
 			this.keyClasses = new ArrayList<Class<? extends Key>>();
 			this.keyColumns1 = new ArrayList<Integer>();

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/ReduceContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/contract/ReduceContract.java
@@ -26,6 +26,9 @@ import eu.stratosphere.pact.common.stubs.ReduceStub;
 import eu.stratosphere.pact.common.type.Key;
 import eu.stratosphere.pact.generic.contract.Contract;
 import eu.stratosphere.pact.generic.contract.GenericReduceContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 
 /**
  * MapContract represents a Pact with a Map Input Contract.
@@ -58,8 +61,28 @@ public class ReduceContract extends GenericReduceContract<ReduceStub> implements
 	 * 
 	 * @param udf The {@link ReduceStub} implementation for this Reduce contract.
 	 */
+	public static Builder builder(ReduceStub udf) {
+		return new Builder(new UserCodeObjectWrapper<ReduceStub>(udf));
+	}
+	
+	/**
+	 * Creates a Builder with the provided {@link ReduceStub} implementation.
+	 * 
+	 * @param udf The {@link ReduceStub} implementation for this Reduce contract.
+	 * @param keyClass The class of the key data type.
+	 * @param keyColumn The position of the key.
+	 */
+	public static Builder builder(ReduceStub udf, Class<? extends Key> keyClass, int keyColumn) {
+		return new Builder(new UserCodeObjectWrapper<ReduceStub>(udf), keyClass, keyColumn);
+	}
+
+	/**
+	 * Creates a Builder with the provided {@link ReduceStub} implementation.
+	 * 
+	 * @param udf The {@link ReduceStub} implementation for this Reduce contract.
+	 */
 	public static Builder builder(Class<? extends ReduceStub> udf) {
-		return new Builder(udf);
+		return new Builder(new UserCodeClassWrapper<ReduceStub>(udf));
 	}
 	
 	/**
@@ -70,7 +93,7 @@ public class ReduceContract extends GenericReduceContract<ReduceStub> implements
 	 * @param keyColumn The position of the key.
 	 */
 	public static Builder builder(Class<? extends ReduceStub> udf, Class<? extends Key> keyClass, int keyColumn) {
-		return new Builder(udf, keyClass, keyColumn);
+		return new Builder(new UserCodeClassWrapper<ReduceStub>(udf), keyClass, keyColumn);
 	}
 	
 	/**
@@ -120,7 +143,7 @@ public class ReduceContract extends GenericReduceContract<ReduceStub> implements
 	 */
 	@Override
 	public boolean isCombinable() {
-		return super.isCombinable() || getUserCodeClass().getAnnotation(Combinable.class) != null;
+		return super.isCombinable() || getUserCodeAnnotation(Combinable.class) != null;
 	}
 	
 	/**
@@ -171,7 +194,7 @@ public class ReduceContract extends GenericReduceContract<ReduceStub> implements
 	public static class Builder {
 		
 		/* The required parameters */
-		private final Class<? extends ReduceStub> udf;
+		private final UserCodeWrapper<ReduceStub> udf;
 		private final List<Class<? extends Key>> keyClasses;
 		private final List<Integer> keyColumns;
 		
@@ -185,7 +208,7 @@ public class ReduceContract extends GenericReduceContract<ReduceStub> implements
 		 * 
 		 * @param udf The {@link ReduceStub} implementation for this Reduce contract.
 		 */
-		private Builder(Class<? extends ReduceStub> udf) {
+		private Builder(UserCodeWrapper<ReduceStub> udf) {
 			this.udf = udf;
 			this.keyClasses = new ArrayList<Class<? extends Key>>();
 			this.keyColumns = new ArrayList<Integer>();
@@ -199,7 +222,7 @@ public class ReduceContract extends GenericReduceContract<ReduceStub> implements
 		 * @param keyClass The class of the key data type.
 		 * @param keyColumn The position of the key.
 		 */
-		public Builder(Class<? extends ReduceStub> udf, Class<? extends Key> keyClass, int keyColumn) {
+		private Builder(UserCodeWrapper<ReduceStub> udf, Class<? extends Key> keyClass, int keyColumn) {
 			this.udf = udf;
 			this.keyClasses = new ArrayList<Class<? extends Key>>();
 			this.keyClasses.add(keyClass);

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/DelimitedInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/DelimitedInputFormat.java
@@ -42,6 +42,8 @@ public abstract class DelimitedInputFormat extends FileInputFormat {
 	
 	// -------------------------------------- Constants -------------------------------------------
 	
+	private static final long serialVersionUID = 1L;
+
 	/**
 	 * The log.
 	 */

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/DelimitedOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/DelimitedOutputFormat.java
@@ -27,8 +27,9 @@ import eu.stratosphere.pact.common.type.PactRecord;
 /**
  * The base class for output formats that serialize their records into a delimited sequence.
  */
-public abstract class DelimitedOutputFormat extends FileOutputFormat
-{
+public abstract class DelimitedOutputFormat extends FileOutputFormat {
+	private static final long serialVersionUID = 1L;
+
 	/**
 	 * The configuration key for the entry that defines the record delimiter.
 	 */

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/ExternalProcessFixedLengthInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/ExternalProcessFixedLengthInputFormat.java
@@ -38,6 +38,8 @@ import eu.stratosphere.pact.common.type.PactRecord;
  */
 public abstract class ExternalProcessFixedLengthInputFormat<T extends ExternalProcessInputSplit> extends ExternalProcessInputFormat<T> {
 
+	private static final long serialVersionUID = 1L;
+
 	/**
 	 * The config parameter which defines the fixed length of a record.
 	 */

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/ExternalProcessInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/ExternalProcessInputFormat.java
@@ -37,7 +37,8 @@ import eu.stratosphere.nephele.template.GenericInputSplit;
  * @param <T>, The type of the input split (must extend ExternalProcessInputSplit)
  */
 public abstract class ExternalProcessInputFormat<T extends ExternalProcessInputSplit> extends GenericInputFormat {
-
+	private static final long serialVersionUID = 1L;
+	 
 	/**
 	 * The config parameter lists (comma separated) all allowed exit codes
 	 */

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/FileInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/FileInputFormat.java
@@ -21,6 +21,6 @@ import eu.stratosphere.pact.common.type.PactRecord;
  * The base interface for input formats that read {@link PactRecord}s from a
  * file.
  */
-public abstract class FileInputFormat extends eu.stratosphere.pact.generic.io.FileInputFormat<PactRecord>
-{
+public abstract class FileInputFormat extends eu.stratosphere.pact.generic.io.FileInputFormat<PactRecord> {
+	private static final long serialVersionUID = 1L;
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/FileOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/FileOutputFormat.java
@@ -22,5 +22,6 @@ import eu.stratosphere.pact.common.type.PactRecord;
  * The abstract base class for all output formats that are file based. Contains the logic to open/close the target
  * file streams.
  */
-public abstract class FileOutputFormat extends eu.stratosphere.pact.generic.io.FileOutputFormat<PactRecord>
-{}
+public abstract class FileOutputFormat extends eu.stratosphere.pact.generic.io.FileOutputFormat<PactRecord> {
+	private static final long serialVersionUID = 1L;
+}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/FixedLengthInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/FixedLengthInputFormat.java
@@ -27,6 +27,7 @@ import eu.stratosphere.pact.common.type.PactRecord;
  * 
  */
 public abstract class FixedLengthInputFormat extends FileInputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	/**
 	 * The config parameter which defines the fixed length of a record.

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/GenericInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/GenericInputFormat.java
@@ -22,6 +22,6 @@ import eu.stratosphere.pact.common.type.PactRecord;
  *
  * @author Stephan Ewen
  */
-public abstract class GenericInputFormat extends eu.stratosphere.pact.generic.io.GenericInputFormat<PactRecord>
-{
+public abstract class GenericInputFormat extends eu.stratosphere.pact.generic.io.GenericInputFormat<PactRecord> {
+	private static final long serialVersionUID = 1L;
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/RecordInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/RecordInputFormat.java
@@ -51,6 +51,7 @@ import eu.stratosphere.pact.generic.contract.Contract;
  * @see PactRecord
  */
 public class RecordInputFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
 
 	// -------------------------------------- Constants -------------------------------------------
 	

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/RecordOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/RecordOutputFormat.java
@@ -50,6 +50,7 @@ import eu.stratosphere.pact.common.type.Value;
  * @see PactRecord
  */
 public class RecordOutputFormat extends FileOutputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	public static final String RECORD_DELIMITER_PARAMETER = "pact.output.record.delimiter";
 	

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/TextInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/io/TextInputFormat.java
@@ -34,6 +34,7 @@ import eu.stratosphere.pact.common.type.base.PactString;
  * only a single string, namely the line.
  */
 public class TextInputFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	public static final String CHARSET_NAME = "textformat.charset";
 	

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/PactRecord.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/PactRecord.java
@@ -19,6 +19,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.UTFDataFormatException;
 
 import eu.stratosphere.nephele.services.memorymanager.DataInputView;
@@ -45,6 +46,7 @@ import eu.stratosphere.pact.common.util.InstantiationUtil;
  * This class is NOT thread-safe!
  */
 public final class PactRecord implements Value {
+	private static final long serialVersionUID = 1L;
 	
 	private static final int NULL_INDICATOR_OFFSET = Integer.MIN_VALUE;			// value marking a field as null
 	
@@ -1174,6 +1176,7 @@ public final class PactRecord implements Value {
 	 * but instead indicates that space should be reserved in the buffer.
 	 */
 	private static final Value RESERVE_SPACE = new Value() {
+		private static final long serialVersionUID = 1L;
 
 		@Override
 		public void write(DataOutput out) throws IOException {
@@ -1189,8 +1192,9 @@ public final class PactRecord implements Value {
 	/**
 	 * Internal interface class to provide serialization for the data types.
 	 */
-	private static final class InternalDeSerializer implements DataInput, DataOutput
-	{
+	private static final class InternalDeSerializer implements DataInput, DataOutput, Serializable {
+		private static final long serialVersionUID = 1L;
+		
 		private byte[] memory;
 		private int position;
 		private int end;

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/Value.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/Value.java
@@ -15,6 +15,8 @@
 
 package eu.stratosphere.pact.common.type;
 
+import java.io.Serializable;
+
 import eu.stratosphere.nephele.types.Record;
 
 /**
@@ -26,5 +28,5 @@ import eu.stratosphere.nephele.types.Record;
  * 
  * @see eu.stratosphere.nephele.io.IOReadableWritable
  */
-public interface Value extends Record {
+public interface Value extends Record, Serializable {
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactBoolean.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactBoolean.java
@@ -27,6 +27,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class PactBoolean implements NormalizableKey, CopyableValue<PactBoolean> {
+	private static final long serialVersionUID = 1L;
 
 	private boolean value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactByte.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactByte.java
@@ -33,6 +33,7 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * @see eu.stratosphere.pact.common.type.Key
  */
 public class PactByte implements Key, NormalizableKey, CopyableValue<PactByte> {
+	private static final long serialVersionUID = 1L;
 	
 	private byte value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactCharacter.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactCharacter.java
@@ -33,6 +33,7 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * @see eu.stratosphere.pact.common.type.Key
  */
 public class PactCharacter implements Key, NormalizableKey, CopyableValue<PactCharacter> {
+	private static final long serialVersionUID = 1L;
 	
 	private char value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactDouble.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactDouble.java
@@ -31,6 +31,7 @@ import eu.stratosphere.pact.common.type.Key;
  * @see eu.stratosphere.pact.common.type.Key
  */
 public class PactDouble implements Key, CopyableValue<PactDouble> {
+	private static final long serialVersionUID = 1L;
 
 	private double value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactFloat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactFloat.java
@@ -31,6 +31,7 @@ import eu.stratosphere.pact.common.type.Key;
  * @see eu.stratosphere.pact.common.type.Key
  */
 public class PactFloat implements Key, CopyableValue<PactFloat> {
+	private static final long serialVersionUID = 1L;
 
 	private float value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactInteger.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactInteger.java
@@ -33,6 +33,7 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * @see eu.stratosphere.pact.common.type.Key
  */
 public class PactInteger implements Key, NormalizableKey, CopyableValue<PactInteger> {
+	private static final long serialVersionUID = 1L;
 	
 	private int value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactList.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactList.java
@@ -41,6 +41,7 @@ import eu.stratosphere.pact.common.util.ReflectionUtil;
  * 
  */
 public abstract class PactList<V extends Value> implements Value, List<V> {
+	private static final long serialVersionUID = 1L;
 	
 	// Type of list elements
 	private final Class<V> valueClass;

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactLong.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactLong.java
@@ -33,6 +33,7 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * @see eu.stratosphere.pact.common.type.Key
  */
 public class PactLong implements Key, NormalizableKey, CopyableValue<PactLong> {
+	private static final long serialVersionUID = 1L;
 
 	private long value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactMap.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactMap.java
@@ -41,6 +41,7 @@ import eu.stratosphere.pact.common.util.ReflectionUtil;
  * 
  */
 public abstract class PactMap<K extends Value, V extends Value> implements Value, Map<K, V> {
+	private static final long serialVersionUID = 1L;
 	
 	// type of the map's key
 	private final Class<K> keyClass;

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactNull.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactNull.java
@@ -33,8 +33,9 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * 
  * @see eu.stratosphere.pact.common.type.Key
  */
-public final class PactNull implements Key, NormalizableKey, CopyableValue<PactNull>
-{	
+public final class PactNull implements Key, NormalizableKey, CopyableValue<PactNull> {
+	private static final long serialVersionUID = 1L;
+	
 	/**
 	 * The PactNull singleton instance.
 	 */

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactPair.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactPair.java
@@ -35,6 +35,7 @@ import eu.stratosphere.pact.common.util.ReflectionUtil;
  * 
  */
 public abstract class PactPair<U extends Key, V extends Key> implements Key {
+	private static final long serialVersionUID = 1L;
 	
 	// class of the first pair element
 	private final Class<U> firstClass;

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactShort.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactShort.java
@@ -33,6 +33,7 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * @see eu.stratosphere.pact.common.type.Key
  */
 public class PactShort implements Key, NormalizableKey, CopyableValue<PactShort> {
+	private static final long serialVersionUID = 1L;
 	
 	private short value;
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactString.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/base/PactString.java
@@ -42,6 +42,7 @@ import eu.stratosphere.pact.common.type.NormalizableKey;
  * @see java.lang.CharSequence
  */
 public class PactString implements Key, NormalizableKey, CharSequence, CopyableValue<PactString>, Appendable {
+	private static final long serialVersionUID = 1L;
 	
 	private static final char[] EMPTY_STRING = new char[0];
 	
@@ -181,7 +182,7 @@ public class PactString implements Key, NormalizableKey, CharSequence, CopyableV
 			throw new NullPointerException();
 		
 		if (offset < 0 || len < 0 || offset > value.len - len)
-			throw new IndexOutOfBoundsException();
+			throw new IndexOutOfBoundsException("offset: " + offset + " len: " + len + " value.len: " + value.len);
 
 		ensureSize(len);
 		this.len = len;

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/util/InstantiationUtil.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/util/InstantiationUtil.java
@@ -16,8 +16,10 @@
 package eu.stratosphere.pact.common.util;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
@@ -184,6 +186,15 @@ public class InstantiationUtil {
 				oois.close();
 			}
 		}
+	}
+	
+	public static void writeObjectToConfig(Object o, Configuration config, String key) throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+	    ObjectOutputStream oos = new ObjectOutputStream(baos);
+	    oos.writeObject(o);
+			    
+	    byte[] bytes = baos.toByteArray();
+	    config.setBytes(key, bytes);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/AbstractPact.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/AbstractPact.java
@@ -23,9 +23,9 @@ import eu.stratosphere.pact.common.stubs.Stub;
 public abstract class AbstractPact<T extends Stub> extends Contract {
 	
 	/**
-	 * The class containing the user function for this Pact.
+	 * The object or class containing the user function.
 	 */
-	protected final Class<? extends T> stubClass;
+	protected final UserCodeWrapper<T> stub;
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -35,9 +35,9 @@ public abstract class AbstractPact<T extends Stub> extends Contract {
 	 * @param name The given name for the Pact, used in plans, logs and progress messages.
 	 * @param stubClass The class containing the user function.
 	 */
-	protected AbstractPact(Class<? extends T> stubClass, String name) {
+	protected AbstractPact(UserCodeWrapper<T> stub, String name) {
 		super(name);
-		this.stubClass = stubClass;
+		this.stub = stub;
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -46,13 +46,16 @@ public abstract class AbstractPact<T extends Stub> extends Contract {
 	 * Gets the stub that is wrapped by this contract. The stub is the actual implementation of the
 	 * user code.
 	 * 
-	 * @return The class with the user function for this Pact.
+	 * This throws an exception if the pact does not contain an object but a class for the user
+	 * code.
+	 * 
+	 * @return The object with the user function for this Pact.
 	 *
-	 * @see eu.stratosphere.pact.generic.contract.Contract#getUserCodeClass()
+	 * @see eu.stratosphere.pact.generic.contract.Contract#getUserCodeObject()
 	 */
 	@Override
-	public Class<? extends T> getUserCodeClass() {
-		return this.stubClass;
+	public UserCodeWrapper<T> getUserCodeWrapper() {
+		return stub;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/BulkIteration.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/BulkIteration.java
@@ -47,7 +47,7 @@ public class BulkIteration extends SingleInputContract<AbstractStub> implements 
 	 * @param name
 	 */
 	public BulkIteration(String name) {
-		super(AbstractStub.class, name);
+		super(new UserCodeClassWrapper<AbstractStub>(AbstractStub.class), name);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -154,7 +154,7 @@ public class BulkIteration extends SingleInputContract<AbstractStub> implements 
 		}
 
 		@Override
-		public Class<?> getUserCodeClass() {
+		public UserCodeWrapper<?> getUserCodeWrapper() {
 			return null;
 		}
 	}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/BulkIteration.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/BulkIteration.java
@@ -28,7 +28,7 @@ public class BulkIteration extends SingleInputContract<AbstractStub> implements 
 	
 	private Contract iterationResult;
 	
-	private final Contract inputPlaceHolder = new PartialSolutionPlaceHolder(this);
+	private Contract inputPlaceHolder = new PartialSolutionPlaceHolder(this);
 	
 	private final AggregatorRegistry aggregators = new AggregatorRegistry();
 	
@@ -133,11 +133,12 @@ public class BulkIteration extends SingleInputContract<AbstractStub> implements 
 	 * Specialized contract to use as a recognizable place-holder for the input to the
 	 * step function when composing the nested data flow.
 	 */
-	public static final class PartialSolutionPlaceHolder extends Contract {
+	// Integer is only a dummy here but this whole placeholder shtick seems a tad bogus.
+	public static class PartialSolutionPlaceHolder extends Contract {
 		
 		private final BulkIteration containingIteration;
 		
-		private PartialSolutionPlaceHolder(BulkIteration container) {
+		public PartialSolutionPlaceHolder(BulkIteration container) {
 			super("Partial Solution Place Holder");
 			this.containingIteration = container;
 		}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/Contract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/Contract.java
@@ -166,13 +166,16 @@ public abstract class Contract implements Visitable<Contract> {
 		this.degreeOfParallelism = degree;
 	}
 	
+	
 	/**
-	 * Gets the user code class. In the case of a pact, that class will be the stub with the user function,
-	 * in the case of an input or output format, it will be the format class.  
+	 * Gets the user code wrapper. In the case of a pact, that object will be the stub with the user function,
+	 * in the case of an input or output format, it will be the format object.  
 	 * 
 	 * @return The class with the user code.
 	 */
-	public abstract Class<?> getUserCodeClass();
+	public UserCodeWrapper<?> getUserCodeWrapper() {
+		return null;
+	}
 	
 	/**
 	 * Gets an annotation that pertains to the user code class. By default, this method will look for
@@ -184,8 +187,9 @@ public abstract class Contract implements Visitable<Contract> {
 	 * @return the annotation, or null if no annotation of the requested type was found
 	 */
 	public <A extends Annotation> A getUserCodeAnnotation(Class<A> annotationClass) {
-		return getUserCodeClass().getAnnotation(annotationClass);
+		return getUserCodeWrapper().getUserCodeAnnotation(annotationClass);
 	}
+	
 	
 	// --------------------------------------------------------------------------------------------
 	

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/DualInputContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/DualInputContract.java
@@ -57,8 +57,8 @@ public abstract class DualInputContract<T extends Stub> extends AbstractPact<T> 
 	 * @param name The given name for the Pact, used in plans, logs and progress messages.
 	 * @param stubClass The class containing the user function.
 	 */
-	protected DualInputContract(Class<? extends T> stubClass, String name) {
-		super(stubClass, name);
+	protected DualInputContract(UserCodeWrapper<T> stub, String name) {
+		super(stub, name);
 		this.keyFields1 = this.keyFields2 = new int[0];
 	}
 	
@@ -70,8 +70,8 @@ public abstract class DualInputContract<T extends Stub> extends AbstractPact<T> 
 	 * @param keyTypes The classes of the data types that act as keys in this stub.
 	 * @param stubClass The class containing the user function.
 	 */
-	protected DualInputContract(Class<? extends T> stubClass, int[] keyPositions1, int[] keyPositions2, String name) {
-		super(stubClass, name);
+	protected DualInputContract(UserCodeWrapper<T> stub, int[] keyPositions1, int[] keyPositions2, String name) {
+		super(stub, name);
 		this.keyFields1 = keyPositions1;
 		this.keyFields2 = keyPositions2;
 	}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericCoGroupContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericCoGroupContract.java
@@ -36,19 +36,25 @@ import eu.stratosphere.pact.generic.stub.GenericCoGrouper;
  */
 public class GenericCoGroupContract<T extends GenericCoGrouper<?, ?, ?>> extends DualInputContract<T> {
 	
-	public GenericCoGroupContract(Class<? extends T> udf, int[] keyPositions1, int[] keyPositions2, String name) {
+	public GenericCoGroupContract(UserCodeWrapper<T> udf, int[] keyPositions1, int[] keyPositions2, String name) {
 		super(udf, keyPositions1, keyPositions2, name);
 	}
 	
+	public GenericCoGroupContract(T udf, int[] keyPositions1, int[] keyPositions2, String name) {
+		this(new UserCodeObjectWrapper<T>(udf), keyPositions1, keyPositions2, name);
+	}
+	
+	public GenericCoGroupContract(Class<? extends T> udf, int[] keyPositions1, int[] keyPositions2, String name) {
+		this(new UserCodeClassWrapper<T>(udf), keyPositions1, keyPositions2, name);
+	}
 
 	public boolean isCombinableFirst() {
-		return getUserCodeClass().getAnnotation(CombinableFirst.class) != null;
+		return getUserCodeAnnotation(CombinableFirst.class) != null;
 	}
 	
 	public boolean isCombinableSecond() {
-		return getUserCodeClass().getAnnotation(CombinableSecond.class) != null;
+		return getUserCodeAnnotation(CombinableSecond.class) != null;
 	}
-	
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericCrossContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericCrossContract.java
@@ -32,7 +32,15 @@ import eu.stratosphere.pact.generic.stub.GenericCrosser;
  */
 public class GenericCrossContract<T extends GenericCrosser<?, ?, ?>> extends DualInputContract<T>
 {
-	public GenericCrossContract(Class<? extends T> udf, String name) {
+	public GenericCrossContract(UserCodeWrapper<T> udf, String name) {
 		super(udf, name);
+	}
+	
+	public GenericCrossContract(T udf, String name) {
+		this(new UserCodeObjectWrapper<T>(udf), name);
+	}
+	
+	public GenericCrossContract(Class<? extends T> udf, String name) {
+		this(new UserCodeClassWrapper<T>(udf), name);
 	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericMapContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericMapContract.java
@@ -34,7 +34,15 @@ import eu.stratosphere.pact.generic.stub.GenericMapper;
  */
 public class GenericMapContract<T extends GenericMapper<?, ?>> extends SingleInputContract<T>
 {
-	public GenericMapContract(Class<? extends T> udf, String name) {
+	public GenericMapContract(UserCodeWrapper<T> udf, String name) {
 		super(udf, name);
+	}
+	
+	public GenericMapContract(T udf, String name) {
+		super(new UserCodeObjectWrapper<T>(udf), name);
+	}
+	
+	public GenericMapContract(Class<? extends T> udf, String name) {
+		super(new UserCodeClassWrapper<T>(udf), name);
 	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericMatchContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericMatchContract.java
@@ -32,7 +32,15 @@ import eu.stratosphere.pact.generic.stub.GenericMatcher;
  */
 public class GenericMatchContract<T extends GenericMatcher<?, ?, ?>> extends DualInputContract<T>
 {
-	public GenericMatchContract(Class <? extends T> udf, int[] keyPositions1, int[] keyPositions2, String name) {
+	public GenericMatchContract(UserCodeWrapper<T> udf, int[] keyPositions1, int[] keyPositions2, String name) {
 		super(udf, keyPositions1, keyPositions2, name);
+	}
+	
+	public GenericMatchContract(T udf, int[] keyPositions1, int[] keyPositions2, String name) {
+		super(new UserCodeObjectWrapper<T>(udf), keyPositions1, keyPositions2, name);
+	}
+	
+	public GenericMatchContract(Class<? extends T> udf, int[] keyPositions1, int[] keyPositions2, String name) {
+		super(new UserCodeClassWrapper<T>(udf), keyPositions1, keyPositions2, name);
 	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericReduceContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/GenericReduceContract.java
@@ -21,7 +21,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import eu.stratosphere.pact.common.stubs.ReduceStub;
-import eu.stratosphere.pact.generic.contract.SingleInputContract;
 import eu.stratosphere.pact.generic.stub.GenericReducer;
 
 
@@ -37,12 +36,28 @@ import eu.stratosphere.pact.generic.stub.GenericReducer;
  */
 public class GenericReduceContract<T extends GenericReducer<?, ?>> extends SingleInputContract<T> {
 	
-	public GenericReduceContract(Class <? extends T> udf, int[] keyPositions, String name) {
+	public GenericReduceContract(UserCodeWrapper<T> udf, int[] keyPositions, String name) {
 		super(udf, keyPositions, name);
 	}
 	
-	public GenericReduceContract(Class <? extends T> udf, String name) {
+	public GenericReduceContract(T udf, int[] keyPositions, String name) {
+		super(new UserCodeObjectWrapper<T>(udf), keyPositions, name);
+	}
+	
+	public GenericReduceContract(Class<? extends T> udf, int[] keyPositions, String name) {
+		super(new UserCodeClassWrapper<T>(udf), keyPositions, name);
+	}
+	
+	public GenericReduceContract(UserCodeWrapper<T> udf, String name) {
 		super(udf, name);
+	}
+	
+	public GenericReduceContract(T udf, String name) {
+		super(new UserCodeObjectWrapper<T>(udf), name);
+	}
+	
+	public GenericReduceContract(Class<? extends T> udf, String name) {
+		super(new UserCodeClassWrapper<T>(udf), name);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -56,7 +71,7 @@ public class GenericReduceContract<T extends GenericReducer<?, ?>> extends Singl
 	 * @return True, if the ReduceContract is combinable, false otherwise.
 	 */
 	public boolean isCombinable() {
-		return getUserCodeClass().getAnnotation(Combinable.class) != null;
+		return getUserCodeAnnotation(Combinable.class) != null;
 	}
 	
 	/**

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/SingleInputContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/SingleInputContract.java
@@ -45,8 +45,8 @@ public abstract class SingleInputContract<T extends Stub> extends AbstractPact<T
 	 * @param keyTypes The classes of the data types that act as keys in this stub.
 	 * @param name The given name for the Pact, used in plans, logs and progress messages.
 	 */
-	protected SingleInputContract(Class<? extends T> stubClass, int[] keyPositions, String name) {
-		super(stubClass, name);
+	protected SingleInputContract(UserCodeWrapper<T> stub, int[] keyPositions, String name) {
+		super(stub, name);
 		this.keyFields = keyPositions;
 	}
 	
@@ -57,8 +57,8 @@ public abstract class SingleInputContract<T extends Stub> extends AbstractPact<T
 	 * @param stubClass The class containing the user function.
 	 * @param name The given name for the Pact, used in plans, logs and progress messages.
 	 */
-	protected SingleInputContract(Class<? extends T> stubClass, String name) {
-		super(stubClass, name);
+	protected SingleInputContract(UserCodeWrapper<T> stub, String name) {
+		super(stub, name);
 		this.keyFields = new int[0];
 	}
 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeClassWrapper.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeClassWrapper.java
@@ -1,0 +1,64 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.pact.generic.contract;
+
+import java.lang.annotation.Annotation;
+
+import eu.stratosphere.pact.common.util.InstantiationUtil;
+
+/**
+ * This holds a class containing user defined code.
+ * @author Aljoscha Krettek
+ *
+ */
+public class UserCodeClassWrapper<T> implements UserCodeWrapper<T> {
+	private static final long serialVersionUID = 1L;
+	
+	private Class<? extends T> userCodeClass;
+	private String className;
+	
+	public UserCodeClassWrapper(Class<? extends T> userCodeClass) {
+		this.userCodeClass = userCodeClass;
+		this.className = userCodeClass.getName();
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public T getUserCodeObject(Class<? super T> superClass, ClassLoader cl) {
+		try {
+			Class<T> clazz = (Class<T>) Class.forName(className, true, cl).asSubclass(superClass);
+			return InstantiationUtil.instantiate(clazz, superClass);
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("User code class could not be instantiated: " + e);
+		}
+	}
+	
+	@Override
+	public T getUserCodeObject() {
+		try {
+			return userCodeClass.newInstance();
+		} catch (InstantiationException e) {
+			throw new RuntimeException("User code class could not be instantiated: " + e);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException("User code class could not be instantiated: " + e);
+		}
+	}
+
+	@Override
+	public <A extends Annotation> A getUserCodeAnnotation(
+			Class<A> annotationClass) {
+		return userCodeClass.getAnnotation(annotationClass);
+	}
+}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeObjectWrapper.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeObjectWrapper.java
@@ -1,0 +1,60 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.pact.generic.contract;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+
+import org.apache.commons.lang3.SerializationUtils;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This holds an actual object containing user defined code.
+ * @author Aljoscha Krettek
+ *
+ */
+public class UserCodeObjectWrapper<T> implements UserCodeWrapper<T> {
+	private static final long serialVersionUID = 1L;
+	
+	private T userCodeObject;
+	
+	public UserCodeObjectWrapper(T userCodeObject) {
+		Preconditions.checkArgument(userCodeObject instanceof Serializable, "User code object is not serializable: " + userCodeObject.getClass());
+		this.userCodeObject = userCodeObject;
+	}
+	
+	@Override
+	public T getUserCodeObject(Class<? super T> superClass, ClassLoader cl) {
+		return getUserCodeObject();
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public T getUserCodeObject() {
+		// return a clone because some code retrieves this and runs configure() on it before
+		// the job is actually run. This way we can always hand out a pristine copy.
+		Serializable ser = (Serializable) userCodeObject;
+		T cloned = (T) SerializationUtils.clone(ser);
+		return cloned;
+		
+	}
+
+	@Override
+	public <A extends Annotation> A getUserCodeAnnotation(
+			Class<A> annotationClass) {
+		return userCodeObject.getClass().getAnnotation(annotationClass);
+	}
+}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeWrapper.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeWrapper.java
@@ -1,0 +1,58 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.pact.generic.contract;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+
+/**
+ * PACT contracts can have either a class or an object containing the user
+ * code, this is the common interface to access them.
+ * 
+ * @author Aljoscha Krettek
+ * 
+ */
+public interface UserCodeWrapper<T> extends Serializable {
+	/**
+	 * Gets the user code object. In the case of a pact, that object will be the stub with the user function,
+	 * in the case of an input or output format, it will be the format object.
+	 * 
+	 * The subclass is supposed to just return the user code object or instantiate the class.
+	 * 
+	 * @return The class with the user code.
+	 */
+	public T getUserCodeObject(Class<? super T> superClass, ClassLoader cl);
+	
+	/**
+	 * Gets the user code object. In the case of a pact, that object will be the stub with the user function,
+	 * in the case of an input or output format, it will be the format object.
+	 * 
+	 * The subclass is supposed to just return the user code object or instantiate the class.
+	 * 
+	 * @return The class with the user code.
+	 */
+	public T getUserCodeObject();
+	
+	/**
+	 * Gets an annotation that pertains to the user code class. By default, this method will look for
+	 * annotations statically present on the user code class. However, inheritors may override this
+	 * behavior to provide annotations dynamically.
+	 * 
+	 * @param annotationClass
+	 *        the Class object corresponding to the annotation type
+	 * @return the annotation, or null if no annotation of the requested type was found
+	 */
+	public <A extends Annotation> A getUserCodeAnnotation(Class<A> annotationClass);
+}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/WorksetIteration.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/WorksetIteration.java
@@ -248,11 +248,11 @@ public class WorksetIteration extends DualInputContract<AbstractStub> implements
 	 * Specialized contract to use as a recognizable place-holder for the working set input to the
 	 * step function, when composing the nested data flow.
 	 */
-	public static final class WorksetPlaceHolder extends Contract {
+	public static class WorksetPlaceHolder extends Contract {
 
 		private final WorksetIteration containingIteration;
 
-		private WorksetPlaceHolder(WorksetIteration container) {
+		public WorksetPlaceHolder(WorksetIteration container) {
 			super("Workset Place Holder");
 			this.containingIteration = container;
 		}
@@ -277,11 +277,11 @@ public class WorksetIteration extends DualInputContract<AbstractStub> implements
 	 * Specialized contract to use as a recognizable place-holder for the solution set input to the
 	 * step function, when composing the nested data flow.
 	 */
-	public static final class SolutionSetPlaceHolder extends Contract {
+	public static class SolutionSetPlaceHolder extends Contract {
 
 		private final WorksetIteration containingIteration;
 
-		private SolutionSetPlaceHolder(WorksetIteration container) {
+		public SolutionSetPlaceHolder(WorksetIteration container) {
 			super("Solution Set Place Holder");
 			this.containingIteration = container;
 		}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/WorksetIteration.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/WorksetIteration.java
@@ -63,7 +63,7 @@ public class WorksetIteration extends DualInputContract<AbstractStub> implements
 	}
 	
 	public WorksetIteration(int[] keyPositions, String name) {
-		super(AbstractStub.class, name);
+		super(new UserCodeClassWrapper<AbstractStub>(AbstractStub.class), name);
 		this.solutionSetKeyFields = keyPositions;
 	}
 	
@@ -248,6 +248,7 @@ public class WorksetIteration extends DualInputContract<AbstractStub> implements
 	 * Specialized contract to use as a recognizable place-holder for the working set input to the
 	 * step function, when composing the nested data flow.
 	 */
+	// Integer is only a dummy here but this whole placeholder shtick seems a tad bogus.
 	public static class WorksetPlaceHolder extends Contract {
 
 		private final WorksetIteration containingIteration;
@@ -268,7 +269,7 @@ public class WorksetIteration extends DualInputContract<AbstractStub> implements
 		}
 
 		@Override
-		public Class<?> getUserCodeClass() {
+		public UserCodeWrapper<?> getUserCodeWrapper() {
 			return null;
 		}
 	}
@@ -277,6 +278,7 @@ public class WorksetIteration extends DualInputContract<AbstractStub> implements
 	 * Specialized contract to use as a recognizable place-holder for the solution set input to the
 	 * step function, when composing the nested data flow.
 	 */
+	// Integer is only a dummy here but this whole placeholder shtick seems a tad bogus.
 	public static class SolutionSetPlaceHolder extends Contract {
 
 		private final WorksetIteration containingIteration;
@@ -297,7 +299,7 @@ public class WorksetIteration extends DualInputContract<AbstractStub> implements
 		}
 
 		@Override
-		public Class<?> getUserCodeClass() {
+		public UserCodeWrapper<?> getUserCodeWrapper() {
 			return null;
 		}
 	}

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryInputFormat.java
@@ -43,6 +43,7 @@ import eu.stratosphere.pact.common.io.statistics.BaseStatistics;
  * @author Arvid Heise
  */
 public abstract class BinaryInputFormat<T extends Record> extends FileInputFormat<T> {
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The log.

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryOutputFormat.java
@@ -27,6 +27,7 @@ import eu.stratosphere.nephele.types.Record;
  * @author Arvid Heise
  */
 public abstract class BinaryOutputFormat<T extends Record> extends FileOutputFormat<T> {
+	private static final long serialVersionUID = 1L;
 	
 	/**
 	 * The config parameter which defines the fixed length of a record.

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/DelimitedInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/DelimitedInputFormat.java
@@ -36,6 +36,7 @@ import eu.stratosphere.pact.common.util.PactConfigConstants;
  * Base implementation for delimiter based input formats.
  */
 public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
+	private static final long serialVersionUID = 1L;
 	
 	// -------------------------------------- Constants -------------------------------------------
 	

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FileInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FileInputFormat.java
@@ -69,6 +69,7 @@ import eu.stratosphere.pact.generic.io.InputFormat;
  * </ol>
  */
 public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSplit> {
+	private static final long serialVersionUID = 1L;
 	
 	// -------------------------------------- Constants -------------------------------------------
 	
@@ -488,6 +489,7 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 		if (this.stream != null) {
 			// close input stream
 			this.stream.close();
+			stream = null;
 		}
 	}
 	

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FileOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FileOutputFormat.java
@@ -34,6 +34,7 @@ import eu.stratosphere.pact.generic.io.OutputFormat;
  * file streams.
  */
 public abstract class FileOutputFormat<IT> implements OutputFormat<IT> {
+	private static final long serialVersionUID = 1L;
 	
 	/**
 	 * The LOG for logging messages in this class.

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/GenericInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/GenericInputFormat.java
@@ -26,6 +26,7 @@ import eu.stratosphere.pact.generic.io.InputFormat;
  * Generic base class for all inputs that are not based on files.
  */
 public abstract class GenericInputFormat<OT> implements InputFormat<OT, GenericInputSplit> {
+	private static final long serialVersionUID = 1L;
 	
 	/**
 	 * The partition of this split.

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/InputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/InputFormat.java
@@ -16,6 +16,7 @@
 package eu.stratosphere.pact.generic.io;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import eu.stratosphere.nephele.configuration.Configuration;
 import eu.stratosphere.nephele.template.InputSplit;
@@ -55,7 +56,7 @@ import eu.stratosphere.pact.common.io.statistics.BaseStatistics;
  * @param <OT> The type of the produced records.
  * @param <T> The type of input split.
  */
-public interface InputFormat<OT, T extends InputSplit> {
+public interface InputFormat<OT, T extends InputSplit> extends Serializable {
 	
 	/**
 	 * Configures this input format. Since input formats are instantiated generically and hence parameterless, 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/OutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/OutputFormat.java
@@ -16,6 +16,7 @@
 package eu.stratosphere.pact.generic.io;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import eu.stratosphere.nephele.configuration.Configuration;
 
@@ -36,7 +37,7 @@ import eu.stratosphere.nephele.configuration.Configuration;
  * 
  * @param <IT> The type of the consumed records. 
  */
-public interface OutputFormat<IT> {
+public interface OutputFormat<IT> extends Serializable {
 	
 	/**
 	 * Configures this output format. Since output formats are instantiated generically and hence parameterless, 

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialInputFormat.java
@@ -26,6 +26,7 @@ import eu.stratosphere.nephele.types.Record;
  * @see SequentialOutputFormat
  */
 public class SequentialInputFormat<T extends Record> extends BinaryInputFormat<T> {
+	private static final long serialVersionUID = 1L;
 	/*
 	 * (non-Javadoc)
 	 * @see

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialOutputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/SequentialOutputFormat.java
@@ -27,6 +27,8 @@ import eu.stratosphere.nephele.types.Record;
  * @see SequentialInputFormat
  */
 public class SequentialOutputFormat extends BinaryOutputFormat<Record> {
+	private static final long serialVersionUID = 1L;
+	
 	/*
 	 * (non-Javadoc)
 	 * @see

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/ExternalProcessFixedLengthInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/ExternalProcessFixedLengthInputFormatTest.java
@@ -212,6 +212,7 @@ private ExternalProcessFixedLengthInputFormat<ExternalProcessInputSplit> format;
 	}
 	
 	private final class MyExternalProcessTestInputFormat extends ExternalProcessFixedLengthInputFormat<ExternalProcessInputSplit> {
+		private static final long serialVersionUID = 1L;
 
 		public static final String FAILCOUNT_PARAMETER_KEY = "test.failingCount";
 		

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/ExternalProcessInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/ExternalProcessInputFormatTest.java
@@ -174,6 +174,7 @@ public class ExternalProcessInputFormatTest {
 	}
 	
 	private final class MyExternalProcessTestInputFormat extends ExternalProcessInputFormat<ExternalProcessInputSplit> {
+		private static final long serialVersionUID = 1L;
 
 		public static final String FAILCOUNT_PARAMETER_KEY = "test.failingCount";
 		

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/FixedLenghtInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/common/io/FixedLenghtInputFormatTest.java
@@ -188,6 +188,7 @@ public class FixedLenghtInputFormatTest {
 		
 	
 	private final class MyFixedLengthInputFormat extends FixedLengthInputFormat {
+		private static final long serialVersionUID = 1L;
 
 		PactInteger p1 = new PactInteger();
 		PactInteger p2 = new PactInteger();

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/common/type/base/CollectionsDataTypeTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/common/type/base/CollectionsDataTypeTest.java
@@ -227,17 +227,22 @@ public class CollectionsDataTypeTest {
 	}
 
 	private class NfIntStringPair extends PactPair<PactInteger, PactString> {
+		private static final long serialVersionUID = 1L;
 	}
 
 	private class NfDoubleStringPair extends PactPair<PactDouble, PactString> {
+		private static final long serialVersionUID = 1L;
 	}
 
 	private class NfStringList extends PactList<PactString> {
+		private static final long serialVersionUID = 1L;
 	}
 
 	private class NfIntStringMap extends PactMap<PactInteger, PactString> {
+		private static final long serialVersionUID = 1L;
 	}
 
 	private class NfStringIntMap extends PactMap<PactString, PactInteger> {
+		private static final long serialVersionUID = 1L;
 	}
 }

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/DelimitedInputFormatSamplingTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/DelimitedInputFormatSamplingTest.java
@@ -275,6 +275,7 @@ public class DelimitedInputFormatSamplingTest {
 	// ========================================================================
 	
 	private static final class TestDelimitedInputFormat extends DelimitedInputFormat<PactInteger> {
+		private static final long serialVersionUID = 1L;
 		@Override
 		public boolean readRecord(PactInteger target, byte[] bytes, int offset, int numBytes) {
 			throw new UnsupportedOperationException();

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/DelimitedInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/DelimitedInputFormatTest.java
@@ -168,6 +168,7 @@ public class DelimitedInputFormatTest {
 	}
 	
 	protected static final class MyTextInputFormat extends eu.stratosphere.pact.generic.io.DelimitedInputFormat<PactRecord> {
+		private static final long serialVersionUID = 1L;
 		
 		private final PactString str1 = new PactString();
 		private final PactString str2 = new PactString();

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/FileInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/FileInputFormatTest.java
@@ -163,6 +163,7 @@ public class FileInputFormatTest {
 	// ------------------------------------------------------------------------
 	
 	private class DummyFileInputFormat extends FileInputFormat<PactInteger> {
+		private static final long serialVersionUID = 1L;
 
 		@Override
 		public boolean reachedEnd() throws IOException {

--- a/pact/pact-compiler-tests/src/test/java/eu/stratosphere/pact/compiler/examples/WordCountCompilerTest.java
+++ b/pact/pact-compiler-tests/src/test/java/eu/stratosphere/pact/compiler/examples/WordCountCompilerTest.java
@@ -113,16 +113,16 @@ public class WordCountCompilerTest extends CompilerTestBase {
 	
 	private void checkWordCountWithSortedSink(boolean estimates) {
 		try {
-			FileDataSource sourceNode = new FileDataSource(TextInputFormat.class, IN_FILE, "Input Lines");
-			MapContract mapNode = MapContract.builder(TokenizeLine.class)
+			FileDataSource sourceNode = new FileDataSource(new TextInputFormat(), IN_FILE, "Input Lines");
+			MapContract mapNode = MapContract.builder(new TokenizeLine())
 				.input(sourceNode)
 				.name("Tokenize Lines")
 				.build();
-			ReduceContract reduceNode = new ReduceContract.Builder(CountWords.class, PactString.class, 0)
+			ReduceContract reduceNode = ReduceContract.builder(new CountWords(), PactString.class, 0)
 				.input(mapNode)
 				.name("Count Words")
 				.build();
-			FileDataSink out = new FileDataSink(RecordOutputFormat.class, OUT_FILE, reduceNode, "Word Counts");
+			FileDataSink out = new FileDataSink(new RecordOutputFormat(), OUT_FILE, reduceNode, "Word Counts");
 			RecordOutputFormat.configureRecordFormat(out)
 				.recordDelimiter('\n')
 				.fieldDelimiter(' ')

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/BinaryUnionNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/BinaryUnionNode.java
@@ -33,6 +33,7 @@ import eu.stratosphere.pact.compiler.plan.candidate.Channel;
 import eu.stratosphere.pact.compiler.plan.candidate.PlanNode;
 import eu.stratosphere.pact.generic.contract.Contract;
 import eu.stratosphere.pact.generic.contract.DualInputContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.generic.stub.AbstractStub;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 
@@ -307,7 +308,7 @@ public class BinaryUnionNode extends TwoInputNode {
 	
 	private static final class UnionPlaceholderContract extends DualInputContract<MockStub> {
 		private UnionPlaceholderContract() {
-			super(MockStub.class, "UnionPlaceholderContract");
+			super(new UserCodeClassWrapper<MockStub>(MockStub.class), "UnionPlaceholderContract");
 		}
 	}
 }

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/DataSourceNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/DataSourceNode.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.lang.SerializationUtils;
+
 import eu.stratosphere.pact.common.contract.CompilerHints;
 import eu.stratosphere.pact.common.contract.GenericDataSource;
 import eu.stratosphere.pact.common.io.FileInputFormat;
@@ -119,8 +121,7 @@ public class DataSourceNode extends OptimizerNode {
 			String inFormatDescription = "<unknown>";
 			
 			try {
-				Class<? extends InputFormat<?, ?>> formatClass = getPactContract().getFormatClass();
-				format = formatClass.newInstance();
+				format = getPactContract().getFormatWrapper().getUserCodeObject();
 				format.configure(getPactContract().getParameters());
 			}
 			catch (Throwable t) {
@@ -255,7 +256,7 @@ public class DataSourceNode extends OptimizerNode {
 		candidate.updatePropertiesWithUniqueSets(getUniqueFields());
 		
 		final Costs costs = new Costs();
-		if (FileInputFormat.class.isAssignableFrom(getPactContract().getFormatClass())) {
+		if (FileInputFormat.class.isAssignableFrom(getPactContract().getFormatWrapper().getUserCodeObject().getClass())) {
 			estimator.addFileInputCost(this.inputSize, costs);
 		}
 		candidate.setCosts(costs);

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plantranslate/NepheleJobGraphGenerator.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plantranslate/NepheleJobGraphGenerator.java
@@ -738,7 +738,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 		}
 		
 		// set user code
-		config.setStubClass(node.getPactContract().getUserCodeClass());
+		config.setStubWrapper(node.getPactContract().getUserCodeWrapper());
 		config.setStubParameters(node.getPactContract().getParameters());
 		
 		// set the driver strategy
@@ -760,7 +760,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 		vertex.setTaskClass(this.currentIteration == null ? RegularPactTask.class : IterationIntermediatePactTask.class);
 		
 		// set user code
-		config.setStubClass(node.getPactContract().getUserCodeClass());
+		config.setStubWrapper(node.getPactContract().getUserCodeWrapper());
 		config.setStubParameters(node.getPactContract().getParameters());
 		
 		// set the driver strategy
@@ -791,7 +791,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 		vertex.setInputClass(clazz);
 
 		// set user code
-		config.setStubClass(node.getPactContract().getUserCodeClass());
+		config.setStubWrapper(node.getPactContract().getUserCodeWrapper());
 		config.setStubParameters(node.getPactContract().getParameters());
 		
 		config.setOutputSerializer(node.getSerializer());
@@ -806,7 +806,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 		vertex.getConfiguration().setInteger(DataSinkTask.DEGREE_OF_PARALLELISM_KEY, node.getDegreeOfParallelism());
 		
 		// set user code
-		config.setStubClass(node.getPactContract().getUserCodeClass());
+		config.setStubWrapper(node.getPactContract().getUserCodeWrapper());
 		config.setStubParameters(node.getPactContract().getParameters());
 		
 		return vertex;

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/postpass/GenericArrayRecordPostPass.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/postpass/GenericArrayRecordPostPass.java
@@ -22,7 +22,6 @@ import eu.stratosphere.pact.common.stubs.Stub;
 import eu.stratosphere.pact.common.type.Key;
 import eu.stratosphere.pact.common.type.Value;
 import eu.stratosphere.pact.common.util.FieldList;
-import eu.stratosphere.pact.common.util.InstantiationUtil;
 import eu.stratosphere.pact.compiler.CompilerException;
 import eu.stratosphere.pact.compiler.CompilerPostPassException;
 import eu.stratosphere.pact.compiler.plan.candidate.DualInputPlanNode;
@@ -53,11 +52,10 @@ public class GenericArrayRecordPostPass extends GenericRecordPostPass<Class<? ex
 	@Override
 	protected void getSinkSchema(SinkPlanNode sinkPlanNode, DenseValueSchema schema) throws CompilerPostPassException {
 		GenericDataSink sink = sinkPlanNode.getSinkNode().getPactContract();
-		Class<? extends OutputFormat<?>> format = sink.getFormatClass();
+		OutputFormat<?> format = sink.getFormatWrapper().getUserCodeObject();
 		
-		if (ArrayModelOutputFormat.class.isAssignableFrom(format)) {
-			Class<? extends ArrayModelOutputFormat> formatClass = format.asSubclass(ArrayModelOutputFormat.class);
-			ArrayModelOutputFormat formatInstance = InstantiationUtil.instantiate(formatClass, ArrayModelOutputFormat.class);
+		if (ArrayModelOutputFormat.class.isAssignableFrom(format.getClass())) {
+			ArrayModelOutputFormat formatInstance = (ArrayModelOutputFormat) format;
 			Class<? extends Value>[] types = formatInstance.getDataTypes();
 			
 			try {
@@ -92,10 +90,10 @@ public class GenericArrayRecordPostPass extends GenericRecordPostPass<Class<? ex
 			throws CompilerPostPassException, ConflictingFieldTypeInfoException
 	{
 		SingleInputContract<?> contract = (SingleInputContract<?>) node.getSingleInputNode().getPactContract();
-		Class<? extends Stub> stubClass = contract.getUserCodeClass();
+		Stub stub = contract.getUserCodeWrapper().getUserCodeObject();
 		
-		if (AbstractArrayModelStub.class.isAssignableFrom(stubClass)) {
-			AbstractArrayModelStub ams = (AbstractArrayModelStub) InstantiationUtil.instantiate(stubClass, Stub.class);
+		if (AbstractArrayModelStub.class.isAssignableFrom(stub.getClass())) {
+			AbstractArrayModelStub ams = (AbstractArrayModelStub) stub;
 			Class<? extends Value>[] types = ams.getDataTypes(0);
 			
 			if (types == null) {
@@ -115,10 +113,10 @@ public class GenericArrayRecordPostPass extends GenericRecordPostPass<Class<? ex
 	{
 		// add the nodes local information. this automatically consistency checks
 		DualInputContract<?> contract = node.getTwoInputNode().getPactContract();
-		Class<? extends Stub> stubClass = contract.getUserCodeClass();
+		Stub stub = contract.getUserCodeWrapper().getUserCodeObject();
 		
-		if (AbstractArrayModelStub.class.isAssignableFrom(stubClass)) {
-			AbstractArrayModelStub ams = (AbstractArrayModelStub) InstantiationUtil.instantiate(stubClass, Stub.class);
+		if (AbstractArrayModelStub.class.isAssignableFrom(stub.getClass())) {
+			AbstractArrayModelStub ams = (AbstractArrayModelStub) stub;
 			
 			Class<? extends Value>[] types1 = ams.getDataTypes(0);
 			Class<? extends Value>[] types2 = ams.getDataTypes(1);

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/util/NoContract.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/util/NoContract.java
@@ -15,13 +15,14 @@
 package eu.stratosphere.pact.compiler.util;
 
 import eu.stratosphere.pact.generic.contract.DualInputContract;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.generic.stub.AbstractStub;
 
 
 public class NoContract extends DualInputContract<MockStub> {
 	
 	public NoContract() {
-		super(MockStub.class, "NoContract");
+		super(new UserCodeClassWrapper<MockStub>(MockStub.class), "NoContract");
 	}
 }
 

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/contextcheck/ContextChecker.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/contextcheck/ContextChecker.java
@@ -81,7 +81,7 @@ public class ContextChecker implements Visitor<Contract> {
 			checkDataSink((GenericDataSink) node);
 		} else if (node instanceof BulkIteration) {
 			checkBulkIteration((BulkIteration) node);
-		} else if (node instanceof SingleInputContract<?>) {
+		} else if (node instanceof SingleInputContract) {
 			checkSingleInputContract((SingleInputContract<?>) node);
 		} else if (node instanceof DualInputContract<?>) {
 			checkDualInputContract((DualInputContract<?>) node);

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
@@ -144,58 +144,58 @@ public class BranchingPlansCompilerTest extends CompilerTestBase {
 	public void testBranchingSourceMultipleTimes() {
 		try {
 			// construct the plan
-			FileDataSource sourceA = new FileDataSource(DummyInputFormat.class, IN_FILE);
+			FileDataSource sourceA = new FileDataSource(new DummyInputFormat(), IN_FILE);
 			
-			MatchContract mat1 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat1 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(sourceA)
 				.input2(sourceA)
 				.build();
-			MatchContract mat2 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat2 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(sourceA)
 				.input2(mat1)
 				.build();
-			MatchContract mat3 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat3 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(sourceA)
 				.input2(mat2)
 				.build();
-			MatchContract mat4 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat4 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(sourceA)
 				.input2(mat3)
 				.build();
-			MatchContract mat5 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat5 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(sourceA)
 				.input2(mat4)
 				.build();
 			
-			MapContract ma = MapContract.builder(IdentityMap.class).input(sourceA).build();
+			MapContract ma = MapContract.builder(new IdentityMap()).input(sourceA).build();
 			
-			MatchContract mat6 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat6 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(ma)
 				.input2(ma)
 				.build();
-			MatchContract mat7 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat7 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(ma)
 				.input2(mat6)
 				.build();
-			MatchContract mat8 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat8 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(ma)
 				.input2(mat7)
 				.build();
-			MatchContract mat9 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat9 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(ma)
 				.input2(mat8)
 				.build();
-			MatchContract mat10 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat10 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(ma)
 				.input2(mat9)
 				.build();
 			
-			CoGroupContract co = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0, 0)
+			CoGroupContract co = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0, 0)
 				.input1(mat5)
 				.input2(mat10)
 				.build();
 	
-			FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, co);
+			FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, co);
 			
 			// return the PACT plan
 			Plan plan = new Plan(sink, "Branching Source Multiple Times");
@@ -239,34 +239,34 @@ public class BranchingPlansCompilerTest extends CompilerTestBase {
 			final String out2Path = "file:///test/2";
 			final String out3Path = "file:///test/3";
 	
-			FileDataSource sourceA = new FileDataSource(DummyInputFormat.class, IN_FILE);
-			FileDataSource sourceB = new FileDataSource(DummyInputFormat.class, IN_FILE);
-			FileDataSource sourceC = new FileDataSource(DummyInputFormat.class, IN_FILE);
+			FileDataSource sourceA = new FileDataSource(new DummyInputFormat(), IN_FILE);
+			FileDataSource sourceB = new FileDataSource(new DummyInputFormat(), IN_FILE);
+			FileDataSource sourceC = new FileDataSource(new DummyInputFormat(), IN_FILE);
 			
-			CoGroupContract co = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract co = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(sourceA)
 				.input2(sourceB)
 				.build();
-			MapContract ma = MapContract.builder(IdentityMap.class).input(co).build();
-			MatchContract mat1 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MapContract ma = MapContract.builder(new IdentityMap()).input(co).build();
+			MatchContract mat1 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(sourceB)
 				.input2(sourceC)
 				.build();
-			MatchContract mat2 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat2 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(ma)
 				.input2(mat1)
 				.build();
-			ReduceContract r = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+			ReduceContract r = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 				.input(ma)
 				.build();
-			CrossContract c = CrossContract.builder(DummyCrossStub.class)
+			CrossContract c = CrossContract.builder(new DummyCrossStub())
 				.input1(r)
 				.input2(mat2)
 				.build();
 			
-			FileDataSink sinkA = new FileDataSink(DummyOutputFormat.class, out1Path, c);
-			FileDataSink sinkB = new FileDataSink(DummyOutputFormat.class, out2Path, mat2);
-			FileDataSink sinkC = new FileDataSink(DummyOutputFormat.class, out3Path, mat2);
+			FileDataSink sinkA = new FileDataSink(new DummyOutputFormat(), out1Path, c);
+			FileDataSink sinkB = new FileDataSink(new DummyOutputFormat(), out2Path, mat2);
+			FileDataSink sinkC = new FileDataSink(new DummyOutputFormat(), out3Path, mat2);
 			
 			List<GenericDataSink> sinks = new ArrayList<GenericDataSink>();
 			sinks.add(sinkA);
@@ -308,76 +308,76 @@ public class BranchingPlansCompilerTest extends CompilerTestBase {
 	public void testBranchEachContractType() {
 		try {
 			// construct the plan
-			FileDataSource sourceA = new FileDataSource(DummyInputFormat.class, "file:///test/file1", "Source A");
-			FileDataSource sourceB = new FileDataSource(DummyInputFormat.class, "file:///test/file2", "Source B");
-			FileDataSource sourceC = new FileDataSource(DummyInputFormat.class, "file:///test/file3", "Source C");
+			FileDataSource sourceA = new FileDataSource(new DummyInputFormat(), "file:///test/file1", "Source A");
+			FileDataSource sourceB = new FileDataSource(new DummyInputFormat(), "file:///test/file2", "Source B");
+			FileDataSource sourceC = new FileDataSource(new DummyInputFormat(), "file:///test/file3", "Source C");
 			
-			MapContract map1 = MapContract.builder(IdentityMap.class).input(sourceA).name("Map 1").build();
+			MapContract map1 = MapContract.builder(new IdentityMap()).input(sourceA).name("Map 1").build();
 			
-			ReduceContract reduce1 = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+			ReduceContract reduce1 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 				.input(map1)
 				.name("Reduce 1")
 				.build();
 			
-			MatchContract match1 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract match1 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(sourceB, sourceB, sourceC)
 				.input2(sourceC)
 				.name("Match 1")
 				.build();
 			;
-			CoGroupContract cogroup1 = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract cogroup1 = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(sourceA)
 				.input2(sourceB)
 				.name("CoGroup 1")
 				.build();
 			
-			CrossContract cross1 = CrossContract.builder(DummyCrossStub.class)
+			CrossContract cross1 = CrossContract.builder(new DummyCrossStub())
 				.input1(reduce1)
 				.input2(cogroup1)
 				.name("Cross 1")
 				.build();
 			
 			
-			CoGroupContract cogroup2 = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract cogroup2 = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(cross1)
 				.input2(cross1)
 				.name("CoGroup 2")
 				.build();
 			
-			CoGroupContract cogroup3 = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract cogroup3 = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(map1)
 				.input2(match1)
 				.name("CoGroup 3")
 				.build();
 			
 			
-			MapContract map2 = MapContract.builder(IdentityMap.class).input(cogroup3).name("Map 2").build();
+			MapContract map2 = MapContract.builder(new IdentityMap()).input(cogroup3).name("Map 2").build();
 			
-			CoGroupContract cogroup4 = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract cogroup4 = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(map2)
 				.input2(match1)
 				.name("CoGroup 4")
 				.build();
 			
-			CoGroupContract cogroup5 = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract cogroup5 = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(cogroup2)
 				.input2(cogroup1)
 				.name("CoGroup 5")
 				.build();
 			
-			CoGroupContract cogroup6 = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract cogroup6 = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(reduce1)
 				.input2(cogroup4)
 				.name("CoGroup 6")
 				.build();
 			
-			CoGroupContract cogroup7 = CoGroupContract.builder(DummyCoGroupStub.class, PactInteger.class, 0,0)
+			CoGroupContract cogroup7 = CoGroupContract.builder(new DummyCoGroupStub(), PactInteger.class, 0,0)
 				.input1(cogroup5)
 				.input2(cogroup6)
 				.name("CoGroup 7")
 				.build();
 			
-			FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, cogroup7);
+			FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, cogroup7);
 	//		sink.addInput(sourceA);
 	//		sink.addInput(co3);
 	//		sink.addInput(co4);
@@ -403,39 +403,39 @@ public class BranchingPlansCompilerTest extends CompilerTestBase {
 	public void testBranchingUnion() {
 		try {
 			// construct the plan
-			FileDataSource source1 = new FileDataSource(DummyInputFormat.class, IN_FILE);
-			FileDataSource source2 = new FileDataSource(DummyInputFormat.class, IN_FILE);
+			FileDataSource source1 = new FileDataSource(new DummyInputFormat(), IN_FILE);
+			FileDataSource source2 = new FileDataSource(new DummyInputFormat(), IN_FILE);
 			
-			MatchContract mat1 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat1 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(source1)
 				.input2(source2)
 				.name("Match 1")
 				.build();
 			
-			MapContract ma1 = MapContract.builder(IdentityMap.class).input(mat1).name("Map1").build();
+			MapContract ma1 = MapContract.builder(new IdentityMap()).input(mat1).name("Map1").build();
 			
-			ReduceContract r1 = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+			ReduceContract r1 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 				.input(ma1)
 				.name("Reduce 1")
 				.build();
 			
-			ReduceContract r2 = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+			ReduceContract r2 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 				.input(mat1)
 				.name("Reduce 2")
 				.build();
 			
-			MapContract ma2 = MapContract.builder(IdentityMap.class).input(mat1).name("Map 2").build();
+			MapContract ma2 = MapContract.builder(new IdentityMap()).input(mat1).name("Map 2").build();
 			
-			MapContract ma3 = MapContract.builder(IdentityMap.class).input(ma2).name("Map 3").build();
+			MapContract ma3 = MapContract.builder(new IdentityMap()).input(ma2).name("Map 3").build();
 			
-			MatchContract mat2 = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+			MatchContract mat2 = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 				.input1(r1, r2, ma2, ma3)
 				.input2(ma2)
 				.name("Match 2")
 				.build();
 			mat2.setParameter(PactCompiler.HINT_LOCAL_STRATEGY, PactCompiler.HINT_LOCAL_STRATEGY_MERGE);
 			
-			FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, mat2);
+			FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, mat2);
 			
 			
 			// return the PACT plan

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/DOPChangeTest.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/DOPChangeTest.java
@@ -63,26 +63,26 @@ public class DOPChangeTest extends CompilerTestBase {
 		final int degOfPar = DEFAULT_PARALLELISM;
 		
 		// construct the plan
-		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
+		FileDataSource source = new FileDataSource(new DummyInputFormat(), IN_FILE, "Source");
 		source.setDegreeOfParallelism(degOfPar);
 		
-		MapContract map1 = MapContract.builder(IdentityMap.class).name("Map1").build();
+		MapContract map1 = MapContract.builder(new IdentityMap()).name("Map1").build();
 		map1.setDegreeOfParallelism(degOfPar);
 		map1.setInput(source);
 		
-		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 1").build();
+		ReduceContract reduce1 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 1").build();
 		reduce1.setDegreeOfParallelism(degOfPar);
 		reduce1.setInput(map1);
 		
-		MapContract map2 = MapContract.builder(IdentityMap.class).name("Map2").build();
+		MapContract map2 = MapContract.builder(new IdentityMap()).name("Map2").build();
 		map2.setDegreeOfParallelism(degOfPar * 2);
 		map2.setInput(reduce1);
 		
-		ReduceContract reduce2 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 2").build();
+		ReduceContract reduce2 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 2").build();
 		reduce2.setDegreeOfParallelism(degOfPar * 2);
 		reduce2.setInput(map2);
 		
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, "Sink");
 		sink.setDegreeOfParallelism(degOfPar * 2);
 		sink.setInput(reduce2);
 		
@@ -117,26 +117,26 @@ public class DOPChangeTest extends CompilerTestBase {
 		final int degOfPar = DEFAULT_PARALLELISM;
 		
 		// construct the plan
-		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
+		FileDataSource source = new FileDataSource(new DummyInputFormat(), IN_FILE, "Source");
 		source.setDegreeOfParallelism(degOfPar);
 		
-		MapContract map1 = MapContract.builder(IdentityMap.class).name("Map1").build();
+		MapContract map1 = MapContract.builder(new IdentityMap()).name("Map1").build();
 		map1.setDegreeOfParallelism(degOfPar);
 		map1.setInput(source);
 		
-		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 1").build();
+		ReduceContract reduce1 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 1").build();
 		reduce1.setDegreeOfParallelism(degOfPar);
 		reduce1.setInput(map1);
 		
-		MapContract map2 = MapContract.builder(IdentityMap.class).name("Map2").build();
+		MapContract map2 = MapContract.builder(new IdentityMap()).name("Map2").build();
 		map2.setDegreeOfParallelism(degOfPar);
 		map2.setInput(reduce1);
 		
-		ReduceContract reduce2 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 2").build();
+		ReduceContract reduce2 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 2").build();
 		reduce2.setDegreeOfParallelism(degOfPar * 2);
 		reduce2.setInput(map2);
 		
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, "Sink");
 		sink.setDegreeOfParallelism(degOfPar * 2);
 		sink.setInput(reduce2);
 		
@@ -171,26 +171,26 @@ public class DOPChangeTest extends CompilerTestBase {
 		final int degOfPar = 2 * DEFAULT_PARALLELISM;
 		
 		// construct the plan
-		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
+		FileDataSource source = new FileDataSource(new DummyInputFormat(), IN_FILE, "Source");
 		source.setDegreeOfParallelism(degOfPar);
 		
-		MapContract map1 = MapContract.builder(IdentityMap.class).name("Map1").build();
+		MapContract map1 = MapContract.builder(new IdentityMap()).name("Map1").build();
 		map1.setDegreeOfParallelism(degOfPar);
 		map1.setInput(source);
 		
-		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 1").build();
+		ReduceContract reduce1 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 1").build();
 		reduce1.setDegreeOfParallelism(degOfPar);
 		reduce1.setInput(map1);
 		
-		MapContract map2 = MapContract.builder(IdentityMap.class).name("Map2").build();
+		MapContract map2 = MapContract.builder(new IdentityMap()).name("Map2").build();
 		map2.setDegreeOfParallelism(degOfPar * 2);
 		map2.setInput(reduce1);
 		
-		ReduceContract reduce2 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 2").build();
+		ReduceContract reduce2 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 2").build();
 		reduce2.setDegreeOfParallelism(degOfPar * 2);
 		reduce2.setInput(map2);
 		
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, "Sink");
 		sink.setDegreeOfParallelism(degOfPar * 2);
 		sink.setInput(reduce2);
 		
@@ -222,26 +222,26 @@ public class DOPChangeTest extends CompilerTestBase {
 		final int degOfPar = DEFAULT_PARALLELISM;
 		
 		// construct the plan
-		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
+		FileDataSource source = new FileDataSource(new DummyInputFormat(), IN_FILE, "Source");
 		source.setDegreeOfParallelism(degOfPar * 2);
 		
-		MapContract map1 = MapContract.builder(IdentityMap.class).name("Map1").build();
+		MapContract map1 = MapContract.builder(new IdentityMap()).name("Map1").build();
 		map1.setDegreeOfParallelism(degOfPar * 2);
 		map1.setInput(source);
 		
-		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 1").build();
+		ReduceContract reduce1 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 1").build();
 		reduce1.setDegreeOfParallelism(degOfPar * 2);
 		reduce1.setInput(map1);
 		
-		MapContract map2 = MapContract.builder(IdentityMap.class).name("Map2").build();
+		MapContract map2 = MapContract.builder(new IdentityMap()).name("Map2").build();
 		map2.setDegreeOfParallelism(degOfPar);
 		map2.setInput(reduce1);
 		
-		ReduceContract reduce2 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce 2").build();
+		ReduceContract reduce2 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce 2").build();
 		reduce2.setDegreeOfParallelism(degOfPar);
 		reduce2.setInput(map2);
 		
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, "Sink");
 		sink.setDegreeOfParallelism(degOfPar);
 		sink.setInput(reduce2);
 		
@@ -277,22 +277,22 @@ public class DOPChangeTest extends CompilerTestBase {
 	public void checkPropertyHandlingWithTwoInputs() {
 		// construct the plan
 
-		FileDataSource sourceA = new FileDataSource(DummyInputFormat.class, IN_FILE);
-		FileDataSource sourceB = new FileDataSource(DummyInputFormat.class, IN_FILE);
+		FileDataSource sourceA = new FileDataSource(new DummyInputFormat(), IN_FILE);
+		FileDataSource sourceB = new FileDataSource(new DummyInputFormat(), IN_FILE);
 		
-		ReduceContract redA = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+		ReduceContract redA = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 			.input(sourceA)
 			.build();
-		ReduceContract redB = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+		ReduceContract redB = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 			.input(sourceB)
 			.build();
 		
-		MatchContract mat = MatchContract.builder(DummyMatchStub.class, PactInteger.class, 0, 0)
+		MatchContract mat = MatchContract.builder(new DummyMatchStub(), PactInteger.class, 0, 0)
 			.input1(redA)
 			.input2(redB)
 			.build();
 		
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, mat);
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, mat);
 		
 		sourceA.setDegreeOfParallelism(5);
 		sourceB.setDegreeOfParallelism(7);

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/HardPlansCompilationTest.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/HardPlansCompilationTest.java
@@ -51,21 +51,21 @@ public class HardPlansCompilationTest extends CompilerTestBase
 	@Test
 	public void testTicket158() {
 		// construct the plan
-		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
+		FileDataSource source = new FileDataSource(new DummyInputFormat(), IN_FILE, "Source");
 		
-		MapContract map = MapContract.builder(IdentityMap.class).name("Map1").input(source).build();
+		MapContract map = MapContract.builder(new IdentityMap()).name("Map1").input(source).build();
 		
-		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce1").input(map).build();
+		ReduceContract reduce1 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce1").input(map).build();
 		
-		CrossContract cross1 = CrossContract.builder(DummyCrossStub.class).name("Cross1").input1(reduce1).input2(source).build();
+		CrossContract cross1 = CrossContract.builder(new DummyCrossStub()).name("Cross1").input1(reduce1).input2(source).build();
 		
-		ReduceContract reduce2 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce2").input(cross1).build();
+		ReduceContract reduce2 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce2").input(cross1).build();
 		
-		CrossContract cross2 = CrossContract.builder(DummyCrossStub.class).name("Cross2").input1(reduce2).input2(source).build();
+		CrossContract cross2 = CrossContract.builder(new DummyCrossStub()).name("Cross2").input1(reduce2).input2(source).build();
 		
-		ReduceContract reduce3 = ReduceContract.builder(IdentityReduce.class, PactInteger.class, 0).name("Reduce3").input(cross2).build();
+		ReduceContract reduce3 = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).name("Reduce3").input(cross2).build();
 		
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, "Sink");
 		sink.setInput(reduce3);
 		
 		Plan plan = new Plan(sink, "Test Temp Task");

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/ReduceAllTest.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/ReduceAllTest.java
@@ -39,9 +39,9 @@ public class ReduceAllTest extends CompilerTestBase  {
 	@Test
 	public void testReduce() {
 		// construct the plan
-		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
-		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class).name("Reduce1").input(source).build();
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		FileDataSource source = new FileDataSource(new DummyInputFormat(), IN_FILE, "Source");
+		ReduceContract reduce1 = ReduceContract.builder(new IdentityReduce()).name("Reduce1").input(source).build();
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, "Sink");
 		sink.setInput(reduce1);
 		Plan plan = new Plan(sink, "Test Temp Task");
 		plan.setDefaultParallelism(DEFAULT_PARALLELISM);

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/UnionPropertyPropagationTest.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/UnionPropertyPropagationTest.java
@@ -44,21 +44,21 @@ public class UnionPropertyPropagationTest extends CompilerTestBase {
 	public void testUnionPropertyPropagation() {
 		// construct the plan
 
-		FileDataSource sourceA = new FileDataSource(DummyInputFormat.class, IN_FILE);
-		FileDataSource sourceB = new FileDataSource(DummyInputFormat.class, IN_FILE);
+		FileDataSource sourceA = new FileDataSource(new DummyInputFormat(), IN_FILE);
+		FileDataSource sourceB = new FileDataSource(new DummyInputFormat(), IN_FILE);
 		
-		ReduceContract redA = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+		ReduceContract redA = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 			.input(sourceA)
 			.build();
-		ReduceContract redB = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0)
+		ReduceContract redB = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0)
 			.input(sourceB)
 			.build();
 		
-		ReduceContract globalRed = new ReduceContract.Builder(IdentityReduce.class, PactInteger.class, 0).build();
+		ReduceContract globalRed = ReduceContract.builder(new IdentityReduce(), PactInteger.class, 0).build();
 		globalRed.addInput(redA);
 		globalRed.addInput(redB);
 		
-		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, globalRed);
+		FileDataSink sink = new FileDataSink(new DummyOutputFormat(), OUT_FILE, globalRed);
 		
 		// return the PACT plan
 		Plan plan = new Plan(sink, "Union Property Propagation");

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyCoGroupStub.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyCoGroupStub.java
@@ -15,13 +15,15 @@
 
 package eu.stratosphere.pact.compiler.util;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import eu.stratosphere.pact.common.stubs.CoGroupStub;
 import eu.stratosphere.pact.common.stubs.Collector;
 import eu.stratosphere.pact.common.type.PactRecord;
 
-public class DummyCoGroupStub extends CoGroupStub {
+public class DummyCoGroupStub extends CoGroupStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public void coGroup(Iterator<PactRecord> records1, Iterator<PactRecord> records2, Collector<PactRecord> out) {

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyCrossStub.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyCrossStub.java
@@ -15,11 +15,14 @@
 
 package eu.stratosphere.pact.compiler.util;
 
+import java.io.Serializable;
+
 import eu.stratosphere.pact.common.stubs.Collector;
 import eu.stratosphere.pact.common.stubs.CrossStub;
 import eu.stratosphere.pact.common.type.PactRecord;
 
-public class DummyCrossStub extends CrossStub {
+public class DummyCrossStub extends CrossStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	/* (non-Javadoc)
 	 * @see eu.stratosphere.pact.common.stubs.CrossStub#cross(eu.stratosphere.pact.common.type.PactRecord, eu.stratosphere.pact.common.type.PactRecord, eu.stratosphere.pact.common.stubs.Collector)

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyInputFormat.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyInputFormat.java
@@ -20,8 +20,9 @@ import eu.stratosphere.pact.common.io.statistics.BaseStatistics;
 import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactInteger;
 
-public final class DummyInputFormat extends DelimitedInputFormat
-{
+public final class DummyInputFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
+	
 	private final PactInteger integer = new PactInteger(1);
 
 	/* (non-Javadoc)

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyMatchStub.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyMatchStub.java
@@ -15,13 +15,16 @@
 
 package eu.stratosphere.pact.compiler.util;
 
+import java.io.Serializable;
+
 import eu.stratosphere.pact.common.stubs.Collector;
 import eu.stratosphere.pact.common.stubs.MatchStub;
 import eu.stratosphere.pact.common.stubs.StubAnnotation.ConstantFieldsFirstExcept;
 import eu.stratosphere.pact.common.type.PactRecord;
 
 @ConstantFieldsFirstExcept({})
-public class DummyMatchStub extends MatchStub {
+public class DummyMatchStub extends MatchStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public void match(PactRecord value1, PactRecord value2, Collector<PactRecord> out) throws Exception {

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyOutputFormat.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/DummyOutputFormat.java
@@ -20,8 +20,9 @@ import eu.stratosphere.pact.common.io.DelimitedOutputFormat;
 import eu.stratosphere.pact.common.type.PactRecord;
 
 
-public final class DummyOutputFormat extends DelimitedOutputFormat
-{	
+public final class DummyOutputFormat extends DelimitedOutputFormat {
+	private static final long serialVersionUID = 1L;
+	
 	/* (non-Javadoc)
 	 * @see eu.stratosphere.pact.common.io.DelimitedOutputFormat#serializeRecord(eu.stratosphere.pact.common.type.PactRecord, byte[])
 	 */

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/IdentityMap.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/IdentityMap.java
@@ -15,13 +15,16 @@
 
 package eu.stratosphere.pact.compiler.util;
 
+import java.io.Serializable;
+
 import eu.stratosphere.pact.common.stubs.Collector;
 import eu.stratosphere.pact.common.stubs.MapStub;
 import eu.stratosphere.pact.common.stubs.StubAnnotation.ConstantFieldsExcept;
 import eu.stratosphere.pact.common.type.PactRecord;
 
 @ConstantFieldsExcept({})
-public final class IdentityMap extends MapStub {
+public final class IdentityMap extends MapStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 	
 	@Override
 	public void map(PactRecord record, Collector<PactRecord> out) throws Exception {

--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/IdentityReduce.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/util/IdentityReduce.java
@@ -15,6 +15,7 @@
 
 package eu.stratosphere.pact.compiler.util;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import eu.stratosphere.pact.common.stubs.Collector;
@@ -23,7 +24,8 @@ import eu.stratosphere.pact.common.stubs.StubAnnotation.ConstantFieldsExcept;
 import eu.stratosphere.pact.common.type.PactRecord;
 
 @ConstantFieldsExcept({})
-public final class IdentityReduce extends ReduceStub {
+public final class IdentityReduce extends ReduceStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 	
 	@Override
 	public void reduce(Iterator<PactRecord> records, Collector<PactRecord> out) throws Exception {

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/connectedcomponents/DuplicateLongInputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/connectedcomponents/DuplicateLongInputFormat.java
@@ -21,6 +21,7 @@ import eu.stratosphere.pact.common.type.base.PactLong;
 import eu.stratosphere.pact.common.type.base.parser.DecimalTextLongParser;
 
 public class DuplicateLongInputFormat extends TextInputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	private final PactLong l1 = new PactLong();
 	private final PactLong l2 = new PactLong();

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/connectedcomponents/LongLongInputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/connectedcomponents/LongLongInputFormat.java
@@ -22,6 +22,7 @@ import eu.stratosphere.pact.common.type.base.PactLong;
 import java.util.regex.Pattern;
 
 public class LongLongInputFormat extends TextInputFormat {
+	private static final long serialVersionUID = 1L;
 
 	private static final Pattern SEPARATOR = Pattern.compile("[,\t ]");
 	

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/hbase/HBaseReadExample.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/hbase/HBaseReadExample.java
@@ -101,10 +101,10 @@ public class HBaseReadExample implements PlanAssembler, PlanAssemblerDescription
 		int numSubTasks   = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
 		String output    = (args.length > 1 ? args[1] : "");
 
-		GenericDataSource<TableInputFormat> source = new GenericDataSource<TableInputFormat>(MyTableInputFormat.class, "HBase Input");
+		GenericDataSource<TableInputFormat> source = new GenericDataSource<TableInputFormat>(new MyTableInputFormat(), "HBase Input");
 		source.setParameter(TableInputFormat.INPUT_TABLE, "twitter");
 		source.setParameter(TableInputFormat.CONFIG_LOCATION, "/etc/hbase/conf/hbase-site.xml");
-		FileDataSink out = new FileDataSink(RecordOutputFormat.class, output, source, "HBase String dump");
+		FileDataSink out = new FileDataSink(new RecordOutputFormat(), output, source, "HBase String dump");
 		RecordOutputFormat.configureRecordFormat(out)
 			.recordDelimiter('\n')
 			.fieldDelimiter(' ')

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/ComputeDistance.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/ComputeDistance.java
@@ -14,6 +14,8 @@
  **********************************************************************************************************************/
 package eu.stratosphere.pact.example.kmeans.udfs;
 
+import java.io.Serializable;
+
 import eu.stratosphere.pact.common.stubs.Collector;
 import eu.stratosphere.pact.common.stubs.CrossStub;
 import eu.stratosphere.pact.common.stubs.StubAnnotation.ConstantFieldsFirst;
@@ -26,7 +28,8 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  * centers.
  */
 @ConstantFieldsFirst({0,1})
-public class ComputeDistance extends	CrossStub {
+public class ComputeDistance extends CrossStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 	
 	private final PactDouble distance = new PactDouble();
 	

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/CoordVector.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/CoordVector.java
@@ -26,6 +26,7 @@ import eu.stratosphere.pact.common.type.Key;
  * the Euclidian distance between the points.
  */
 public final class CoordVector implements Key {
+	private static final long serialVersionUID = 1L;
 	
 	// coordinate array
 	private double[] coordinates;

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/FindNearestCenter.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/FindNearestCenter.java
@@ -14,6 +14,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.pact.example.kmeans.udfs;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import eu.stratosphere.pact.common.contract.ReduceContract.Combinable;
@@ -30,7 +31,8 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  */
 @Combinable
 @ConstantFields(1)
-public class FindNearestCenter extends ReduceStub {
+public class FindNearestCenter extends ReduceStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 	
 	private final PactInteger centerId = new PactInteger();
 	private final CoordVector position = new CoordVector();

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/PointInFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/PointInFormat.java
@@ -32,6 +32,7 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  * "42|23.23|52.57|74.43| Id: 42 Coordinate vector: (23.23, 52.57, 74.43)
  */
 public class PointInFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	private final PactInteger idInteger = new PactInteger();
 	private final CoordVector point = new CoordVector();

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/PointOutFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/PointOutFormat.java
@@ -32,6 +32,7 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  * "42|23.23|52.57|74.43| Id: 42 Coordinate vector: (23.23, 52.57, 74.43)
  */
 public class PointOutFormat extends DelimitedOutputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	private final DecimalFormat df = new DecimalFormat("####0.00");
 	private final StringBuilder line = new StringBuilder();

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/RecomputeClusterCenter.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/kmeans/udfs/RecomputeClusterCenter.java
@@ -14,6 +14,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.pact.example.kmeans.udfs;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import eu.stratosphere.pact.common.contract.ReduceContract.Combinable;
@@ -34,7 +35,8 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  */
 @Combinable
 @ConstantFields(0)
-public class RecomputeClusterCenter extends ReduceStub {
+public class RecomputeClusterCenter extends ReduceStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 	
 	private final PactInteger count = new PactInteger();
 	

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/AsciiLongArrayView.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/AsciiLongArrayView.java
@@ -15,9 +15,12 @@
 
 package eu.stratosphere.pact.example.pagerank;
 
+import java.io.Serializable;
+
 import com.google.common.base.Charsets;
 
-public class AsciiLongArrayView {
+public class AsciiLongArrayView implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private byte[] buffer;
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DanglingPageRank.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DanglingPageRank.java
@@ -49,23 +49,23 @@ public class DanglingPageRank implements PlanAssembler, PlanAssemblerDescription
 			numDanglingVertices = Long.parseLong(args[6]);
 		}
 		
-		FileDataSource pageWithRankInput = new FileDataSource(DanglingPageRankInputFormat.class,
+		FileDataSource pageWithRankInput = new FileDataSource(new DanglingPageRankInputFormat(),
 			pageWithRankInputPath, "DanglingPageWithRankInput");
 		pageWithRankInput.getParameters().setLong(DanglingPageRankInputFormat.NUM_VERTICES_PARAMETER, numVertices);
 		
 		BulkIteration iteration = new BulkIteration("Page Rank Loop");
 		iteration.setInput(pageWithRankInput);
 		
-		FileDataSource adjacencyListInput = new FileDataSource(ImprovedAdjacencyListInputFormat.class,
+		FileDataSource adjacencyListInput = new FileDataSource(new ImprovedAdjacencyListInputFormat(),
 			adjacencyListInputPath, "AdjancencyListInput");
 		
-		MatchContract join = MatchContract.builder(DotProductMatch.class, PactLong.class, 0, 0)
+		MatchContract join = MatchContract.builder(new DotProductMatch(), PactLong.class, 0, 0)
 				.input1(iteration.getPartialSolution())
 				.input2(adjacencyListInput)
 				.name("Join with Edges")
 				.build();
 		
-		CoGroupContract rankAggregation = CoGroupContract.builder(DotProductCoGroup.class, PactLong.class, 0, 0)
+		CoGroupContract rankAggregation = CoGroupContract.builder(new DotProductCoGroup(), PactLong.class, 0, 0)
 				.input1(iteration.getPartialSolution())
 				.input2(join)
 				.name("Rank Aggregation")
@@ -77,7 +77,7 @@ public class DanglingPageRank implements PlanAssembler, PlanAssemblerDescription
 		iteration.setMaximumNumberOfIterations(numIterations);
 		iteration.getAggregators().registerAggregationConvergenceCriterion(DotProductCoGroup.AGGREGATOR_NAME, PageRankStatsAggregator.class, DiffL1NormConvergenceCriterion.class);
 		
-		FileDataSink out = new FileDataSink(PageWithRankOutFormat.class, outputPath, iteration, "Final Ranks");
+		FileDataSink out = new FileDataSink(new PageWithRankOutFormat(), outputPath, iteration, "Final Ranks");
 
 		Plan p = new Plan(out, "Dangling PageRank");
 		p.setDefaultParallelism(dop);

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DanglingPageRankInputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DanglingPageRankInputFormat.java
@@ -9,6 +9,7 @@ import eu.stratosphere.pact.common.type.base.PactLong;
 import eu.stratosphere.pact.example.util.ConfigUtils;
 
 public class DanglingPageRankInputFormat extends TextInputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	public static final String NUM_VERTICES_PARAMETER = "pageRank.numVertices";
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DotProductCoGroup.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DotProductCoGroup.java
@@ -10,6 +10,7 @@ import eu.stratosphere.pact.common.type.base.PactDouble;
 import eu.stratosphere.pact.common.type.base.PactLong;
 import eu.stratosphere.pact.example.util.ConfigUtils;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 /**
@@ -18,7 +19,8 @@ import java.util.Iterator;
  * OUTPUT = (pageId, newRank, dangling)
  */
 @ConstantFieldsFirst(0)
-public class DotProductCoGroup extends CoGroupStub {
+public class DotProductCoGroup extends CoGroupStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 	
 	public static final String NUM_VERTICES_PARAMETER = "pageRank.numVertices";
 	

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DotProductMatch.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/DotProductMatch.java
@@ -15,6 +15,8 @@
 
 package eu.stratosphere.pact.example.pagerank;
 
+import java.io.Serializable;
+
 import eu.stratosphere.pact.common.stubs.Collector;
 import eu.stratosphere.pact.common.stubs.MatchStub;
 import eu.stratosphere.pact.common.type.PactRecord;
@@ -26,7 +28,8 @@ import eu.stratosphere.pact.common.type.base.PactLong;
  * INPUT = (pageId, rank, dangling), (pageId, neighbors-list).
  * OUTPUT = (targetPageId, partialRank)
  */
-public class DotProductMatch extends MatchStub {
+public class DotProductMatch extends MatchStub implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private PactRecord record = new PactRecord();
 	private PactLong vertexID = new PactLong();

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/ImprovedAdjacencyListInputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/ImprovedAdjacencyListInputFormat.java
@@ -5,6 +5,7 @@ import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactLong;
 
 public class ImprovedAdjacencyListInputFormat extends TextInputFormat {
+	private static final long serialVersionUID = 1L;
 
 	private final PactLong vertexID = new PactLong();
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/LongArrayView.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/LongArrayView.java
@@ -7,6 +7,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class LongArrayView implements Value {
+	private static final long serialVersionUID = 1L;
 
 	private long[] entries = new long[0];
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/PageRankStats.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/PageRankStats.java
@@ -7,6 +7,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class PageRankStats implements Value {
+	private static final long serialVersionUID = 1L;
 
 	private double diff;
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/PageWithRankOutFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/pagerank/PageWithRankOutFormat.java
@@ -21,6 +21,7 @@ import eu.stratosphere.pact.common.type.base.PactDouble;
 import eu.stratosphere.pact.common.type.base.PactLong;
 
 public class PageWithRankOutFormat extends DelimitedOutputFormat {
+	private static final long serialVersionUID = 1L;
 
 	private final StringBuilder buffer = new StringBuilder();
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/ReduceGroupSort.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/ReduceGroupSort.java
@@ -15,6 +15,7 @@
 
 package eu.stratosphere.pact.example.sort;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import eu.stratosphere.pact.common.contract.FileDataSink;
@@ -51,7 +52,8 @@ public class ReduceGroupSort implements PlanAssembler, PlanAssemblerDescription 
 	 *
 	 */
 	@ConstantFieldsExcept(0)
-	public static class IdentityReducer extends ReduceStub {
+	public static class IdentityReducer extends ReduceStub implements Serializable {
+		private static final long serialVersionUID = 1L;
 		
 		@Override
 		public void reduce(Iterator<PactRecord> records, Collector<PactRecord> out) {
@@ -83,7 +85,7 @@ public class ReduceGroupSort implements PlanAssembler, PlanAssemblerDescription 
 		String dataInput = (args.length > 1 ? args[1] : "");
 		String output = (args.length > 2 ? args[2] : "");
 
-		FileDataSource input = new FileDataSource(RecordInputFormat.class, dataInput, "Input");
+		FileDataSource input = new FileDataSource(new RecordInputFormat(), dataInput, "Input");
 		RecordInputFormat.configureRecordFormat(input)
 			.recordDelimiter('\n')
 			.fieldDelimiter(' ')
@@ -91,7 +93,7 @@ public class ReduceGroupSort implements PlanAssembler, PlanAssemblerDescription 
 			.field(DecimalTextIntParser.class, 1);
 		
 		// create the reduce contract and sets the key to the first field
-		ReduceContract sorter = new ReduceContract.Builder(IdentityReducer.class, PactInteger.class, 0)
+		ReduceContract sorter = ReduceContract.builder(new IdentityReducer(), PactInteger.class, 0)
 			.input(input)
 			.name("Reducer")
 			.build();
@@ -99,7 +101,7 @@ public class ReduceGroupSort implements PlanAssembler, PlanAssemblerDescription 
 		sorter.setGroupOrder(new Ordering(1, PactInteger.class, Order.ASCENDING));
 
 		// create and configure the output format
-		FileDataSink out = new FileDataSink(RecordOutputFormat.class, output, sorter, "Sorted Output");
+		FileDataSink out = new FileDataSink(new RecordOutputFormat(), output, sorter, "Sorted Output");
 		RecordOutputFormat.configureRecordFormat(out)
 			.recordDelimiter('\n')
 			.fieldDelimiter(' ')

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/TeraSort.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/TeraSort.java
@@ -63,12 +63,12 @@ public final class TeraSort implements PlanAssembler, PlanAssemblerDescription {
 
 		// This task will read the input data and generate the key/value pairs
 		final FileDataSource source = 
-				new FileDataSource(TeraInputFormat.class, input, "Data Source");
+				new FileDataSource(new TeraInputFormat(), input, "Data Source");
 		source.setDegreeOfParallelism(numSubTasks);
 
 		// This task writes the sorted data back to disk
 		final FileDataSink sink = 
-				new FileDataSink(TeraOutputFormat.class, output, "Data Sink");
+				new FileDataSink(new TeraOutputFormat(), output, "Data Sink");
 		sink.setDegreeOfParallelism(numSubTasks);
 		sink.setGlobalOrder(new Ordering(0, TeraKey.class, Order.ASCENDING), new TeraDistribution());
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraInputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraInputFormat.java
@@ -22,8 +22,9 @@ import eu.stratosphere.pact.common.type.PactRecord;
  * This class is responsible for converting a line from the input file to a two field record. 
  * Lines which do not match the expected length are skipped.
  */
-public final class TeraInputFormat extends DelimitedInputFormat
-{
+public final class TeraInputFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
+	
 	private final TeraKey key = new TeraKey();
 	private final TeraValue value = new TeraValue();
 	

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraKey.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraKey.java
@@ -31,6 +31,7 @@ import eu.stratosphere.pact.common.type.Key;
  * @author warneke
  */
 public final class TeraKey implements Key {
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The size of the key in bytes.

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraOutputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraOutputFormat.java
@@ -28,6 +28,7 @@ import eu.stratosphere.pact.common.type.PactRecord;
  * @author warneke
  */
 public final class TeraOutputFormat extends FileOutputFormat {
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * A buffer to store the line which is about to be written back to disk.

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraValue.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/terasort/TeraValue.java
@@ -29,6 +29,7 @@ import eu.stratosphere.pact.common.type.Value;
  * This class is a wrapper for the value part of the integer number.
  */
 public final class TeraValue implements Value {
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The size of the value in bytes.

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/EdgeInputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/EdgeInputFormat.java
@@ -25,6 +25,7 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  * 
  */
 public final class EdgeInputFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	public static final String ID_DELIMITER_CHAR = "edgeinput.delimiter";
 	

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/EdgeWithDegreesInputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/EdgeWithDegreesInputFormat.java
@@ -33,6 +33,7 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  * the vertical bar (<code>|</code>).
  */
 public final class EdgeWithDegreesInputFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	public static final String VERTEX_DELIMITER_CHAR = "edgeinput.vertexdelimiter";
 	public static final String DEGREE_DELIMITER_CHAR = "edgeinput.degreedelimiter";

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/EdgeWithDegreesOutputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/EdgeWithDegreesOutputFormat.java
@@ -24,6 +24,7 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  * 
  */
 public final class EdgeWithDegreesOutputFormat extends DelimitedOutputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	private final StringBuilder line = new StringBuilder();
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/TriangleOutputFormat.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/triangles/io/TriangleOutputFormat.java
@@ -24,6 +24,7 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
  * 
  */
 public final class TriangleOutputFormat extends DelimitedOutputFormat {
+	private static final long serialVersionUID = 1L;
 	
 	private final StringBuilder line = new StringBuilder();
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/util/AsciiUtils.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/util/AsciiUtils.java
@@ -15,6 +15,8 @@
 
 package eu.stratosphere.pact.example.util;
 
+import java.io.Serializable;
+
 import eu.stratosphere.pact.common.type.base.PactString;
 import eu.stratosphere.pact.common.util.MutableObjectIterator;
 
@@ -71,7 +73,8 @@ public final class AsciiUtils {
 	 * The tokenizer is designed to have a resettable state and operate on mutable objects,
 	 * sparing object allocation and garbage collection overhead.
 	 */
-	public static final class WhitespaceTokenizer implements MutableObjectIterator<PactString> {
+	public static final class WhitespaceTokenizer implements MutableObjectIterator<PactString>, Serializable {
+		private static final long serialVersionUID = 1L;
 		
 		private PactString toTokenize;		// the string to tokenize
 		private int pos;					// the current position in the string

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCountClassic.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCountClassic.java
@@ -15,7 +15,6 @@
 
 package eu.stratosphere.pact.example.wordcount;
 
-import java.io.Serializable;
 import java.util.Iterator;
 
 import eu.stratosphere.pact.common.contract.FileDataSink;
@@ -39,17 +38,18 @@ import eu.stratosphere.pact.example.util.AsciiUtils;
 
 /**
  * Implements a word count which takes the input file and counts the number of
- * the occurrences of each word in the file.
+ * the occurrences of each word in the file. This is an example of using the
+ * classic PACT Contract interface where you can specify classes insted of
+ * objects.
  */
-public class WordCount implements PlanAssembler, PlanAssemblerDescription {
+public class WordCountClassic implements PlanAssembler, PlanAssemblerDescription {
 	
 	/**
 	 * Converts a PactRecord containing one string in to multiple string/integer pairs.
 	 * The string is tokenized by whitespaces. For each token a new record is emitted,
 	 * where the token is the first field and an Integer(1) is the second field.
 	 */
-	public static class TokenizeLine extends MapStub implements Serializable {
-		private static final long serialVersionUID = 1L;
+	public static class TokenizeLine extends MapStub {
 		
 		// initialize reusable mutable objects
 		private final PactRecord outputRecord = new PactRecord();
@@ -86,8 +86,7 @@ public class WordCount implements PlanAssembler, PlanAssemblerDescription {
 	 */
 	@Combinable
 	@ConstantFields(0)
-	public static class CountWords extends ReduceStub implements Serializable {
-		private static final long serialVersionUID = 1L;
+	public static class CountWords extends ReduceStub {
 		
 		private final PactInteger cnt = new PactInteger();
 		
@@ -126,9 +125,9 @@ public class WordCount implements PlanAssembler, PlanAssemblerDescription {
 		String dataInput = (args.length > 1 ? args[1] : "");
 		String output    = (args.length > 2 ? args[2] : "");
 
-		FileDataSource source = new FileDataSource(new TextInputFormat(), dataInput, "Input Lines");
+		FileDataSource source = new FileDataSource(TextInputFormat.class, dataInput, "Input Lines");
 		source.setParameter(TextInputFormat.CHARSET_NAME, "ASCII");		// comment out this line for UTF-8 inputs
-		MapContract mapper = MapContract.builder(new TokenizeLine())
+		MapContract mapper = MapContract.builder(TokenizeLine.class)
 			.input(source)
 			.name("Tokenize Lines")
 			.build();
@@ -136,7 +135,7 @@ public class WordCount implements PlanAssembler, PlanAssemblerDescription {
 			.input(mapper)
 			.name("Count Words")
 			.build();
-		FileDataSink out = new FileDataSink(new RecordOutputFormat(), output, reducer, "Word Counts");
+		FileDataSink out = new FileDataSink(RecordOutputFormat.class, output, reducer, "Word Counts");
 		RecordOutputFormat.configureRecordFormat(out)
 			.recordDelimiter('\n')
 			.fieldDelimiter(' ')

--- a/pact/pact-hbase/src/main/java/eu/stratosphere/pact/common/contract/HBaseDataSink.java
+++ b/pact/pact-hbase/src/main/java/eu/stratosphere/pact/common/contract/HBaseDataSink.java
@@ -13,9 +13,9 @@ public class HBaseDataSink extends GenericDataSink
 {
 	private static final int IDENTIFYIER_LEN = 16;
 	
-	public HBaseDataSink(Class<? extends GenericTableOutputFormat> c, Contract input, String name)
+	public HBaseDataSink(GenericTableOutputFormat f, Contract input, String name)
 	{
-		super(c, input, name);
+		super(f, input, name);
 		
 		// generate a random unique identifier string
 		final Random rnd = new Random();

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/util/TaskConfig.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/util/TaskConfig.java
@@ -37,6 +37,7 @@ import eu.stratosphere.pact.common.stubs.aggregators.AggregatorWithName;
 import eu.stratosphere.pact.common.stubs.aggregators.ConvergenceCriterion;
 import eu.stratosphere.pact.common.type.Value;
 import eu.stratosphere.pact.common.util.InstantiationUtil;
+import eu.stratosphere.pact.generic.contract.UserCodeWrapper;
 import eu.stratosphere.pact.generic.types.TypeComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypePairComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypeSerializerFactory;
@@ -54,7 +55,7 @@ public class TaskConfig {
 	
 	// ------------------------------------ User Code ---------------------------------------------
 	
-	private static final String STUB_CLASS = "pact.stub.class";
+	private static final String STUB_OBJECT = "pact.stub.udf-object";
 	
 	private static final String STUB_PARAM_PREFIX = "pact.stub.param.";
 	
@@ -243,18 +244,24 @@ public class TaskConfig {
 	}
 	
 	
-	public void setStubClass(Class<?> stubClass) {
-		this.config.setString(STUB_CLASS, stubClass.getName());
+	public void setStubWrapper(UserCodeWrapper<?> wrapper) {
+		try {
+			InstantiationUtil.writeObjectToConfig(wrapper, this.config, STUB_OBJECT);
+		} catch (IOException e) {
+			throw new CorruptConfigurationException("Could not write the user code wrapper " + wrapper.getClass() + " : " + e.toString());
+		}
 	}
 
-	public <T> Class<? extends T> getStubClass(Class<T> superClass, ClassLoader cl)
-		throws ClassNotFoundException, ClassCastException
+	@SuppressWarnings("unchecked")
+	public <T> UserCodeWrapper<T> getStubWrapper()
 	{
-		final String stubClassName = this.config.getString(STUB_CLASS, null);
-		if (stubClassName == null) {
-			throw new CorruptConfigurationException("The stub class is missing.");
+		try {
+			return (UserCodeWrapper<T>) InstantiationUtil.readObjectFormConfig(this.config, STUB_OBJECT);
+		} catch (ClassNotFoundException e) {
+			throw new CorruptConfigurationException("Could not read the user code wrapper: " + e);
+		} catch (IOException e) {
+			throw new CorruptConfigurationException("Could not read the user code wrapper: " + e);
 		}
-		return Class.forName(stubClassName, true, cl).asSubclass(superClass);
 	}
 	
 	public void setStubParameters(Configuration parameters) {

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/DataSinkTaskTest.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/DataSinkTaskTest.java
@@ -191,8 +191,9 @@ public class DataSinkTaskTest extends TaskTestBase
 				
 	}
 	
-	public static class MockOutputFormat extends DelimitedOutputFormat
-	{
+	public static class MockOutputFormat extends DelimitedOutputFormat {
+		private static final long serialVersionUID = 1L;
+		
 		final StringBuilder bld = new StringBuilder();
 		
 		@Override
@@ -218,6 +219,7 @@ public class DataSinkTaskTest extends TaskTestBase
 	}
 	
 	public static class MockFailingOutputFormat extends MockOutputFormat {
+		private static final long serialVersionUID = 1L;
 
 		int cnt = 0;
 		

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/DataSourceTaskTest.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/DataSourceTaskTest.java
@@ -224,8 +224,9 @@ public class DataSourceTaskTest extends TaskTestBase
 		}
 	}
 	
-	public static class MockInputFormat extends DelimitedInputFormat
-	{
+	public static class MockInputFormat extends DelimitedInputFormat {
+		private static final long serialVersionUID = 1L;
+		
 		private final PactInteger key = new PactInteger();
 		private final PactInteger value = new PactInteger();
 		
@@ -248,8 +249,9 @@ public class DataSourceTaskTest extends TaskTestBase
 		}
 	}
 	
-	public static class MockDelayingInputFormat extends DelimitedInputFormat
-	{
+	public static class MockDelayingInputFormat extends DelimitedInputFormat {
+		private static final long serialVersionUID = 1L;
+		
 		private final PactInteger key = new PactInteger();
 		private final PactInteger value = new PactInteger();
 		
@@ -279,8 +281,9 @@ public class DataSourceTaskTest extends TaskTestBase
 		
 	}
 	
-	public static class MockFailingInputFormat extends DelimitedInputFormat
-	{
+	public static class MockFailingInputFormat extends DelimitedInputFormat {
+		private static final long serialVersionUID = 1L;
+		
 		private final PactInteger key = new PactInteger();
 		private final PactInteger value = new PactInteger();
 		

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/chaining/ChainTaskTest.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/chaining/ChainTaskTest.java
@@ -27,6 +27,7 @@ import eu.stratosphere.pact.common.stubs.Collector;
 import eu.stratosphere.pact.common.stubs.ReduceStub;
 import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactInteger;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.generic.stub.GenericMapper;
 import eu.stratosphere.pact.runtime.plugable.pactrecord.PactRecordComparatorFactory;
 import eu.stratosphere.pact.runtime.plugable.pactrecord.PactRecordSerializerFactory;
@@ -37,8 +38,8 @@ import eu.stratosphere.pact.runtime.task.MapTaskTest.MockMapStub;
 import eu.stratosphere.pact.runtime.task.ReduceTaskTest.MockReduceStub;
 import eu.stratosphere.pact.runtime.task.RegularPactTask;
 import eu.stratosphere.pact.runtime.task.util.TaskConfig;
-import eu.stratosphere.pact.runtime.test.util.UniformPactRecordGenerator;
 import eu.stratosphere.pact.runtime.test.util.TaskTestBase;
+import eu.stratosphere.pact.runtime.test.util.UniformPactRecordGenerator;
 
 
 public class ChainTaskTest extends TaskTestBase {
@@ -79,7 +80,7 @@ public class ChainTaskTest extends TaskTestBase {
 				combineConfig.setMemoryDriver(3 * 1024 * 1024);
 				
 				// udf
-				combineConfig.setStubClass(MockReduceStub.class);
+				combineConfig.setStubWrapper(new UserCodeClassWrapper<MockReduceStub>(MockReduceStub.class));
 				
 				getTaskConfig().addChainedTask(ChainedCombineDriver.class, combineConfig, "combine");
 			}
@@ -135,7 +136,7 @@ public class ChainTaskTest extends TaskTestBase {
 				combineConfig.setMemoryDriver(3 * 1024 * 1024);
 				
 				// udf
-				combineConfig.setStubClass(MockFailingCombineStub.class);
+				combineConfig.setStubWrapper(new UserCodeClassWrapper<MockFailingCombineStub>(MockFailingCombineStub.class));
 				
 				getTaskConfig().addChainedTask(ChainedCombineDriver.class, combineConfig, "combine");
 			}

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/test/util/TaskTestBase.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/test/util/TaskTestBase.java
@@ -31,6 +31,7 @@ import eu.stratosphere.pact.common.io.FileOutputFormat;
 import eu.stratosphere.pact.common.stubs.Stub;
 import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.util.MutableObjectIterator;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.runtime.plugable.pactrecord.PactRecordSerializerFactory;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.pact.runtime.task.DataSinkTask;
@@ -78,7 +79,7 @@ public abstract class TaskTestBase {
 	public void registerTask(AbstractTask task, @SuppressWarnings("rawtypes") Class<? extends PactDriver> driver, Class<? extends Stub> stubClass) {
 		final TaskConfig config = new TaskConfig(this.mockEnv.getTaskConfiguration());
 		config.setDriver(driver);
-		config.setStubClass(stubClass);
+		config.setStubWrapper(new UserCodeClassWrapper<Stub>(stubClass));
 		
 		task.setEnvironment(this.mockEnv);
 
@@ -99,7 +100,7 @@ public abstract class TaskTestBase {
 	{
 		TaskConfig dsConfig = new TaskConfig(this.mockEnv.getTaskConfiguration());
 
-		dsConfig.setStubClass(stubClass);
+		dsConfig.setStubWrapper(new UserCodeClassWrapper<FileOutputFormat>(stubClass));
 		dsConfig.setStubParameter(FileOutputFormat.FILE_PARAMETER_KEY, outPath);
 
 		outTask.setEnvironment(this.mockEnv);
@@ -115,7 +116,7 @@ public abstract class TaskTestBase {
 			Class<? extends DelimitedInputFormat> stubClass, String inPath, String delimiter)
 	{
 		TaskConfig dsConfig = new TaskConfig(this.mockEnv.getTaskConfiguration());
-		dsConfig.setStubClass(stubClass);
+		dsConfig.setStubWrapper(new UserCodeClassWrapper<DelimitedInputFormat>(stubClass));
 		dsConfig.setStubParameter(FileInputFormat.FILE_PARAMETER_KEY, inPath);
 		dsConfig.setStubParameter(DelimitedInputFormat.RECORD_DELIMITER, delimiter);
 

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/test/util/TestData.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/test/util/TestData.java
@@ -51,6 +51,8 @@ public final class TestData {
 	 * Key implementation.
 	 */
 	public static class Key extends PactInteger {
+		private static final long serialVersionUID = 1L;
+		
 		public Key() {
 			super();
 		}
@@ -72,6 +74,7 @@ public final class TestData {
 	 * Value implementation.
 	 */
 	public static class Value extends PactString {
+		private static final long serialVersionUID = 1L;
 
 		public Value() {
 			super();

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/cancelling/MapCancelingITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/cancelling/MapCancelingITCase.java
@@ -33,12 +33,12 @@ public class MapCancelingITCase extends CancellingTestBase {
 	@Test
 	public void testMapCancelling() throws Exception {
 		GenericDataSource<InfiniteIntegerInputFormat> source = new GenericDataSource<InfiniteIntegerInputFormat>(
-																		InfiniteIntegerInputFormat.class, "Source");
+																		new InfiniteIntegerInputFormat(), "Source");
 		MapContract mapper = MapContract.builder(IdentityMapper.class)
 			.input(source)
 			.name("Identity Mapper")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, mapper, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), mapper, "Sink");
 		
 		
 		Plan p = new Plan(sink);
@@ -50,12 +50,12 @@ public class MapCancelingITCase extends CancellingTestBase {
 	@Test
 	public void testSlowMapCancelling() throws Exception {
 		GenericDataSource<InfiniteIntegerInputFormat> source = new GenericDataSource<InfiniteIntegerInputFormat>(
-																		InfiniteIntegerInputFormat.class, "Source");
+																		new InfiniteIntegerInputFormat(), "Source");
 		MapContract mapper = MapContract.builder(DelayingIdentityMapper.class)
 			.input(source)
 			.name("Delay Mapper")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, mapper, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), mapper, "Sink");
 		
 		
 		Plan p = new Plan(sink);
@@ -67,12 +67,12 @@ public class MapCancelingITCase extends CancellingTestBase {
 	@Test
 	public void testMapWithLongCancellingResponse() throws Exception {
 		GenericDataSource<InfiniteIntegerInputFormat> source = new GenericDataSource<InfiniteIntegerInputFormat>(
-																		InfiniteIntegerInputFormat.class, "Source");
+																		new InfiniteIntegerInputFormat(), "Source");
 		MapContract mapper = MapContract.builder(LongCancelTimeIdentityMapper.class)
 			.input(source)
 			.name("Long Cancelling Time Mapper")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, mapper, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), mapper, "Sink");
 		
 		
 		Plan p = new Plan(sink);
@@ -84,12 +84,12 @@ public class MapCancelingITCase extends CancellingTestBase {
 	@Test
 	public void testMapPriorToFirstRecordReading() throws Exception {
 		GenericDataSource<InfiniteIntegerInputFormat> source = new GenericDataSource<InfiniteIntegerInputFormat>(
-																		InfiniteIntegerInputFormat.class, "Source");
+																		new InfiniteIntegerInputFormat(), "Source");
 		MapContract mapper = MapContract.builder(StuckInOpenIdentityMapper.class)
 			.input(source)
 			.name("Stuck-In-Open Mapper")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, mapper, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), mapper, "Sink");
 		
 		
 		Plan p = new Plan(sink);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/cancelling/MatchJoinCancelingITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/cancelling/MatchJoinCancelingITCase.java
@@ -38,17 +38,17 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 	public void testCancelSortMatchWhileReadingSlowInputs() throws Exception
 	{
 		GenericDataSource<InfiniteIntegerInputFormatWithDelay> source1 =
-			new GenericDataSource<InfiniteIntegerInputFormatWithDelay>(InfiniteIntegerInputFormatWithDelay.class, "Source 1");
+			new GenericDataSource<InfiniteIntegerInputFormatWithDelay>(new InfiniteIntegerInputFormatWithDelay(), "Source 1");
 
 		GenericDataSource<InfiniteIntegerInputFormatWithDelay> source2 =
-			new GenericDataSource<InfiniteIntegerInputFormatWithDelay>(InfiniteIntegerInputFormatWithDelay.class, "Source 2");
+			new GenericDataSource<InfiniteIntegerInputFormatWithDelay>(new InfiniteIntegerInputFormatWithDelay(), "Source 2");
 		
 		MatchContract matcher = MatchContract.builder(SimpleMatcher.class, PactInteger.class, 0, 0)
 			.input1(source1)
 			.input2(source2)
 			.name("Sort Join")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, matcher, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), matcher, "Sink");
 		
 		Plan p = new Plan(sink);
 		p.setDefaultParallelism(4);
@@ -60,17 +60,17 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 	public void testCancelSortMatchWhileReadingFastInputs() throws Exception
 	{
 		GenericDataSource<InfiniteIntegerInputFormat> source1 =
-			new GenericDataSource<InfiniteIntegerInputFormat>(InfiniteIntegerInputFormat.class, "Source 1");
+			new GenericDataSource<InfiniteIntegerInputFormat>(new InfiniteIntegerInputFormat(), "Source 1");
 
 		GenericDataSource<InfiniteIntegerInputFormat> source2 =
-			new GenericDataSource<InfiniteIntegerInputFormat>(InfiniteIntegerInputFormat.class, "Source 2");
+			new GenericDataSource<InfiniteIntegerInputFormat>(new InfiniteIntegerInputFormat(), "Source 2");
 		
 		MatchContract matcher = MatchContract.builder(SimpleMatcher.class, PactInteger.class, 0, 0)
 			.input1(source1)
 			.input2(source2)
 			.name("Sort Join")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, matcher, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), matcher, "Sink");
 		
 		Plan p = new Plan(sink);
 		p.setDefaultParallelism(4);
@@ -82,17 +82,17 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 	public void testCancelSortMatchPriorToFirstRecordReading() throws Exception
 	{
 		GenericDataSource<InfiniteIntegerInputFormat> source1 =
-			new GenericDataSource<InfiniteIntegerInputFormat>(InfiniteIntegerInputFormat.class, "Source 1");
+			new GenericDataSource<InfiniteIntegerInputFormat>(new InfiniteIntegerInputFormat(), "Source 1");
 
 		GenericDataSource<InfiniteIntegerInputFormat> source2 =
-			new GenericDataSource<InfiniteIntegerInputFormat>(InfiniteIntegerInputFormat.class, "Source 2");
+			new GenericDataSource<InfiniteIntegerInputFormat>(new InfiniteIntegerInputFormat(), "Source 2");
 		
 		MatchContract matcher = MatchContract.builder(StuckInOpenMatcher.class, PactInteger.class, 0, 0)
 			.input1(source1)
 			.input2(source2)
 			.name("Stuc-In-Open Match")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, matcher, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), matcher, "Sink");
 		
 		Plan p = new Plan(sink);
 		p.setDefaultParallelism(4);
@@ -106,12 +106,12 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 	public void testCancelSortMatchWhileDoingHeavySorting() throws Exception
 	{
 		GenericDataSource<UniformIntInput> source1 =
-			new GenericDataSource<UniformIntInput>(UniformIntInput.class, "Source 1");
+			new GenericDataSource<UniformIntInput>(new UniformIntInput(), "Source 1");
 		source1.setParameter(UniformIntInput.NUM_KEYS_KEY, 50000);
 		source1.setParameter(UniformIntInput.NUM_VALUES_KEY, 100);
 
 		GenericDataSource<UniformIntInput> source2 =
-			new GenericDataSource<UniformIntInput>(UniformIntInput.class, "Source 2");
+			new GenericDataSource<UniformIntInput>(new UniformIntInput(), "Source 2");
 		source2.setParameter(UniformIntInput.NUM_KEYS_KEY, 50000);
 		source2.setParameter(UniformIntInput.NUM_VALUES_KEY, 100);
 		
@@ -120,7 +120,7 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 			.input2(source2)
 			.name("Long Cancelling Sort Join")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, matcher, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), matcher, "Sink");
 		
 		Plan p = new Plan(sink);
 		p.setDefaultParallelism(4);
@@ -135,12 +135,12 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 	public void testCancelSortMatchWhileJoining() throws Exception
 	{
 		GenericDataSource<UniformIntInput> source1 =
-			new GenericDataSource<UniformIntInput>(UniformIntInput.class, "Source 1");
+			new GenericDataSource<UniformIntInput>(new UniformIntInput(), "Source 1");
 		source1.setParameter(UniformIntInput.NUM_KEYS_KEY, 500);
 		source1.setParameter(UniformIntInput.NUM_VALUES_KEY, 3);
 
 		GenericDataSource<UniformIntInput> source2 =
-			new GenericDataSource<UniformIntInput>(UniformIntInput.class, "Source 2");
+			new GenericDataSource<UniformIntInput>(new UniformIntInput(), "Source 2");
 		source2.setParameter(UniformIntInput.NUM_KEYS_KEY, 500);
 		source2.setParameter(UniformIntInput.NUM_VALUES_KEY, 3);
 		
@@ -149,7 +149,7 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 			.input2(source2)
 			.name("Long Cancelling Sort Join")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, matcher, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), matcher, "Sink");
 		
 		Plan p = new Plan(sink);
 		p.setDefaultParallelism(4);
@@ -161,12 +161,12 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 	public void testCancelSortMatchWithLongCancellingResponse() throws Exception
 	{
 		GenericDataSource<UniformIntInput> source1 =
-			new GenericDataSource<UniformIntInput>(UniformIntInput.class, "Source 1");
+			new GenericDataSource<UniformIntInput>(new UniformIntInput(), "Source 1");
 		source1.setParameter(UniformIntInput.NUM_KEYS_KEY, 500);
 		source1.setParameter(UniformIntInput.NUM_VALUES_KEY, 3);
 
 		GenericDataSource<UniformIntInput> source2 =
-			new GenericDataSource<UniformIntInput>(UniformIntInput.class, "Source 2");
+			new GenericDataSource<UniformIntInput>(new UniformIntInput(), "Source 2");
 		source2.setParameter(UniformIntInput.NUM_KEYS_KEY, 500);
 		source2.setParameter(UniformIntInput.NUM_VALUES_KEY, 3);
 		
@@ -175,7 +175,7 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 			.input2(source2)
 			.name("Long Cancelling Sort Join")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, matcher, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), matcher, "Sink");
 		
 		Plan p = new Plan(sink);
 		p.setDefaultParallelism(4);
@@ -189,17 +189,17 @@ public class MatchJoinCancelingITCase extends CancellingTestBase
 	public void testCancelSortMatchWithHighDOP() throws Exception
 	{
 		GenericDataSource<InfiniteIntegerInputFormat> source1 =
-			new GenericDataSource<InfiniteIntegerInputFormat>(InfiniteIntegerInputFormat.class, "Source 1");
+			new GenericDataSource<InfiniteIntegerInputFormat>(new InfiniteIntegerInputFormat(), "Source 1");
 
 		GenericDataSource<InfiniteIntegerInputFormat> source2 =
-			new GenericDataSource<InfiniteIntegerInputFormat>(InfiniteIntegerInputFormat.class, "Source 2");
+			new GenericDataSource<InfiniteIntegerInputFormat>(new InfiniteIntegerInputFormat(), "Source 2");
 		
-		MatchContract matcher = MatchContract.builder(SimpleMatcher.class, PactInteger.class, 0, 0)
+		MatchContract matcher = MatchContract.builder(new SimpleMatcher(), PactInteger.class, 0, 0)
 			.input1(source1)
 			.input2(source2)
 			.name("Sort Join")
 			.build();
-		GenericDataSink sink = new GenericDataSink(DiscardingOutputFormat.class, matcher, "Sink");
+		GenericDataSink sink = new GenericDataSink(new DiscardingOutputFormat(), matcher, "Sink");
 		
 		Plan p = new Plan(sink);
 		p.setDefaultParallelism(64);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/CoGroupITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/CoGroupITCase.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.test.contracts;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -95,6 +96,7 @@ public class CoGroupITCase extends TestBase {
 	}
 
 	public static class CoGroupTestInFormat extends DelimitedInputFormat {
+		private static final long serialVersionUID = 1L;
 		
 		private final PactString keyString = new PactString();
 		private final PactString valueString = new PactString();
@@ -114,6 +116,7 @@ public class CoGroupITCase extends TestBase {
 	}
 
 	public static class CoGroupOutFormat extends FileOutputFormat {
+		private static final long serialVersionUID = 1L;
 		
 		private final StringBuilder buffer = new StringBuilder();
 		private final PactString keyString = new PactString();
@@ -135,7 +138,8 @@ public class CoGroupITCase extends TestBase {
 		}
 	}
 
-	public static class TestCoGrouper extends CoGroupStub {
+	public static class TestCoGrouper extends CoGroupStub implements Serializable {
+		private static final long serialVersionUID = 1L;
 
 		private PactString keyString = new PactString();
 		private PactString valueString = new PactString();
@@ -177,17 +181,17 @@ public class CoGroupITCase extends TestBase {
 
 		String pathPrefix = getFilesystemProvider().getURIPrefix() + getFilesystemProvider().getTempDirPath();
 
-		FileDataSource input_left =  new FileDataSource(CoGroupTestInFormat.class, pathPrefix + "/cogroup_left");
+		FileDataSource input_left =  new FileDataSource(new CoGroupTestInFormat(), pathPrefix + "/cogroup_left");
 		DelimitedInputFormat.configureDelimitedFormat(input_left)
 			.recordDelimiter('\n');
 		input_left.setDegreeOfParallelism(config.getInteger("CoGroupTest#NoSubtasks", 1));
 
-		FileDataSource input_right =  new FileDataSource(CoGroupTestInFormat.class, pathPrefix + "/cogroup_right");
+		FileDataSource input_right =  new FileDataSource(new CoGroupTestInFormat(), pathPrefix + "/cogroup_right");
 		DelimitedInputFormat.configureDelimitedFormat(input_right)
 			.recordDelimiter('\n');
 		input_right.setDegreeOfParallelism(config.getInteger("CoGroupTest#NoSubtasks", 1));
 
-		CoGroupContract testCoGrouper = CoGroupContract.builder(TestCoGrouper.class, PactString.class, 0, 0)
+		CoGroupContract testCoGrouper = CoGroupContract.builder(new TestCoGrouper(), PactString.class, 0, 0)
 			.build();
 		testCoGrouper.setDegreeOfParallelism(config.getInteger("CoGroupTest#NoSubtasks", 1));
 		testCoGrouper.getParameters().setString(PactCompiler.HINT_LOCAL_STRATEGY,
@@ -195,7 +199,7 @@ public class CoGroupITCase extends TestBase {
 		testCoGrouper.getParameters().setString(PactCompiler.HINT_SHIP_STRATEGY,
 				config.getString("CoGroupTest#ShipStrategy", ""));
 
-		FileDataSink output = new FileDataSink(CoGroupOutFormat.class, pathPrefix + "/result.txt");
+		FileDataSink output = new FileDataSink(new CoGroupOutFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		output.addInput(testCoGrouper);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/CrossITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/CrossITCase.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.test.contracts;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -103,7 +104,8 @@ public class CrossITCase extends TestBase
 	}
 
 
-	public static class TestCross extends CrossStub {
+	public static class TestCross extends CrossStub implements Serializable {
+		private static final long serialVersionUID = 1L;
 
 		private PactString string = new PactString();
 		private PactInteger integer = new PactInteger();
@@ -140,18 +142,18 @@ public class CrossITCase extends TestBase
 		String pathPrefix = getFilesystemProvider().getURIPrefix() + getFilesystemProvider().getTempDirPath();
 
 		FileDataSource input_left = new FileDataSource(
-				ContractITCaseInputFormat.class, pathPrefix + "/cross_left");
+				new ContractITCaseInputFormat(), pathPrefix + "/cross_left");
 		DelimitedInputFormat.configureDelimitedFormat(input_left)
 			.recordDelimiter('\n');
 		input_left.setDegreeOfParallelism(config.getInteger("CrossTest#NoSubtasks", 1));
 
 		FileDataSource input_right = new FileDataSource(
-				ContractITCaseInputFormat.class, pathPrefix + "/cross_right");
+				new ContractITCaseInputFormat(), pathPrefix + "/cross_right");
 		DelimitedInputFormat.configureDelimitedFormat(input_right)
 			.recordDelimiter('\n');
 		input_right.setDegreeOfParallelism(config.getInteger("CrossTest#NoSubtasks", 1));
 
-		CrossContract testCross = CrossContract.builder(TestCross.class).build();
+		CrossContract testCross = CrossContract.builder(new TestCross()).build();
 		testCross.setDegreeOfParallelism(config.getInteger("CrossTest#NoSubtasks", 1));
 		testCross.getParameters().setString(PactCompiler.HINT_LOCAL_STRATEGY,
 				config.getString("CrossTest#LocalStrategy", ""));
@@ -171,7 +173,7 @@ public class CrossITCase extends TestBase
 		}
 
 		FileDataSink output = new FileDataSink(
-				ContractITCaseOutputFormat.class, pathPrefix + "/result.txt");
+				new ContractITCaseOutputFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		output.addInput(testCross);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/MapITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/MapITCase.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.test.contracts;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -77,7 +78,8 @@ public class MapITCase extends TestBase {
 		getFilesystemProvider().createFile(tempDir+"/mapInput/mapTest_4.txt", MAP_IN_4);
 	}
 
-	public static class TestMapper extends MapStub {
+	public static class TestMapper extends MapStub implements Serializable {
+		private static final long serialVersionUID = 1L;
 
 		private PactString keyString = new PactString();
 		private PactString valueString = new PactString();
@@ -105,16 +107,16 @@ public class MapITCase extends TestBase {
 		String pathPrefix = getFilesystemProvider().getURIPrefix()+getFilesystemProvider().getTempDirPath();
 		
 		FileDataSource input = new FileDataSource(
-				ContractITCaseInputFormat.class, pathPrefix+"/mapInput");
+				new ContractITCaseInputFormat(), pathPrefix+"/mapInput");
 		DelimitedInputFormat.configureDelimitedFormat(input)
 			.recordDelimiter('\n');
 		input.setDegreeOfParallelism(config.getInteger("MapTest#NoSubtasks", 1));
 
-		MapContract testMapper = MapContract.builder(TestMapper.class).build();
+		MapContract testMapper = MapContract.builder(new TestMapper()).build();
 		testMapper.setDegreeOfParallelism(config.getInteger("MapTest#NoSubtasks", 1));
 
 		FileDataSink output = new FileDataSink(
-				ContractITCaseOutputFormat.class, pathPrefix + "/result.txt");
+				new ContractITCaseOutputFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		output.addInput(testMapper);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/MatchITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/MatchITCase.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.test.contracts;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -103,7 +104,8 @@ public class MatchITCase extends TestBase
 
 	}
 
-	public static class TestMatcher extends MatchStub {
+	public static class TestMatcher extends MatchStub implements Serializable {
+		private static final long serialVersionUID = 1L;
 
 		private PactString keyString = new PactString();
 		private PactString valueString = new PactString();
@@ -136,18 +138,18 @@ public class MatchITCase extends TestBase
 		String pathPrefix = getFilesystemProvider().getURIPrefix() + getFilesystemProvider().getTempDirPath();
 
 		FileDataSource input_left = new FileDataSource(
-				ContractITCaseInputFormat.class, pathPrefix + "/match_left");
+				new ContractITCaseInputFormat(), pathPrefix + "/match_left");
 		DelimitedInputFormat.configureDelimitedFormat(input_left)
 			.recordDelimiter('\n');
 		input_left.setDegreeOfParallelism(config.getInteger("MatchTest#NoSubtasks", 1));
 
 		FileDataSource input_right = new FileDataSource(
-				ContractITCaseInputFormat.class, pathPrefix + "/match_right");
+				new ContractITCaseInputFormat(), pathPrefix + "/match_right");
 		DelimitedInputFormat.configureDelimitedFormat(input_right)
 			.recordDelimiter('\n');
 		input_right.setDegreeOfParallelism(config.getInteger("MatchTest#NoSubtasks", 1));
 
-		MatchContract testMatcher = MatchContract.builder(TestMatcher.class, PactString.class, 0, 0)
+		MatchContract testMatcher = MatchContract.builder(new TestMatcher(), PactString.class, 0, 0)
 			.build();
 		testMatcher.setDegreeOfParallelism(config.getInteger("MatchTest#NoSubtasks", 1));
 		testMatcher.getParameters().setString(PactCompiler.HINT_LOCAL_STRATEGY,
@@ -168,7 +170,7 @@ public class MatchITCase extends TestBase
 		}
 
 		FileDataSink output = new FileDataSink(
-				ContractITCaseOutputFormat.class, pathPrefix + "/result.txt");
+				new ContractITCaseOutputFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		output.addInput(testMatcher);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/ReduceITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/ReduceITCase.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.test.contracts;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -80,7 +81,8 @@ public class ReduceITCase extends TestBase {
 	}
 
 	@ReduceContract.Combinable
-	public static class TestReducer extends ReduceStub {
+	public static class TestReducer extends ReduceStub implements Serializable {
+		private static final long serialVersionUID = 1L;
 
 		private PactString reduceValue = new PactString();
 		private PactString combineValue = new PactString();
@@ -126,12 +128,12 @@ public class ReduceITCase extends TestBase {
 		String pathPrefix = getFilesystemProvider().getURIPrefix() + getFilesystemProvider().getTempDirPath();
 
 		FileDataSource input = new FileDataSource(
-				ContractITCaseInputFormat.class, pathPrefix + "/reduceInput");
+				new ContractITCaseInputFormat(), pathPrefix + "/reduceInput");
 		DelimitedInputFormat.configureDelimitedFormat(input)
 			.recordDelimiter('\n');
 		input.setDegreeOfParallelism(config.getInteger("ReduceTest#NoSubtasks", 1));
 
-		ReduceContract testReducer = new ReduceContract.Builder(TestReducer.class, PactString.class, 0)
+		ReduceContract testReducer = ReduceContract.builder(new TestReducer(), PactString.class, 0)
 			.build();
 		testReducer.setDegreeOfParallelism(config.getInteger("ReduceTest#NoSubtasks", 1));
 		testReducer.getParameters().setString(PactCompiler.HINT_LOCAL_STRATEGY,
@@ -140,7 +142,7 @@ public class ReduceITCase extends TestBase {
 				config.getString("ReduceTest#ShipStrategy", ""));
 
 		FileDataSink output = new FileDataSink(
-				ContractITCaseOutputFormat.class, pathPrefix + "/result.txt");
+				new ContractITCaseOutputFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		output.addInput(testReducer);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/UnionITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/UnionITCase.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.test.contracts;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -92,8 +93,9 @@ public class UnionITCase extends TestBase {
 		getFilesystemProvider().createFile(tempDir+emptyInputFilePathPostfix+"/UnionTest_4.txt", "");
 	}
 
-	public static class TestMapper extends MapStub {
-
+	public static class TestMapper extends MapStub implements Serializable {
+		private static final long serialVersionUID = 1L;
+		
 		private PactString keyString = new PactString();
 		private PactString valueString = new PactString();
 		
@@ -122,22 +124,22 @@ public class UnionITCase extends TestBase {
 		
 		
 		FileDataSource input1 = new FileDataSource(
-			ContractITCaseInputFormat.class, pathPrefix + config.getString("UnionTest#Input1Path", ""));
+			new ContractITCaseInputFormat(), pathPrefix + config.getString("UnionTest#Input1Path", ""));
 		DelimitedInputFormat.configureDelimitedFormat(input1)
 			.recordDelimiter('\n');
 		input1.setDegreeOfParallelism(config.getInteger("UnionTest#NoSubtasks", 1));
 		
 		FileDataSource input2 = new FileDataSource(
-				ContractITCaseInputFormat.class, pathPrefix + config.getString("UnionTest#Input2Path", ""));
+				new ContractITCaseInputFormat(), pathPrefix + config.getString("UnionTest#Input2Path", ""));
 		DelimitedInputFormat.configureDelimitedFormat(input2)
 			.recordDelimiter('\n');
 		input2.setDegreeOfParallelism(config.getInteger("UnionTest#NoSubtasks", 1));
 		
-		MapContract testMapper = MapContract.builder(TestMapper.class).build();
+		MapContract testMapper = MapContract.builder(new TestMapper()).build();
 		testMapper.setDegreeOfParallelism(config.getInteger("UnionTest#NoSubtasks", 1));
 
 		FileDataSink output = new FileDataSink(
-				ContractITCaseOutputFormat.class, pathPrefix + "/result.txt");
+				new ContractITCaseOutputFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		output.addInput(testMapper);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/io/ContractITCaseIOFormats.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/io/ContractITCaseIOFormats.java
@@ -31,6 +31,7 @@ public class ContractITCaseIOFormats {
 	private static final Log LOG = LogFactory.getLog(ContractITCaseIOFormats.class);
 	
 	public static class ContractITCaseInputFormat extends DelimitedInputFormat {
+		private static final long serialVersionUID = 1L;
 
 		private final PactString keyString = new PactString();
 		private final PactString valueString = new PactString();
@@ -50,6 +51,8 @@ public class ContractITCaseIOFormats {
 	}
 
 	public static class ContractITCaseOutputFormat extends FileOutputFormat {
+		private static final long serialVersionUID = 1L;
+		
 		private final StringBuilder buffer = new StringBuilder();
 		private final PactString keyString = new PactString();
 		private final PactInteger valueInteger = new PactInteger();

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/io/CustomDataTypeTest.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/contracts/io/CustomDataTypeTest.java
@@ -67,10 +67,10 @@ public class CustomDataTypeTest extends TestBase
 	@Override
 	protected JobGraph getJobGraph() throws Exception {
 		GenericDataSource<EmptyInputFormat> datasource = 
-				new GenericDataSource<EmptyInputFormat>(EmptyInputFormat.class, "Source");
+				new GenericDataSource<EmptyInputFormat>(new EmptyInputFormat(), "Source");
 		datasource.getParameters().setString(CLASS_TO_INSTANTIATE_KEY, CLASS_TO_INSTANTIATE_NAME);
 		
-		GenericDataSink sink = new GenericDataSink(BlackholeOutputFormat.class, datasource, "Sink");
+		GenericDataSink sink = new GenericDataSink(new BlackholeOutputFormat(), datasource, "Sink");
 		sink.getParameters().setString(CLASS_TO_INSTANTIATE_KEY, CLASS_TO_INSTANTIATE_NAME);
 		
 		Plan plan = new Plan(sink);
@@ -89,6 +89,7 @@ public class CustomDataTypeTest extends TestBase
 	}
 	
 	public static final class EmptyInputFormat extends GenericInputFormat {
+		private static final long serialVersionUID = 1L;
 		
 		@Override
 		public void configure(Configuration parameters)	{
@@ -109,6 +110,7 @@ public class CustomDataTypeTest extends TestBase
 	}
 	
 	public static final class BlackholeOutputFormat implements OutputFormat<PactRecord> {
+		private static final long serialVersionUID = 1L;
 		
 		@Override
 		public void configure(Configuration parameters) {

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/failingPrograms/TaskFailureITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/failingPrograms/TaskFailureITCase.java
@@ -103,7 +103,7 @@ public class TaskFailureITCase extends FailingTestBase {
 		
 		// init data source 
 		FileDataSource input = new FileDataSource(
-			ContractITCaseInputFormat.class, pathPrefix+"/mapInput");
+			new ContractITCaseInputFormat(), pathPrefix+"/mapInput");
 		DelimitedInputFormat.configureDelimitedFormat(input)
 			.recordDelimiter('\n');
 		input.setDegreeOfParallelism(config.getInteger("MapTest#NoSubtasks", 1));
@@ -114,7 +114,7 @@ public class TaskFailureITCase extends FailingTestBase {
 
 		// init data sink
 		FileDataSink output = new FileDataSink(
-			ContractITCaseOutputFormat.class, pathPrefix + "/result.txt");
+			new ContractITCaseOutputFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		// compose failing program
@@ -144,7 +144,7 @@ public class TaskFailureITCase extends FailingTestBase {
 		
 		// init data source 
 		FileDataSource input = new FileDataSource(
-			ContractITCaseInputFormat.class, pathPrefix+"/mapInput");
+			new ContractITCaseInputFormat(), pathPrefix+"/mapInput");
 		DelimitedInputFormat.configureDelimitedFormat(input)
 			.recordDelimiter('\n');
 		input.setDegreeOfParallelism(config.getInteger("MapTest#NoSubtasks", 1));
@@ -155,7 +155,7 @@ public class TaskFailureITCase extends FailingTestBase {
 
 		// init data sink
 		FileDataSink output = new FileDataSink(
-			ContractITCaseOutputFormat.class, pathPrefix + "/result.txt");
+			new ContractITCaseOutputFormat(), pathPrefix + "/result.txt");
 		output.setDegreeOfParallelism(1);
 
 		// compose working program

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/ConnectedComponentsNepheleITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/ConnectedComponentsNepheleITCase.java
@@ -46,6 +46,7 @@ import eu.stratosphere.pact.common.type.base.parser.DecimalTextLongParser;
 import eu.stratosphere.pact.example.connectedcomponents.WorksetConnectedComponents.MinimumComponentIDReduce;
 import eu.stratosphere.pact.example.connectedcomponents.WorksetConnectedComponents.NeighborWithComponentIDJoin;
 import eu.stratosphere.pact.example.connectedcomponents.WorksetConnectedComponents.UpdateComponentIdMatch;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.generic.types.TypeComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypePairComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypeSerializerFactory;
@@ -163,7 +164,7 @@ public class ConnectedComponentsNepheleITCase extends TestBase2 {
 			
 			// chained mapper that duplicates the id
 			TaskConfig chainedMapperConfig = new TaskConfig(new Configuration());
-			chainedMapperConfig.setStubClass(IdDuplicator.class);
+			chainedMapperConfig.setStubWrapper(new UserCodeClassWrapper<IdDuplicator>(IdDuplicator.class));
 			chainedMapperConfig.setDriverStrategy(DriverStrategy.MAP);
 			chainedMapperConfig.setInputLocalStrategy(0, LocalStrategy.NONE);
 			chainedMapperConfig.setInputSerializer(serializer, 0);
@@ -253,7 +254,7 @@ public class ConnectedComponentsNepheleITCase extends TestBase2 {
 			// the driver 
 			headConfig.setDriver(BuildSecondCachedMatchDriver.class);
 			headConfig.setDriverStrategy(DriverStrategy.HYBRIDHASH_BUILD_SECOND);
-			headConfig.setStubClass(NeighborWithComponentIDJoin.class);
+			headConfig.setStubWrapper(new UserCodeClassWrapper<NeighborWithComponentIDJoin>(NeighborWithComponentIDJoin.class));
 			headConfig.setDriverComparator(comparator, 0);
 			headConfig.setDriverComparator(comparator, 1);
 			headConfig.setDriverPairComparator(pairComparator);
@@ -283,7 +284,7 @@ public class ConnectedComponentsNepheleITCase extends TestBase2 {
 			intermediateConfig.setDriver(ReduceDriver.class);
 			intermediateConfig.setDriverStrategy(DriverStrategy.SORTED_GROUP);
 			intermediateConfig.setDriverComparator(comparator, 0);
-			intermediateConfig.setStubClass(MinimumComponentIDReduce.class);
+			intermediateConfig.setStubWrapper(new UserCodeClassWrapper<MinimumComponentIDReduce>(MinimumComponentIDReduce.class));
 		}
 		
 		// --------------- the tail (solution set join) ---------------
@@ -307,7 +308,7 @@ public class ConnectedComponentsNepheleITCase extends TestBase2 {
 			// the driver
 			tailConfig.setDriver(SolutionSetSecondJoinDriver.class);
 			tailConfig.setDriverStrategy(DriverStrategy.HYBRIDHASH_BUILD_SECOND);
-			tailConfig.setStubClass(UpdateComponentIdMatch.class);
+			tailConfig.setStubWrapper(new UserCodeClassWrapper<UpdateComponentIdMatch>(UpdateComponentIdMatch.class));
 			tailConfig.setSolutionSetSerializer(serializer);
 		}
 		
@@ -319,7 +320,7 @@ public class ConnectedComponentsNepheleITCase extends TestBase2 {
 			outputConfig.addInputToGroup(0);
 			outputConfig.setInputSerializer(serializer, 0);
 			
-			outputConfig.setStubClass(RecordOutputFormat.class);
+			outputConfig.setStubWrapper(new UserCodeClassWrapper<RecordOutputFormat>(RecordOutputFormat.class));
 			outputConfig.setStubParameter(FileOutputFormat.FILE_PARAMETER_KEY, resultPath);
 			
 			Configuration outputUserConfig = outputConfig.getStubParameters();

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomCompensatableDanglingPageRank.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomCompensatableDanglingPageRank.java
@@ -23,6 +23,7 @@ import eu.stratosphere.nephele.jobgraph.JobInputVertex;
 import eu.stratosphere.nephele.jobgraph.JobOutputVertex;
 import eu.stratosphere.nephele.jobgraph.JobTaskVertex;
 import eu.stratosphere.pact.common.io.FileOutputFormat;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.generic.types.TypeComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypePairComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypeSerializerFactory;
@@ -185,7 +186,7 @@ public class CustomCompensatableDanglingPageRank {
 		// the driver 
 		headConfig.setDriver(MapDriver.class);
 		headConfig.setDriverStrategy(DriverStrategy.MAP);
-		headConfig.setStubClass(CustomCompensatingMap.class);
+		headConfig.setStubWrapper(new UserCodeClassWrapper<CustomCompensatingMap>(CustomCompensatingMap.class));
 		headConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		headConfig.setStubParameter("compensation.failingWorker", failingWorkers);
 		headConfig.setStubParameter("compensation.failingIteration", String.valueOf(failingIteration));
@@ -214,7 +215,7 @@ public class CustomCompensatableDanglingPageRank {
 		intermediateConfig.addOutputShipStrategy(ShipStrategyType.PARTITION_HASH);
 		intermediateConfig.setOutputComparator(vertexWithRankComparator, 0);
 		
-		intermediateConfig.setStubClass(CustomCompensatableDotProductMatch.class);
+		intermediateConfig.setStubWrapper(new UserCodeClassWrapper<CustomCompensatableDotProductMatch>(CustomCompensatableDotProductMatch.class));
 		intermediateConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		intermediateConfig.setStubParameter("compensation.failingWorker", failingWorkers);
 		intermediateConfig.setStubParameter("compensation.failingIteration", String.valueOf(failingIteration));
@@ -251,7 +252,7 @@ public class CustomCompensatableDanglingPageRank {
 		tailConfig.setOutputSerializer(vertexWithRankAndDanglingSerializer);
 		
 		// the stub
-		tailConfig.setStubClass(CustomCompensatableDotProductCoGroup.class);
+		tailConfig.setStubWrapper(new UserCodeClassWrapper<CustomCompensatableDotProductCoGroup>(CustomCompensatableDotProductCoGroup.class));
 		tailConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		tailConfig.setStubParameter("pageRank.numDanglingVertices", String.valueOf(numDanglingVertices));
 		tailConfig.setStubParameter("compensation.failingWorker", failingWorkers);
@@ -265,7 +266,7 @@ public class CustomCompensatableDanglingPageRank {
 		TaskConfig outputConfig = new TaskConfig(output.getConfiguration());
 		outputConfig.addInputToGroup(0);
 		outputConfig.setInputSerializer(vertexWithRankAndDanglingSerializer, 0);
-		outputConfig.setStubClass(CustomPageWithRankOutFormat.class);
+		outputConfig.setStubWrapper(new UserCodeClassWrapper<CustomPageWithRankOutFormat>(CustomPageWithRankOutFormat.class));
 		outputConfig.setStubParameter(FileOutputFormat.FILE_PARAMETER_KEY, outputPath);
 		
 		// --------------- the auxiliaries ---------------------

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomCompensatableDanglingPageRankWithCombiner.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomCompensatableDanglingPageRankWithCombiner.java
@@ -23,6 +23,7 @@ import eu.stratosphere.nephele.jobgraph.JobInputVertex;
 import eu.stratosphere.nephele.jobgraph.JobOutputVertex;
 import eu.stratosphere.nephele.jobgraph.JobTaskVertex;
 import eu.stratosphere.pact.common.io.FileOutputFormat;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.generic.types.TypeComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypePairComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypeSerializerFactory;
@@ -185,7 +186,7 @@ public class CustomCompensatableDanglingPageRankWithCombiner {
 		// the driver 
 		headConfig.setDriver(MapDriver.class);
 		headConfig.setDriverStrategy(DriverStrategy.MAP);
-		headConfig.setStubClass(CustomCompensatingMap.class);
+		headConfig.setStubWrapper(new UserCodeClassWrapper<CustomCompensatingMap>(CustomCompensatingMap.class));
 		headConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		headConfig.setStubParameter("compensation.failingWorker", failingWorkers);
 		headConfig.setStubParameter("compensation.failingIteration", String.valueOf(failingIteration));
@@ -213,7 +214,7 @@ public class CustomCompensatableDanglingPageRankWithCombiner {
 		intermediateConfig.setOutputSerializer(vertexWithRankSerializer);
 		intermediateConfig.addOutputShipStrategy(ShipStrategyType.FORWARD);
 		
-		intermediateConfig.setStubClass(CustomCompensatableDotProductMatch.class);
+		intermediateConfig.setStubWrapper(new UserCodeClassWrapper<CustomCompensatableDotProductMatch>(CustomCompensatableDotProductMatch.class));
 		intermediateConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		intermediateConfig.setStubParameter("compensation.failingWorker", failingWorkers);
 		intermediateConfig.setStubParameter("compensation.failingIteration", String.valueOf(failingIteration));
@@ -229,7 +230,7 @@ public class CustomCompensatableDanglingPageRankWithCombiner {
 		combinerConfig.setOutputSerializer(vertexWithRankSerializer);
 		combinerConfig.addOutputShipStrategy(ShipStrategyType.PARTITION_HASH);
 		combinerConfig.setOutputComparator(vertexWithRankComparator, 0);
-		combinerConfig.setStubClass(CustomRankCombiner.class);
+		combinerConfig.setStubWrapper(new UserCodeClassWrapper<CustomRankCombiner>(CustomRankCombiner.class));
 		intermediateConfig.addChainedTask(SynchronousChainedCombineDriver.class, combinerConfig, "Combiner");
 
 		// ---------------- the tail (co group) --------------------
@@ -263,7 +264,7 @@ public class CustomCompensatableDanglingPageRankWithCombiner {
 		tailConfig.setOutputSerializer(vertexWithRankAndDanglingSerializer);
 		
 		// the stub
-		tailConfig.setStubClass(CustomCompensatableDotProductCoGroup.class);
+		tailConfig.setStubWrapper(new UserCodeClassWrapper<CustomCompensatableDotProductCoGroup>(CustomCompensatableDotProductCoGroup.class));
 		tailConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		tailConfig.setStubParameter("pageRank.numDanglingVertices", String.valueOf(numDanglingVertices));
 		tailConfig.setStubParameter("compensation.failingWorker", failingWorkers);
@@ -277,7 +278,7 @@ public class CustomCompensatableDanglingPageRankWithCombiner {
 		TaskConfig outputConfig = new TaskConfig(output.getConfiguration());
 		outputConfig.addInputToGroup(0);
 		outputConfig.setInputSerializer(vertexWithRankAndDanglingSerializer, 0);
-		outputConfig.setStubClass(CustomPageWithRankOutFormat.class);
+		outputConfig.setStubWrapper(new UserCodeClassWrapper<CustomPageWithRankOutFormat>(CustomPageWithRankOutFormat.class));
 		outputConfig.setStubParameter(FileOutputFormat.FILE_PARAMETER_KEY, outputPath);
 		
 		// --------------- the auxiliaries ---------------------

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomImprovedAdjacencyListInputFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomImprovedAdjacencyListInputFormat.java
@@ -5,6 +5,7 @@ import eu.stratosphere.pact.test.iterative.nephele.customdanglingpagerank.types.
 import eu.stratosphere.pact.test.iterative.nephele.danglingpagerank.AsciiLongArrayView;
 
 public class CustomImprovedAdjacencyListInputFormat extends DelimitedInputFormat<VertexWithAdjacencyList> {
+	private static final long serialVersionUID = 1L;
 
 	private final AsciiLongArrayView arrayView = new AsciiLongArrayView();
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomImprovedDanglingPageRankInputFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomImprovedDanglingPageRankInputFormat.java
@@ -7,6 +7,7 @@ import eu.stratosphere.pact.test.iterative.nephele.customdanglingpagerank.types.
 import eu.stratosphere.pact.test.iterative.nephele.danglingpagerank.AsciiLongArrayView;
 
 public class CustomImprovedDanglingPageRankInputFormat extends DelimitedInputFormat<VertexWithRankAndDangling> {
+	private static final long serialVersionUID = 1L;
 
 	private AsciiLongArrayView arrayView = new AsciiLongArrayView();
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomPageWithRankOutFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/CustomPageWithRankOutFormat.java
@@ -23,6 +23,7 @@ import eu.stratosphere.pact.test.iterative.nephele.customdanglingpagerank.types.
 import java.io.IOException;
 
 public class CustomPageWithRankOutFormat extends FileOutputFormat<VertexWithRankAndDangling> {
+	private static final long serialVersionUID = 1L;
 
 	private final StringBuilder buffer = new StringBuilder();
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/types/VertexWithRank.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/types/VertexWithRank.java
@@ -14,11 +14,14 @@
  **********************************************************************************************************************/
 package eu.stratosphere.pact.test.iterative.nephele.customdanglingpagerank.types;
 
+import java.io.Serializable;
+
 
 /**
  *
  */
-public final class VertexWithRank {
+public final class VertexWithRank implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private long vertexID;
 	

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/types/VertexWithRankAndDangling.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/customdanglingpagerank/types/VertexWithRankAndDangling.java
@@ -14,11 +14,14 @@
  **********************************************************************************************************************/
 package eu.stratosphere.pact.test.iterative.nephele.customdanglingpagerank.types;
 
+import java.io.Serializable;
+
 
 /**
  *
  */
-public final class VertexWithRankAndDangling {
+public final class VertexWithRankAndDangling implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private long vertexID;
 	

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/AsciiLongArrayView.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/AsciiLongArrayView.java
@@ -1,8 +1,11 @@
 package eu.stratosphere.pact.test.iterative.nephele.danglingpagerank;
 
+import java.io.Serializable;
+
 import com.google.common.base.Charsets;
 
-public class AsciiLongArrayView {
+public class AsciiLongArrayView implements Serializable {
+  private static final long serialVersionUID = 1L;
 
   private byte[] buffer;
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/BooleanValue.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/BooleanValue.java
@@ -7,6 +7,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class BooleanValue implements Value {
+  private static final long serialVersionUID = 1L;
 
   private boolean value;
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/CompensatableDanglingPageRank.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/CompensatableDanglingPageRank.java
@@ -24,6 +24,7 @@ import eu.stratosphere.nephele.jobgraph.JobOutputVertex;
 import eu.stratosphere.nephele.jobgraph.JobTaskVertex;
 import eu.stratosphere.pact.common.io.FileOutputFormat;
 import eu.stratosphere.pact.common.type.base.PactLong;
+import eu.stratosphere.pact.generic.contract.UserCodeClassWrapper;
 import eu.stratosphere.pact.generic.types.TypeComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypePairComparatorFactory;
 import eu.stratosphere.pact.generic.types.TypeSerializerFactory;
@@ -165,7 +166,7 @@ public class CompensatableDanglingPageRank {
 		// the driver 
 		headConfig.setDriver(MapDriver.class);
 		headConfig.setDriverStrategy(DriverStrategy.MAP);
-		headConfig.setStubClass(CompensatingMap.class);
+		headConfig.setStubWrapper(new UserCodeClassWrapper<CompensatingMap>(CompensatingMap.class));
 		headConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		headConfig.setStubParameter("compensation.failingWorker", failingWorkers);
 		headConfig.setStubParameter("compensation.failingIteration", String.valueOf(failingIteration));
@@ -194,7 +195,7 @@ public class CompensatableDanglingPageRank {
 		intermediateConfig.addOutputShipStrategy(ShipStrategyType.PARTITION_HASH);
 		intermediateConfig.setOutputComparator(fieldZeroComparator, 0);
 		
-		intermediateConfig.setStubClass(CompensatableDotProductMatch.class);
+		intermediateConfig.setStubWrapper(new UserCodeClassWrapper<CompensatableDotProductMatch>(CompensatableDotProductMatch.class));
 		intermediateConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		intermediateConfig.setStubParameter("compensation.failingWorker", failingWorkers);
 		intermediateConfig.setStubParameter("compensation.failingIteration", String.valueOf(failingIteration));
@@ -231,7 +232,7 @@ public class CompensatableDanglingPageRank {
 		tailConfig.setOutputSerializer(recSerializer);
 		
 		// the stub
-		tailConfig.setStubClass(CompensatableDotProductCoGroup.class);
+		tailConfig.setStubWrapper(new UserCodeClassWrapper<CompensatableDotProductCoGroup>(CompensatableDotProductCoGroup.class));
 		tailConfig.setStubParameter("pageRank.numVertices", String.valueOf(numVertices));
 		tailConfig.setStubParameter("pageRank.numDanglingVertices", String.valueOf(numDanglingVertices));
 		tailConfig.setStubParameter("compensation.failingWorker", failingWorkers);
@@ -245,7 +246,7 @@ public class CompensatableDanglingPageRank {
 		TaskConfig outputConfig = new TaskConfig(output.getConfiguration());
 		outputConfig.addInputToGroup(0);
 		outputConfig.setInputSerializer(recSerializer, 0);
-		outputConfig.setStubClass(PageWithRankOutFormat.class);
+		outputConfig.setStubWrapper(new UserCodeClassWrapper<PageWithRankOutFormat>(PageWithRankOutFormat.class));
 		outputConfig.setStubParameter(FileOutputFormat.FILE_PARAMETER_KEY, outputPath);
 		
 		// --------------- the auxiliaries ---------------------

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/DanglingPageGenerateRankInputFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/DanglingPageGenerateRankInputFormat.java
@@ -10,6 +10,7 @@ import eu.stratosphere.pact.test.iterative.nephele.ConfigUtils;
 import java.util.regex.Pattern;
 
 public class DanglingPageGenerateRankInputFormat extends TextInputFormat {
+  private static final long serialVersionUID = 1L;
 
   private PactDouble initialRank;
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/ImprovedAdjacencyListInputFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/ImprovedAdjacencyListInputFormat.java
@@ -5,6 +5,7 @@ import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactLong;
 
 public class ImprovedAdjacencyListInputFormat extends TextInputFormat {
+  private static final long serialVersionUID = 1L;
 
   private final PactLong vertexID = new PactLong();
   private final AsciiLongArrayView arrayView = new AsciiLongArrayView();

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/ImprovedDanglingPageRankInputFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/ImprovedDanglingPageRankInputFormat.java
@@ -8,6 +8,7 @@ import eu.stratosphere.pact.common.type.base.PactLong;
 import eu.stratosphere.pact.test.iterative.nephele.ConfigUtils;
 
 public class ImprovedDanglingPageRankInputFormat extends TextInputFormat {
+	private static final long serialVersionUID = 1L;
 
 	private PactLong vertexID = new PactLong();
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/LongArrayView.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/LongArrayView.java
@@ -7,6 +7,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class LongArrayView implements Value {
+  private static final long serialVersionUID = 1L;
 
   private long[] entries = new long[0];
   private int numEntries = 0;

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/PageRankStats.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/PageRankStats.java
@@ -7,6 +7,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class PageRankStats implements Value {
+	private static final long serialVersionUID = 1L;
 
 	private double diff;
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/PageWithRankOutFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/iterative/nephele/danglingpagerank/PageWithRankOutFormat.java
@@ -24,6 +24,7 @@ import eu.stratosphere.pact.common.type.base.PactLong;
 import java.io.IOException;
 
 public class PageWithRankOutFormat extends FileOutputFormat {
+  private static final long serialVersionUID = 1L;
 
   private final StringBuilder buffer = new StringBuilder();
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/pactPrograms/WordCountClassicITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/pactPrograms/WordCountClassicITCase.java
@@ -1,0 +1,206 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.pact.test.pactPrograms;
+
+import java.util.Collection;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import eu.stratosphere.nephele.configuration.Configuration;
+import eu.stratosphere.pact.common.plan.Plan;
+import eu.stratosphere.pact.example.wordcount.WordCountClassic;
+import eu.stratosphere.pact.test.util.TestBase2;
+
+@RunWith(Parameterized.class)
+public class WordCountClassicITCase extends TestBase2 {
+
+	protected static final Log LOG = LogFactory.getLog(WordCountClassicITCase.class);
+
+	protected static final String TEXT = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
+			+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
+			+ "RAPHAEL: Die Sonne toent, nach alter Weise, In Brudersphaeren Wettgesang,\n"
+			+ "Und ihre vorgeschriebne Reise Vollendet sie mit Donnergang. Ihr Anblick\n"
+			+ "gibt den Engeln Staerke, Wenn keiner Sie ergruenden mag; die unbegreiflich\n"
+			+ "hohen Werke Sind herrlich wie am ersten Tag.\n"
+			+ "GABRIEL: Und schnell und unbegreiflich schnelle Dreht sich umher der Erde\n"
+			+ "Pracht; Es wechselt Paradieseshelle Mit tiefer, schauervoller Nacht. Es\n"
+			+ "schaeumt das Meer in breiten Fluessen Am tiefen Grund der Felsen auf, Und\n"
+			+ "Fels und Meer wird fortgerissen Im ewig schnellem Sphaerenlauf.\n"
+			+ "MICHAEL: Und Stuerme brausen um die Wette Vom Meer aufs Land, vom Land\n"
+			+ "aufs Meer, und bilden wuetend eine Kette Der tiefsten Wirkung rings umher.\n"
+			+ "Da flammt ein blitzendes Verheeren Dem Pfade vor des Donnerschlags. Doch\n"
+			+ "deine Boten, Herr, verehren Das sanfte Wandeln deines Tags.\n"
+			+ "ZU DREI: Der Anblick gibt den Engeln Staerke, Da keiner dich ergruenden\n"
+			+ "mag, Und alle deine hohen Werke Sind herrlich wie am ersten Tag.\n"
+			+ "MEPHISTOPHELES: Da du, o Herr, dich einmal wieder nahst Und fragst, wie\n"
+			+ "alles sich bei uns befinde, Und du mich sonst gewoehnlich gerne sahst, So\n"
+			+ "siehst du mich auch unter dem Gesinde. Verzeih, ich kann nicht hohe Worte\n"
+			+ "machen, Und wenn mich auch der ganze Kreis verhoehnt; Mein Pathos braechte\n"
+			+ "dich gewiss zum Lachen, Haettst du dir nicht das Lachen abgewoehnt. Von\n"
+			+ "Sonn' und Welten weiss ich nichts zu sagen, Ich sehe nur, wie sich die\n"
+			+ "Menschen plagen. Der kleine Gott der Welt bleibt stets von gleichem\n"
+			+ "Schlag, Und ist so wunderlich als wie am ersten Tag. Ein wenig besser\n"
+			+ "wuerd er leben, Haettst du ihm nicht den Schein des Himmelslichts gegeben;\n"
+			+ "Er nennt's Vernunft und braucht's allein, Nur tierischer als jedes Tier\n"
+			+ "zu sein. Er scheint mir, mit Verlaub von euer Gnaden, Wie eine der\n"
+			+ "langbeinigen Zikaden, Die immer fliegt und fliegend springt Und gleich im\n"
+			+ "Gras ihr altes Liedchen singt; Und laeg er nur noch immer in dem Grase! In\n"
+			+ "jeden Quark begraebt er seine Nase.\n"
+			+ "DER HERR: Hast du mir weiter nichts zu sagen? Kommst du nur immer\n"
+			+ "anzuklagen? Ist auf der Erde ewig dir nichts recht?\n"
+			+ "MEPHISTOPHELES: Nein Herr! ich find es dort, wie immer, herzlich\n"
+			+ "schlecht. Die Menschen dauern mich in ihren Jammertagen, Ich mag sogar\n"
+			+ "die armen selbst nicht plagen.\n" + "DER HERR: Kennst du den Faust?\n" + "MEPHISTOPHELES: Den Doktor?\n"
+			+ "DER HERR: Meinen Knecht!\n"
+			+ "MEPHISTOPHELES: Fuerwahr! er dient Euch auf besondre Weise. Nicht irdisch\n"
+			+ "ist des Toren Trank noch Speise. Ihn treibt die Gaerung in die Ferne, Er\n"
+			+ "ist sich seiner Tollheit halb bewusst; Vom Himmel fordert er die schoensten\n"
+			+ "Sterne Und von der Erde jede hoechste Lust, Und alle Naeh und alle Ferne\n"
+			+ "Befriedigt nicht die tiefbewegte Brust.\n"
+			+ "DER HERR: Wenn er mir auch nur verworren dient, So werd ich ihn bald in\n"
+			+ "die Klarheit fuehren. Weiss doch der Gaertner, wenn das Baeumchen gruent, Das\n"
+			+ "Bluet und Frucht die kuenft'gen Jahre zieren.\n"
+			+ "MEPHISTOPHELES: Was wettet Ihr? den sollt Ihr noch verlieren! Wenn Ihr\n"
+			+ "mir die Erlaubnis gebt, Ihn meine Strasse sacht zu fuehren.\n"
+			+ "DER HERR: Solang er auf der Erde lebt, So lange sei dir's nicht verboten,\n"
+			+ "Es irrt der Mensch so lang er strebt.\n"
+			+ "MEPHISTOPHELES: Da dank ich Euch; denn mit den Toten Hab ich mich niemals\n"
+			+ "gern befangen. Am meisten lieb ich mir die vollen, frischen Wangen. Fuer\n"
+			+ "einem Leichnam bin ich nicht zu Haus; Mir geht es wie der Katze mit der Maus.\n"
+			+ "DER HERR: Nun gut, es sei dir ueberlassen! Zieh diesen Geist von seinem\n"
+			+ "Urquell ab, Und fuehr ihn, kannst du ihn erfassen, Auf deinem Wege mit\n"
+			+ "herab, Und steh beschaemt, wenn du bekennen musst: Ein guter Mensch, in\n"
+			+ "seinem dunklen Drange, Ist sich des rechten Weges wohl bewusst.\n"
+			+ "MEPHISTOPHELES: Schon gut! nur dauert es nicht lange. Mir ist fuer meine\n"
+			+ "Wette gar nicht bange. Wenn ich zu meinem Zweck gelange, Erlaubt Ihr mir\n"
+			+ "Triumph aus voller Brust. Staub soll er fressen, und mit Lust, Wie meine\n"
+			+ "Muhme, die beruehmte Schlange.\n"
+			+ "DER HERR: Du darfst auch da nur frei erscheinen; Ich habe deinesgleichen\n"
+			+ "nie gehasst. Von allen Geistern, die verneinen, ist mir der Schalk am\n"
+			+ "wenigsten zur Last. Des Menschen Taetigkeit kann allzu leicht erschlaffen,\n"
+			+ "er liebt sich bald die unbedingte Ruh; Drum geb ich gern ihm den Gesellen\n"
+			+ "zu, Der reizt und wirkt und muss als Teufel schaffen. Doch ihr, die echten\n"
+			+ "Goettersoehne, Erfreut euch der lebendig reichen Schoene! Das Werdende, das\n"
+			+ "ewig wirkt und lebt, Umfass euch mit der Liebe holden Schranken, Und was\n"
+			+ "in schwankender Erscheinung schwebt, Befestigt mit dauernden Gedanken!\n"
+			+ "(Der Himmel schliesst, die Erzengel verteilen sich.)\n"
+			+ "MEPHISTOPHELES (allein): Von Zeit zu Zeit seh ich den Alten gern, Und\n"
+			+ "huete mich, mit ihm zu brechen. Es ist gar huebsch von einem grossen Herrn,\n"
+			+ "So menschlich mit dem Teufel selbst zu sprechen.";
+
+	protected static final String COUNTS = "machen 1\n" + "zeit 2\n" + "heerscharen 1\n" + "keiner 2\n" + "meine 3\n"
+			+ "fuehr 1\n" + "triumph 1\n" + "kommst 1\n" + "frei 1\n" + "schaffen 1\n" + "gesinde 1\n"
+			+ "langbeinigen 1\n" + "schalk 1\n" + "besser 1\n" + "solang 1\n" + "meer 4\n" + "fragst 1\n"
+			+ "gabriel 1\n" + "selbst 2\n" + "bin 1\n" + "sich 7\n" + "du 11\n" + "sogar 1\n" + "geht 1\n"
+			+ "immer 4\n" + "mensch 2\n" + "befestigt 1\n" + "lebt 2\n" + "mag 3\n" + "engeln 2\n" + "breiten 1\n"
+			+ "blitzendes 1\n" + "tags 1\n" + "sie 2\n" + "plagen 2\n" + "allzu 1\n" + "meisten 1\n" + "o 1\n"
+			+ "pfade 1\n" + "kennst 1\n" + "nichts 3\n" + "gedanken 1\n" + "befriedigt 1\n" + "mich 6\n" + "s 3\n"
+			+ "es 8\n" + "verneinen 1\n" + "er 13\n" + "gleich 1\n" + "baeumchen 1\n" + "donnergang 1\n"
+			+ "wunderlich 1\n" + "reise 1\n" + "urquell 1\n" + "doch 3\n" + "aufs 2\n" + "toten 1\n" + "niemals 1\n"
+			+ "eine 2\n" + "hab 1\n" + "darfst 1\n" + "da 5\n" + "gen 1\n" + "einem 2\n" + "teil 1\n" + "das 7\n"
+			+ "speise 1\n" + "wenig 1\n" + "sterne 1\n" + "geb 1\n" + "welten 1\n" + "alle 3\n" + "toent 1\n"
+			+ "gras 1\n" + "felsen 1\n" + "kette 1\n" + "ich 14\n" + "fuer 2\n" + "als 3\n" + "mein 1\n"
+			+ "schoene 1\n" + "verzeih 1\n" + "schwankender 1\n" + "wie 9\n" + "menschlich 1\n" + "gaertner 1\n"
+			+ "taetigkeit 1\n" + "bange 1\n" + "liebe 1\n" + "sei 2\n" + "seh 1\n" + "tollheit 1\n" + "am 6\n"
+			+ "michael 1\n" + "geist 1\n" + "ab 1\n" + "nahst 1\n" + "vollendet 1\n" + "liebt 1\n" + "brausen 1\n"
+			+ "nase 1\n" + "erlaubt 1\n" + "weiss 2\n" + "schnellem 1\n" + "deinem 1\n" + "gleichem 1\n"
+			+ "gaerung 1\n" + "dauernden 1\n" + "deines 1\n" + "vorgeschriebne 1\n" + "irdisch 1\n" + "worte 1\n"
+			+ "verehren 1\n" + "hohen 2\n" + "weise 2\n" + "kuenft 1\n" + "werdende 1\n" + "wette 2\n" + "wuetend 1\n"
+			+ "erscheinung 1\n" + "gar 2\n" + "verlieren 1\n" + "braucht 1\n" + "weiter 1\n" + "trank 1\n"
+			+ "tierischer 1\n" + "wohl 1\n" + "verteilen 1\n" + "verhoehnt 1\n" + "schaeumt 1\n" + "himmelslichts 1\n"
+			+ "unbedingte 1\n" + "herzlich 1\n" + "anblick 2\n" + "nennt 1\n" + "gruent 1\n" + "bluet 1\n"
+			+ "leichnam 1\n" + "erschlaffen 1\n" + "jammertagen 1\n" + "zieh 1\n" + "ihm 3\n" + "besondre 1\n"
+			+ "ihn 5\n" + "grossen 1\n" + "vollen 1\n" + "ihr 7\n" + "boten 1\n" + "voller 1\n" + "singt 1\n"
+			+ "muhme 1\n" + "schon 1\n" + "last 1\n" + "kleine 1\n" + "paradieseshelle 1\n" + "nein 1\n" + "echten 1\n"
+			+ "unter 1\n" + "bei 1\n" + "herr 11\n" + "gern 3\n" + "sphaerenlauf 1\n" + "stets 1\n" + "ganze 1\n"
+			+ "braechte 1\n" + "fordert 1\n" + "schoensten 1\n" + "herrlich 2\n" + "gegeben 1\n" + "allein 2\n"
+			+ "reichen 1\n" + "schauervoller 1\n" + "musst 1\n" + "recht 1\n" + "bleibt 1\n" + "pracht 1\n"
+			+ "treibt 1\n" + "befangen 1\n" + "was 2\n" + "menschen 3\n" + "jede 1\n" + "hohe 1\n" + "tiefsten 1\n"
+			+ "bilden 1\n" + "drum 1\n" + "gibt 2\n" + "guter 1\n" + "fuerwahr 1\n" + "im 3\n" + "grund 1\n" + "in 9\n"
+			+ "hoechste 1\n" + "schliesst 1\n" + "fels 1\n" + "steh 1\n" + "euer 1\n" + "erster 1\n" + "ersten 3\n"
+			+ "goettersoehne 1\n" + "brechen 1\n" + "tiefen 1\n" + "frucht 1\n" + "kreis 1\n" + "siehst 1\n"
+			+ "wege 1\n" + "ist 8\n" + "zikaden 1\n" + "frischen 1\n" + "ruh 1\n" + "deine 2\n" + "maus 1\n"
+			+ "brudersphaeren 1\n" + "nachher 1\n" + "euch 4\n" + "gnaden 1\n" + "anzuklagen 1\n" + "schlange 1\n"
+			+ "staerke 2\n" + "erde 4\n" + "verlaub 1\n" + "sanfte 1\n" + "holden 1\n" + "sonst 1\n" + "treten 1\n"
+			+ "sahst 1\n" + "alten 1\n" + "um 1\n" + "wieder 1\n" + "alter 1\n" + "altes 1\n" + "nun 1\n" + "lieb 1\n"
+			+ "gesellen 1\n" + "erscheinen 1\n" + "wirkt 2\n" + "haettst 2\n" + "nur 7\n" + "tiefbewegte 1\n"
+			+ "lachen 2\n" + "drange 1\n" + "schlag 1\n" + "schein 1\n" + "muss 1\n" + "verworren 1\n" + "weges 1\n"
+			+ "allen 1\n" + "gewoehnlich 1\n" + "alles 1\n" + "halb 1\n" + "stuerme 1\n" + "springt 1\n" + "sollt 1\n"
+			+ "klarheit 1\n" + "so 6\n" + "erfassen 1\n" + "liedchen 1\n" + "prolog 1\n" + "zur 1\n" + "fressen 1\n"
+			+ "zum 1\n" + "faust 2\n" + "erzengel 2\n" + "jahre 1\n" + "sonn 1\n" + "raphael 1\n" + "land 2\n"
+			+ "lang 1\n" + "gelange 1\n" + "lust 2\n" + "welt 1\n" + "sehe 1\n" + "ihre 1\n" + "jedes 1\n"
+			+ "erfreut 1\n" + "seiner 1\n" + "denn 1\n" + "wandeln 1\n" + "wechselt 1\n" + "jeden 1\n" + "dort 1\n"
+			+ "schlecht 1\n" + "wenigsten 1\n" + "wuerd 1\n" + "schranken 1\n" + "bewusst 2\n" + "seinem 2\n"
+			+ "gehasst 1\n" + "sein 1\n" + "meinem 1\n" + "meinen 1\n" + "pathos 1\n" + "herrn 1\n" + "lange 2\n"
+			+ "herab 1\n" + "diesen 1\n" + "ihren 1\n" + "beruehmte 1\n" + "goethe 1\n" + "tag 3\n" + "tier 1\n"
+			+ "quark 1\n" + "dank 1\n" + "seine 1\n" + "teufel 2\n" + "zweck 1\n" + "wenn 7\n" + "soll 1\n"
+			+ "wirkung 1\n" + "erlaubnis 1\n" + "lebendig 1\n" + "uns 1\n" + "leicht 1\n" + "gewiss 1\n"
+			+ "schnell 1\n" + "und 29\n" + "gerne 1\n" + "rechten 1\n" + "umher 2\n" + "vernunft 1\n" + "grase 1\n"
+			+ "nach 1\n" + "leben 1\n" + "gott 1\n" + "der 29\n" + "des 5\n" + "doktor 1\n" + "beschaemt 1\n"
+			+ "dreht 1\n" + "habe 1\n" + "sagen 2\n" + "bekennen 1\n" + "dunklen 1\n" + "wettet 1\n" + "den 9\n"
+			+ "mephistopheles 9\n" + "dem 4\n" + "auch 4\n" + "kann 2\n" + "armen 1\n" + "mir 9\n" + "strebt 1\n"
+			+ "gut 2\n" + "mit 11\n" + "bald 2\n" + "himmlischen 1\n" + "himmel 3\n" + "noch 3\n" + "kannst 1\n"
+			+ "deinesgleichen 1\n" + "flammt 1\n" + "ergruenden 2\n" + "nacht 1\n" + "scheint 1\n" + "ferne 2\n"
+			+ "tragoedie 1\n" + "abgewoehnt 1\n" + "reizt 1\n" + "geistern 1\n" + "nicht 10\n" + "sacht 1\n"
+			+ "unbegreiflich 2\n" + "schnelle 1\n" + "einmal 1\n" + "werd 1\n" + "werke 2\n" + "begraebt 1\n"
+			+ "knecht 1\n" + "rings 1\n" + "wird 1\n" + "katze 1\n" + "huete 1\n" + "fortgerissen 1\n" + "gebt 1\n"
+			+ "huebsch 1\n" + "hast 1\n" + "irrt 1\n" + "befinde 1\n" + "sind 2\n" + "fuehren 2\n" + "fliegt 1\n"
+			+ "ewig 3\n" + "brust 2\n" + "sonne 1\n" + "sprechen 1\n" + "ein 3\n" + "strasse 1\n" + "von 8\n"
+			+ "ueberlassen 1\n" + "dir 4\n" + "vom 3\n" + "zu 11\n" + "schwebt 1\n" + "die 22\n" + "vor 2\n"
+			+ "wangen 1\n" + "wettgesang 1\n" + "donnerschlags 1\n" + "find 1\n" + "dich 3\n" + "umfass 1\n"
+			+ "verboten 1\n" + "laeg 1\n" + "nie 1\n" + "drei 2\n" + "dauern 1\n" + "toren 1\n" + "dauert 1\n"
+			+ "verheeren 1\n" + "fliegend 1\n" + "aus 1\n" + "staub 1\n" + "fluessen 1\n" + "haus 1\n" + "auf 5\n"
+			+ "dient 2\n" + "tiefer 1\n" + "naeh 1\n" + "zieren 1\n";
+
+	protected String textPath;
+	protected String resultPath;
+
+	
+	public WordCountClassicITCase(Configuration config) {
+		super(config);
+	}
+
+	
+	@Override
+	protected void preSubmit() throws Exception {
+		textPath = createTempFile("text.txt", TEXT);
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected Plan getPactPlan() {
+		WordCountClassic wc = new WordCountClassic();
+		return wc.getPlan(config.getString("WordCountTest#NumSubtasks", "1"),
+				textPath, resultPath);
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		// Test results
+		compareResultsByLinesInMemory(COUNTS, resultPath);
+	}
+
+	@Parameters
+	public static Collection<Object[]> getConfigurations() {
+		Configuration config = new Configuration();
+		config.setInteger("WordCountTest#NumSubtasks", 4);
+		return toParameterList(config);
+	}
+}

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/mergeOnlyJoin/MergeOnlyJoin.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/mergeOnlyJoin/MergeOnlyJoin.java
@@ -70,7 +70,7 @@ public class MergeOnlyJoin implements PlanAssembler, PlanAssemblerDescription {
 		int numSubtasksInput2 = (args.length > 4 ? Integer.parseInt(args[4]) : 1);
 
 		// create DataSourceContract for Orders input
-		FileDataSource input1 = new FileDataSource(RecordInputFormat.class, input1Path, "Input 1");
+		FileDataSource input1 = new FileDataSource(new RecordInputFormat(), input1Path, "Input 1");
 		input1.setDegreeOfParallelism(numSubtasks);
 		RecordInputFormat.configureRecordFormat(input1)
 			.recordDelimiter('\n')
@@ -78,7 +78,7 @@ public class MergeOnlyJoin implements PlanAssembler, PlanAssemblerDescription {
 			.field(DecimalTextIntParser.class, 0)
 			.field(DecimalTextIntParser.class, 1);
 		
-		ReduceContract aggInput1 = new ReduceContract.Builder(DummyReduce.class, PactInteger.class, 0)
+		ReduceContract aggInput1 = ReduceContract.builder(DummyReduce.class, PactInteger.class, 0)
 			.input(input1)
 			.name("AggOrders")
 			.build();
@@ -86,7 +86,7 @@ public class MergeOnlyJoin implements PlanAssembler, PlanAssemblerDescription {
 
 		
 		// create DataSourceContract for Orders input
-		FileDataSource input2 = new FileDataSource(RecordInputFormat.class, input2Path, "Input 2");
+		FileDataSource input2 = new FileDataSource(new RecordInputFormat(), input2Path, "Input 2");
 		input2.setDegreeOfParallelism(numSubtasksInput2);
 		RecordInputFormat.configureRecordFormat(input2)
 			.recordDelimiter('\n')
@@ -94,7 +94,7 @@ public class MergeOnlyJoin implements PlanAssembler, PlanAssemblerDescription {
 			.field(DecimalTextIntParser.class, 0)
 			.field(DecimalTextIntParser.class, 1);
 
-		ReduceContract aggInput2 = new ReduceContract.Builder(DummyReduce.class, PactInteger.class, 0)
+		ReduceContract aggInput2 = ReduceContract.builder(DummyReduce.class, PactInteger.class, 0)
 			.input(input2)
 			.name("AggLines")
 			.build();
@@ -109,7 +109,7 @@ public class MergeOnlyJoin implements PlanAssembler, PlanAssemblerDescription {
 		joinLiO.setDegreeOfParallelism(numSubtasks);
 
 		// create DataSinkContract for writing the result
-		FileDataSink result = new FileDataSink(RecordOutputFormat.class, output, joinLiO, "Output");
+		FileDataSink result = new FileDataSink(new RecordOutputFormat(), output, joinLiO, "Output");
 		result.setDegreeOfParallelism(numSubtasks);
 		RecordOutputFormat.configureRecordFormat(result)
 			.recordDelimiter('\n')

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch1/TPCHQuery1.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch1/TPCHQuery1.java
@@ -61,21 +61,21 @@ public class TPCHQuery1 implements PlanAssembler, PlanAssemblerDescription {
 		}
 		
 		FileDataSource lineItems =
-			new FileDataSource(IntTupleDataInFormat.class, this.lineItemInputPath, "LineItems");
+			new FileDataSource(new IntTupleDataInFormat(), this.lineItemInputPath, "LineItems");
 		lineItems.setDegreeOfParallelism(this.degreeOfParallelism);
 		
 		FileDataSink result = 
-			new FileDataSink(StringTupleDataOutFormat.class, this.outputPath, "Output");
+			new FileDataSink(new StringTupleDataOutFormat(), this.outputPath, "Output");
 		result.setDegreeOfParallelism(this.degreeOfParallelism);
 		
 		MapContract lineItemFilter = 
-			MapContract.builder(LineItemFilter.class)
+			MapContract.builder(new LineItemFilter())
 			.name("LineItem Filter")
 			.build();
 		lineItemFilter.setDegreeOfParallelism(this.degreeOfParallelism);
 		
 		ReduceContract groupByReturnFlag = 
-			new ReduceContract.Builder(GroupByReturnFlag.class, PactString.class, 0)
+			ReduceContract.builder(new GroupByReturnFlag(), PactString.class, 0)
 			.name("groupyBy")
 			.build();
 		

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch10/TPCHQuery10.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch10/TPCHQuery10.java
@@ -226,8 +226,9 @@ public class TPCHQuery10 implements PlanAssembler, PlanAssemblerDescription
 		}
 	}
 
-	public static class TupleOutputFormat extends FileOutputFormat
-	{
+	public static class TupleOutputFormat extends FileOutputFormat {
+		private static final long serialVersionUID = 1L;
+		
 		private final DecimalFormat formatter;
 		private final StringBuilder buffer = new StringBuilder();
 		
@@ -299,22 +300,22 @@ public class TPCHQuery10 implements PlanAssembler, PlanAssemblerDescription
 			resultPath = args[5];
 		}
 		
-		FileDataSource orders = new FileDataSource(IntTupleDataInFormat.class, ordersPath, "Orders");
+		FileDataSource orders = new FileDataSource(new IntTupleDataInFormat(), ordersPath, "Orders");
 		orders.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		orders.setDegreeOfParallelism(degreeOfParallelism);
 		// orders.setOutputContract(UniqueKey.class);
 		// orders.getCompilerHints().setAvgNumValuesPerKey(1);
 
-		FileDataSource lineitems = new FileDataSource(IntTupleDataInFormat.class, lineitemsPath, "LineItems");
+		FileDataSource lineitems = new FileDataSource(new IntTupleDataInFormat(), lineitemsPath, "LineItems");
 		lineitems.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		lineitems.setDegreeOfParallelism(degreeOfParallelism);
 		// lineitems.getCompilerHints().setAvgNumValuesPerKey(4);
 
-		FileDataSource customers = new FileDataSource(IntTupleDataInFormat.class, customersPath, "Customers");
+		FileDataSource customers = new FileDataSource(new IntTupleDataInFormat(), customersPath, "Customers");
 		customers.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		customers.setDegreeOfParallelism(degreeOfParallelism);
 
-		FileDataSource nations = new FileDataSource(IntTupleDataInFormat.class, nationsPath, "Nations");
+		FileDataSource nations = new FileDataSource(new IntTupleDataInFormat(), nationsPath, "Nations");
 		nations.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		nations.setDegreeOfParallelism(degreeOfParallelism);
 
@@ -365,7 +366,7 @@ public class TPCHQuery10 implements PlanAssembler, PlanAssemblerDescription
 			.build();
 		reduce.setDegreeOfParallelism(degreeOfParallelism);
 
-		FileDataSink result = new FileDataSink(TupleOutputFormat.class, resultPath, "Output");
+		FileDataSink result = new FileDataSink(new TupleOutputFormat(), resultPath, "Output");
 		result.setDegreeOfParallelism(degreeOfParallelism);
 
 		result.setInput(reduce);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch3Unioned/TPCHQuery3Unioned.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch3Unioned/TPCHQuery3Unioned.java
@@ -73,7 +73,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 		String output        = (args.length > 6 ? args[6] : "");
 
 		// create DataSourceContract for Orders input
-		FileDataSource orders1 = new FileDataSource(RecordInputFormat.class, orders1Path, "Orders 1");
+		FileDataSource orders1 = new FileDataSource(new RecordInputFormat(), orders1Path, "Orders 1");
 		RecordInputFormat.configureRecordFormat(orders1)
 			.recordDelimiter('\n')
 			.fieldDelimiter('|')
@@ -83,7 +83,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 			.field(VarLengthStringParser.class, 4, 10)	// order date
 			.field(VarLengthStringParser.class, 5, 8);	// order prio
 		
-		FileDataSource orders2 = new FileDataSource(RecordInputFormat.class, orders2Path, "Orders 2");
+		FileDataSource orders2 = new FileDataSource(new RecordInputFormat(), orders2Path, "Orders 2");
 		RecordInputFormat.configureRecordFormat(orders2)
 			.recordDelimiter('\n')
 			.fieldDelimiter('|')
@@ -94,7 +94,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 			.field(VarLengthStringParser.class, 5, 8);	// order prio
 		
 		// create DataSourceContract for LineItems input
-		FileDataSource lineitems = new FileDataSource(RecordInputFormat.class, lineitemsPath, "LineItems");
+		FileDataSource lineitems = new FileDataSource(new RecordInputFormat(), lineitemsPath, "LineItems");
 		RecordInputFormat.configureRecordFormat(lineitems)
 			.recordDelimiter('\n')
 			.fieldDelimiter('|')
@@ -102,7 +102,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 			.field(DecimalTextDoubleParser.class, 5);
 
 		// create MapContract for filtering Orders tuples
-		MapContract filterO1 = MapContract.builder(FilterO.class)
+		MapContract filterO1 = MapContract.builder(new FilterO())
 			.name("FilterO")
 			.input(orders1)
 			.build();
@@ -112,7 +112,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 		filterO1.getCompilerHints().setAvgRecordsEmittedPerStubCall(0.05f);
 		
 		// create MapContract for filtering Orders tuples
-		MapContract filterO2 = MapContract.builder(FilterO.class)
+		MapContract filterO2 = MapContract.builder(new FilterO())
 			.name("FilterO")
 			.input(orders2)
 			.build();
@@ -122,13 +122,13 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 		filterO2.getCompilerHints().setAvgRecordsEmittedPerStubCall(1.0f);
 
 		// create MatchContract for joining Orders and LineItems
-		MatchContract joinLiO = MatchContract.builder(JoinLiO.class, PactLong.class, 0, 0)
+		MatchContract joinLiO = MatchContract.builder(new JoinLiO(), PactLong.class, 0, 0)
 			.input1(filterO2, filterO1)
 			.input2(lineitems)
 			.name("JoinLiO")
 			.build();
 		
-		FileDataSource partJoin1 = new FileDataSource(RecordInputFormat.class, partJoin1Path, "Part Join 1");
+		FileDataSource partJoin1 = new FileDataSource(new RecordInputFormat(), partJoin1Path, "Part Join 1");
 		RecordInputFormat.configureRecordFormat(partJoin1)
 			.recordDelimiter('\n')
 			.fieldDelimiter('|')
@@ -136,7 +136,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 			.field(DecimalTextIntParser.class, 1)
 			.field(DecimalTextDoubleParser.class, 2);
 		
-		FileDataSource partJoin2 = new FileDataSource(RecordInputFormat.class, partJoin2Path, "Part Join 2");
+		FileDataSource partJoin2 = new FileDataSource(new RecordInputFormat(), partJoin2Path, "Part Join 2");
 		RecordInputFormat.configureRecordFormat(partJoin2)
 			.recordDelimiter('\n')
 			.fieldDelimiter('|')
@@ -146,7 +146,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 		
 		// create ReduceContract for aggregating the result
 		// the reducer has a composite key, consisting of the fields 0 and 1
-		ReduceContract aggLiO = ReduceContract.builder(AggLiO.class)
+		ReduceContract aggLiO = ReduceContract.builder(new AggLiO())
 			.keyField(PactLong.class, 0)
 			.keyField(PactString.class, 1)
 			.input(joinLiO, partJoin2, partJoin1)
@@ -154,7 +154,7 @@ public class TPCHQuery3Unioned implements PlanAssembler, PlanAssemblerDescriptio
 			.build();
 
 		// create DataSinkContract for writing the result
-		FileDataSink result = new FileDataSink(RecordOutputFormat.class, output, aggLiO, "Output");
+		FileDataSink result = new FileDataSink(new RecordOutputFormat(), output, aggLiO, "Output");
 		RecordOutputFormat.configureRecordFormat(result)
 			.recordDelimiter('\n')
 			.fieldDelimiter('|')

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch4/TPCHQuery4.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch4/TPCHQuery4.java
@@ -224,16 +224,16 @@ public class TPCHQuery4 implements PlanAssembler, PlanAssemblerDescription {
 		}
 		
 		FileDataSource orders = 
-			new FileDataSource(IntTupleDataInFormat.class, this.ordersInputPath, "Orders");
+			new FileDataSource(new IntTupleDataInFormat(), this.ordersInputPath, "Orders");
 		orders.setDegreeOfParallelism(this.degreeOfParallelism);
 		//orders.setOutputContract(UniqueKey.class);
 		
 		FileDataSource lineItems =
-			new FileDataSource(IntTupleDataInFormat.class, this.lineItemInputPath, "LineItems");
+			new FileDataSource(new IntTupleDataInFormat(), this.lineItemInputPath, "LineItems");
 		lineItems.setDegreeOfParallelism(this.degreeOfParallelism);
 		
 		FileDataSink result = 
-				new FileDataSink(StringTupleDataOutFormat.class, this.outputPath, "Output");
+				new FileDataSink(new StringTupleDataOutFormat(), this.outputPath, "Output");
 		result.setDegreeOfParallelism(degreeOfParallelism);
 		
 		MapContract lineFilter = 
@@ -255,7 +255,7 @@ public class TPCHQuery4 implements PlanAssembler, PlanAssemblerDescription {
 			join.setDegreeOfParallelism(degreeOfParallelism);
 		
 		ReduceContract aggregation = 
-				new ReduceContract.Builder(CountAgg.class, PactString.class, 0)
+				ReduceContract.builder(CountAgg.class, PactString.class, 0)
 			.name("AggregateGroupBy")
 			.build();
 		aggregation.setDegreeOfParallelism(this.degreeOfParallelism);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/IntPair.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/IntPair.java
@@ -19,6 +19,8 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
 import eu.stratosphere.pact.common.type.base.PactPair;
 
 public class IntPair extends PactPair<PactInteger, PactInteger> {
+	private static final long serialVersionUID = 1L;
+	
 	public IntPair() {
 	}
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/StringIntPair.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/StringIntPair.java
@@ -18,6 +18,8 @@ package eu.stratosphere.pact.test.testPrograms.tpch9;
 import eu.stratosphere.pact.common.type.base.*;
 
 public class StringIntPair extends PactPair<PactString, PactInteger> {
+	private static final long serialVersionUID = 1L;
+	
 	public StringIntPair() {
 	}
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/StringIntPairStringDataOutFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/StringIntPairStringDataOutFormat.java
@@ -23,6 +23,7 @@ import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactString;
 
 public class StringIntPairStringDataOutFormat extends FileOutputFormat {
+	private static final long serialVersionUID = 1L;
 
 	private final StringBuilder buffer = new StringBuilder();
 	private StringIntPair key = new StringIntPair();

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/TPCHQuery9.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/tpch9/TPCHQuery9.java
@@ -110,7 +110,7 @@ public class TPCHQuery9 implements PlanAssembler, PlanAssemblerDescription {
 		/* Create the 6 data sources: */
 		/* part: (partkey | name, mfgr, brand, type, size, container, retailprice, comment) */
 		FileDataSource partInput = new FileDataSource(
-			IntTupleDataInFormat.class, this.partInputPath, "\"part\" source");
+			new IntTupleDataInFormat(), this.partInputPath, "\"part\" source");
 		partInput.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		partInput.setDegreeOfParallelism(this.degreeOfParallelism);
 		//partInput.setOutputContract(UniqueKey.class);
@@ -118,13 +118,13 @@ public class TPCHQuery9 implements PlanAssembler, PlanAssemblerDescription {
 
 		/* partsupp: (partkey | suppkey, availqty, supplycost, comment) */
 		FileDataSource partSuppInput = new FileDataSource(
-			IntTupleDataInFormat.class, this.partSuppInputPath, "\"partsupp\" source");
+			new IntTupleDataInFormat(), this.partSuppInputPath, "\"partsupp\" source");
 		partSuppInput.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		partSuppInput.setDegreeOfParallelism(this.degreeOfParallelism);
 
 		/* orders: (orderkey | custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment) */
 		FileDataSource ordersInput = new FileDataSource(
-			IntTupleDataInFormat.class, this.ordersInputPath, "\"orders\" source");
+			new IntTupleDataInFormat(), this.ordersInputPath, "\"orders\" source");
 		ordersInput.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		ordersInput.setDegreeOfParallelism(this.degreeOfParallelism);
 		//ordersInput.setOutputContract(UniqueKey.class);
@@ -132,13 +132,13 @@ public class TPCHQuery9 implements PlanAssembler, PlanAssemblerDescription {
 
 		/* lineitem: (orderkey | partkey, suppkey, linenumber, quantity, extendedprice, discount, tax, ...) */
 		FileDataSource lineItemInput = new FileDataSource(
-			IntTupleDataInFormat.class, this.lineItemInputPath, "\"lineitem\" source");
+			new IntTupleDataInFormat(), this.lineItemInputPath, "\"lineitem\" source");
 		lineItemInput.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		lineItemInput.setDegreeOfParallelism(this.degreeOfParallelism);
 
 		/* supplier: (suppkey | name, address, nationkey, phone, acctbal, comment) */
 		FileDataSource supplierInput = new FileDataSource(
-			IntTupleDataInFormat.class, this.supplierInputPath, "\"supplier\" source");
+			new IntTupleDataInFormat(), this.supplierInputPath, "\"supplier\" source");
 		supplierInput.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		supplierInput.setDegreeOfParallelism(this.degreeOfParallelism);
 		//supplierInput.setOutputContract(UniqueKey.class);
@@ -146,7 +146,7 @@ public class TPCHQuery9 implements PlanAssembler, PlanAssemblerDescription {
 
 		/* nation: (nationkey | name, regionkey, comment) */
 		FileDataSource nationInput = new FileDataSource(
-			IntTupleDataInFormat.class, this.nationInputPath, "\"nation\" source");
+			new IntTupleDataInFormat(), this.nationInputPath, "\"nation\" source");
 		nationInput.setParameter(TextInputFormat.RECORD_DELIMITER, "\n");
 		nationInput.setDegreeOfParallelism(this.degreeOfParallelism);
 		//nationInput.setOutputContract(UniqueKey.class);
@@ -247,7 +247,7 @@ public class TPCHQuery9 implements PlanAssembler, PlanAssemblerDescription {
 
 		/* Connect sink: */
 		FileDataSink result = new FileDataSink(
-				StringIntPairStringDataOutFormat.class, this.outputPath, "Results sink");
+				new StringIntPairStringDataOutFormat(), this.outputPath, "Results sink");
 		result.setDegreeOfParallelism(this.degreeOfParallelism);
 		result.addInput(sumAmountAggregate);
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/DiscardingOutputFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/DiscardingOutputFormat.java
@@ -24,8 +24,9 @@ import eu.stratosphere.pact.generic.io.OutputFormat;
 /**
  * A simple output format that discards all data by doing nothing.
  */
-public class DiscardingOutputFormat implements OutputFormat<PactRecord>
-{
+public class DiscardingOutputFormat implements OutputFormat<PactRecord> {
+	private static final long serialVersionUID = 1L;
+	
 	/* (non-Javadoc)
 	 * @see eu.stratosphere.pact.common.generic.io.OutputFormat#configure(eu.stratosphere.nephele.configuration.Configuration)
 	 */

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/InfiniteIntegerInputFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/InfiniteIntegerInputFormat.java
@@ -24,8 +24,9 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
 /**
  * 
  */
-public class InfiniteIntegerInputFormat extends GenericInputFormat
-{
+public class InfiniteIntegerInputFormat extends GenericInputFormat {
+	private static final long serialVersionUID = 1L;
+	
 	private final PactInteger one = new PactInteger(1);
 	
 	/* (non-Javadoc)

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/InfiniteIntegerInputFormatWithDelay.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/InfiniteIntegerInputFormatWithDelay.java
@@ -24,8 +24,9 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
 /**
  * 
  */
-public class InfiniteIntegerInputFormatWithDelay extends GenericInputFormat
-{
+public class InfiniteIntegerInputFormatWithDelay extends GenericInputFormat {
+	private static final long serialVersionUID = 1L;
+	
 	private static final int DELAY = 20;
 	
 	private final PactInteger one = new PactInteger(1);

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/IntTupleDataInFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/IntTupleDataInFormat.java
@@ -20,6 +20,7 @@ import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactInteger;
 
 public class IntTupleDataInFormat extends DelimitedInputFormat {
+	private static final long serialVersionUID = 1L;
 
 	public static final int MAX_COLUMNS = 20;
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/StringTupleDataOutFormat.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/StringTupleDataOutFormat.java
@@ -20,6 +20,7 @@ import eu.stratosphere.pact.common.type.PactRecord;
 import eu.stratosphere.pact.common.type.base.PactString;
 
 public class StringTupleDataOutFormat extends DelimitedOutputFormat {
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public int serializeRecord(PactRecord rec, byte[] target) throws Exception {

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/Tuple.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/Tuple.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import eu.stratosphere.pact.common.type.Value;
 
 public class Tuple implements Value {
+	private static final long serialVersionUID = 1L;
 
 	private byte[] bytes;
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/UniformIntInput.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/testPrograms/util/UniformIntInput.java
@@ -25,8 +25,9 @@ import eu.stratosphere.pact.common.type.base.PactInteger;
 /**
  * 
  */
-public class UniformIntInput extends GenericInputFormat
-{
+public class UniformIntInput extends GenericInputFormat {
+	private static final long serialVersionUID = 1L;
+	
 	public static final String NUM_KEYS_KEY = "testfomat.numkeys";
 	public static final String NUM_VALUES_KEY = "testfomat.numvalues";
 	


### PR DESCRIPTION
Hi Everyone,
I'm opening this pull request to start a discussion on this new feature. I changed the whole stratosphere stack to use objects instead of classes to pass usercode (i.e. Stubs) around. This means that one now uses
MapContract mapper = MapContract.builder(new TokenizeLine())
            .input(source)
            .name("Tokenize Lines")
            .build();
instead of
MapContract mapper = MapContract.builder(TokenizeLine.class)
            .input(source)
            .name("Tokenize Lines")
            .build();

The initial motivation for this is that I require it for the scala-frontend. I cannot generate classes that would be instantiable by the stratosphere runtime so I need to pass objects to the PACTs. I noticed though that this could also make regular java usercode more concise. The Configuration would not be necessary any more because one can just store the configuration in the stub object and for example have a stub with a constructor where you pass in stuff, i.e.:
MapContract mapper = MapContract.builder(new TokenizeLine("<some-line-ending>"))
            .input(source)
            .name("Tokenize Lines")
            .build();
The line ending would then be stored in the stub, the runtime serializes everything and then when the job is run the runtime deserializes the job and the information is available in every instance of the stub.

On thing that is affected by the change is that all usercode stubs now must be serializable. For this I made base class Stub "Serializable" and also other things such as Value and the derived classes.

Now, discuss away... :D

Aljoscha

P.S. We could then also have
        FileDataSource source = new FileDataSource(new TextInputFormat("ASCII"), dataInput, "Input Lines");
instead of
    FileDataSource source = new FileDataSource(TextInputFormat.class, dataInput, "Input Lines");
    source.setParameter(TextInputFormat.CHARSET_NAME, "ASCII");
