### PR TITLE
Fix wrong inputSplits with big BinaryInputsFiles

### DIFF
--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryInputFormat.java
@@ -112,7 +112,7 @@ public abstract class BinaryInputFormat<T extends Record> extends FileInputForma
 			}
 		}
 
-		if (files.size() < minNumSplits) {
+		if (inputSplits.size() < minNumSplits) {
 			LOG.warn(String.format(
 				"With the given block size %d, the file %s cannot be split into %d blocks. Filling up with empty splits...",
 				blockSize, this.filePath, minNumSplits));

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/BinaryInputFormat.java
@@ -117,7 +117,7 @@ public abstract class BinaryInputFormat<T extends Record> extends FileInputForma
 				"With the given block size %d, the file %s cannot be split into %d blocks. Filling up with empty splits...",
 				blockSize, this.filePath, minNumSplits));
 			FileStatus last = files.get(files.size() - 1);
-			final BlockLocation[] blocks = fs.getFileBlockLocations(last, last.getLen(), 0);
+			final BlockLocation[] blocks = fs.getFileBlockLocations(last, 0, last.getLen());
 			for (int index = files.size(); index < minNumSplits; index++)
 				inputSplits.add(new FileInputSplit(index, last.getPath(), last.getLen(), 0, blocks[0].getHosts()));
 		}

--- a/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/BinaryInputFormatTest.java
+++ b/pact/pact-common/src/test/java/eu/stratosphere/pact/generic/io/BinaryInputFormatTest.java
@@ -1,0 +1,49 @@
+package eu.stratosphere.pact.generic.io;
+
+import java.io.DataInput;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import eu.stratosphere.nephele.configuration.Configuration;
+import eu.stratosphere.nephele.fs.FileInputSplit;
+import eu.stratosphere.pact.common.type.PactRecord;
+
+public class BinaryInputFormatTest {
+	
+	private static final class MyBinaryInputFormat extends BinaryInputFormat<PactRecord> {
+		@Override
+		protected void deserialize(PactRecord record, DataInput dataInput) throws IOException {}
+	}
+
+	@Test
+	public void testCreateInputSplitsWithOneFile() throws IOException {
+		// create temporary file with 3 blocks
+		final File tempFile = File.createTempFile("binary_input_format_test", "tmp");
+		tempFile.deleteOnExit();
+		final int blockInfoSize = new BlockInfo().getInfoSize();
+		final int blockSize = blockInfoSize + 8;
+		final int numBlocks = 3;
+		FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+		for(int i = 0; i < blockSize * numBlocks; i++)
+			fileOutputStream.write(new byte[]{1});
+		fileOutputStream.close();
+
+		final Configuration config = new Configuration();
+		config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
+		config.setString(BinaryInputFormat.FILE_PARAMETER_KEY, tempFile.toURI().toString());
+		final BinaryInputFormat<PactRecord> inputFormat = new MyBinaryInputFormat();
+		inputFormat.configure(config);
+		
+		FileInputSplit[] inputSplits = inputFormat.createInputSplits(numBlocks);
+		
+		Assert.assertEquals("Returns requested numbers of splits.", numBlocks, inputSplits.length);
+		Assert.assertEquals("1. split has block size length.", blockSize, inputSplits[0].getLength());
+		Assert.assertEquals("2. split has block size length.", blockSize, inputSplits[1].getLength());
+		Assert.assertEquals("3. split has block size length.", blockSize, inputSplits[2].getLength());
+	}
+	
+}


### PR DESCRIPTION
Hi Everyone,

i got some trouble using SequentialInputFormat with one big file and found two bugs in BinaryInputFormat.
1. Unnecessary empty input splits are created if more minNumSplits requested than input files are present.
2. This empty splits are created using invalid ranges. HDFS returns an empty block locations array in this case and ends up with an IndexOutOfBoundsException two lines further.

I am not sure how to test the second bug, but attached a test against the first one.

Regards,
Sascha
