### PR TITLE
Pact Compiler: Potential fix for a NullPointerException in SinkJoiner

### DIFF
--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/SingleInputContract.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/SingleInputContract.java
@@ -149,6 +149,9 @@ public abstract class SingleInputContract<T extends Stub> extends AbstractPact<T
 	public void accept(Visitor<Contract> visitor) {
 		if (visitor.preVisit(this)) {
 			for(Contract c : this.input) {
+				if(c == null) {
+					throw new IllegalArgumentException("The contract '"+this.getName()+"' has a illegal input (null)");
+				}
 				c.accept(visitor);
 			}
 			visitor.postVisit(this);

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/SinkJoiner.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/SinkJoiner.java
@@ -76,9 +76,14 @@ public class SinkJoiner extends TwoInputNode {
 		
 		List<UnclosedBranchDescriptor> result1 = new ArrayList<UnclosedBranchDescriptor>();
 		List<UnclosedBranchDescriptor> result2 = new ArrayList<UnclosedBranchDescriptor>();
-		result1.addAll(getFirstPredecessorNode().openBranches);
-		result2.addAll(getSecondPredecessorNode().openBranches);
-
+		
+		if(getFirstPredecessorNode().openBranches != null) {
+			result1.addAll(getFirstPredecessorNode().openBranches);
+		}
+		if(getSecondPredecessorNode().openBranches != null) {
+			result2.addAll(getSecondPredecessorNode().openBranches);
+		}
+		
 		this.openBranches = mergeLists(result1, result2);
 	}
 


### PR DESCRIPTION
I got the following exception during my work on the tlabs usecases.

I'm not sure if this fix is a suitable solution. Since the original plan is quite large, it is not very easy for me to reproduce the bug in a dedicated test case.

```
Exception in thread "main" java.lang.NullPointerException
    at java.util.ArrayList.addAll(ArrayList.java:559)
    at eu.stratosphere.pact.compiler.plan.SinkJoiner.computeUnclosedBranchStack(SinkJoiner.java:81)
    at eu.stratosphere.pact.compiler.PactCompiler$BranchesVisitor.postVisit(PactCompiler.java:1233)
    at eu.stratosphere.pact.compiler.PactCompiler$BranchesVisitor.postVisit(PactCompiler.java:1)
    at eu.stratosphere.pact.compiler.plan.TwoInputNode.accept(TwoInputNode.java:809)
    at eu.stratosphere.pact.compiler.plan.TwoInputNode.accept(TwoInputNode.java:807)
    at eu.stratosphere.pact.compiler.PactCompiler.compile(PactCompiler.java:703)
    at eu.stratosphere.pact.compiler.PactCompiler.compile(PactCompiler.java:547)
    at eu.stratosphere.pact.client.LocalExecutor.executePlan(LocalExecutor.java:79)
```

This PR also contains a little change to show an meaningful exception if a null-input is given into a contract.
