### PR TITLE
Fixed commons-io missing in lib directory + fixed wrong groupId of commons-io

### DIFF
--- a/pact/pact-clients/pom.xml
+++ b/pact/pact-clients/pom.xml
@@ -70,9 +70,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
+			<version>2.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/stratosphere-dist/src/main/assemblies/bin.xml
+++ b/stratosphere-dist/src/main/assemblies/bin.xml
@@ -34,12 +34,7 @@
           The previous command did not work because it also excludes libraries that should be in lib, such as commons-io.
 				-->
         <exclude>commons-fileupload:commons-fileupload</exclude>
-        <exclude>org.eclipse.jetty:jetty-continuation</exclude>
-        <exclude>org.eclipse.jetty:jetty-http</exclude>
-        <exclude>org.eclipse.jetty:jetty-io</exclude>
-        <exclude>org.eclipse.jetty:jetty-security</exclude>
-        <exclude>org.eclipse.jetty:jetty-server</exclude>
-        <exclude>org.eclipse.jetty:jetty-servlet</exclude>
+        <exclude>org.eclipse.jetty:jetty-*</exclude>
 			</excludes>
 		</dependencySet>
 		

--- a/stratosphere-dist/src/main/assemblies/bin.xml
+++ b/stratosphere-dist/src/main/assemblies/bin.xml
@@ -28,7 +28,18 @@
 				<exclude>**/*examples*.jar</exclude>
 				<exclude>**/*javadoc*</exclude>
 				<exclude>**/*sources*</exclude>
-				<exclude>eu.stratosphere:pact-clients:**</exclude>
+<!-- 				<exclude>eu.stratosphere:pact-clients:**</exclude> -->
+				<!--
+				  This is a hardcoded exclude-list containing all libraries that are exclusively used in pact-clients.
+          The previous command did not work because it also excludes libraries that should be in lib, such as commons-io.
+				-->
+        <exclude>commons-fileupload:commons-fileupload</exclude>
+        <exclude>org.eclipse.jetty:jetty-continuation</exclude>
+        <exclude>org.eclipse.jetty:jetty-http</exclude>
+        <exclude>org.eclipse.jetty:jetty-io</exclude>
+        <exclude>org.eclipse.jetty:jetty-security</exclude>
+        <exclude>org.eclipse.jetty:jetty-server</exclude>
+        <exclude>org.eclipse.jetty:jetty-servlet</exclude>
 			</excludes>
 		</dependencySet>
 		


### PR DESCRIPTION
This fixes the bug that commons-io was missing in the lib directory.

Furthermore, a wrong (outdated) groupId for commons-io was specified in pact-clients (the [old pom file](http://repo1.maven.org/maven2/org/apache/commons/commons-io/1.3.2/commons-io-1.3.2.pom) specifies the relocation). I also switched to the commons-io versions that is used by hadoop (2.1).
