### PR TITLE
Fixed nephele-config.sh substr command calls on OS X (closes #88)

### DIFF
--- a/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-config.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-config.sh
@@ -19,7 +19,8 @@
 # but the windows java version expects them in Windows Format, i.e. C:\bla\blub.
 # "cygpath" can do the conversion.
 manglePath() {
-    if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then
+    UNAME=$(uname -s)
+    if [ "${UNAME:0:6}" == "CYGWIN" ]; then
         echo `cygpath -w $1`
     else
         echo $1
@@ -27,8 +28,9 @@ manglePath() {
 }
 
 manglePathList() {
+    UNAME=$(uname -s)
     # a path list, for example a java classpath
-    if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then
+    if [ "${UNAME:0:6}" == "CYGWIN" ]; then
         echo `cygpath -wp $1`
     else
         echo $1
@@ -73,7 +75,8 @@ if [ -z "${JAVA_HOME+x}" ]; then
         JAVA_HOME=/usr/lib/jvm/java-6-sun/
 fi
 
-if [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then
+UNAME=$(uname -s)
+if [ "${UNAME:0:6}" == "CYGWIN" ]; then
     JAVA_RUN=java
 else
     if [[ -d $JAVA_HOME ]]; then


### PR DESCRIPTION
This is issue #88.

On OS X the `expr substr` (sub-)command is not supported. I replaced it with bash's (extended) syntax for string expansions.

If this is not OK an alternative would be to use `uname -s | cut -c1-6`.
