### PR TITLE
Remove TeraSort from examples

### DIFF
--- a/pact/pact-examples/pom.xml
+++ b/pact/pact-examples/pom.xml
@@ -305,7 +305,9 @@
 						</configuration>
 					</execution>
 
-					<!-- TeraSort -->
+					<!-- TeraSort
+					TeraSort is currently not working, because of problems with the RangePartioner (see https://github.com/dimalabs/ozone/issues/7).
+					It should be included again after fixing the issue.
 					<execution>
 						<id>TeraSort</id>
 						<phase>package</phase>
@@ -326,7 +328,7 @@
 								<include>**/sort/terasort/*.class</include>
 							</includes>
 						</configuration>
-					</execution>
+					</execution> -->
 				</executions>
 			</plugin>
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/TeraSort.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/sort/TeraSort.java
@@ -33,7 +33,10 @@ import eu.stratosphere.pact.example.sort.terasort.TeraOutputFormat;
  * input data is the Hadoop TeraGen program. For more details see <a
  * href="http://hadoop.apache.org/common/docs/current/api/org/apache/hadoop/examples/terasort/TeraGen.html">
  * http://hadoop.apache.org/common/docs/current/api/org/apache/hadoop/examples/terasort/TeraGen.html</a>.
- * 
+ *
+ * Note: this example job is currently not included in the build, because of problems with the RangePartioner (see
+ * https://github.com/dimalabs/ozone/issues/7). It should be included again after fixing the issue.
+ *
  * @author warneke
  */
 public final class TeraSort implements PlanAssembler, PlanAssemblerDescription {


### PR DESCRIPTION
The TeraSort job (one of the example jobs) is currently not working, because of some issues with the range partitioner (see issue #7).

I think we shouldn't have it in the build until this is fixed.
