### PR TITLE
AllReducer does not work in iterations with dop>1 (added test case)

### DIFF
--- a/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/ReduceAllTest.java
+++ b/pact/pact-compiler/src/test/java/eu/stratosphere/pact/compiler/ReduceAllTest.java
@@ -15,7 +15,7 @@
 
 package eu.stratosphere.pact.compiler;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -28,10 +28,11 @@ import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
 import eu.stratosphere.pact.compiler.util.DummyInputFormat;
 import eu.stratosphere.pact.compiler.util.DummyOutputFormat;
 import eu.stratosphere.pact.compiler.util.IdentityReduce;
+import eu.stratosphere.pact.generic.contract.BulkIteration;
 
 
 /**
- * This test case has been created to validate a bug that occurred when
+ * This test case has been created to validate bugs that occurred when
  * the ReduceContract was used without a grouping key.
  */
 public class ReduceAllTest extends CompilerTestBase  {
@@ -56,4 +57,34 @@ public class ReduceAllTest extends CompilerTestBase  {
 			fail("The pact compiler is unable to compile this plan correctly");
 		}
 	}
+	
+	@Test
+	public void testAllReduceIterations() {
+		// construct a plan that uses an all reducer inside iterations
+		FileDataSource source = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source");
+
+		BulkIteration iteration = new BulkIteration("Bulk Iteration AllReduce Test");
+		iteration.setMaximumNumberOfIterations(2);
+		iteration.setInput(source);
+		
+		ReduceContract reduce1 = ReduceContract.builder(IdentityReduce.class)
+			.name("Reduce1").input(iteration.getPartialSolution()).build();
+		iteration.setNextPartialSolution(reduce1);
+		
+		FileDataSink sink = new FileDataSink(DummyOutputFormat.class, OUT_FILE, "Sink");
+		sink.setInput(iteration);
+		Plan plan = new Plan(sink, "Test Temp Task");
+		
+		// Explicitly defined this to be > 1. This caused the compiler to report an error.
+		plan.setDefaultParallelism(2);
+		
+		try {
+			OptimizedPlan oPlan = compileNoStats(plan);
+			NepheleJobGraphGenerator jobGen = new NepheleJobGraphGenerator();
+			jobGen.compileJobGraph(oPlan);
+		} catch(CompilerException ce) {
+			ce.printStackTrace();
+			fail("The pact compiler is unable to compile this plan correctly");
+		}
+	}	
 }


### PR DESCRIPTION
Compiler throws the following error when I use the AllReducer inside iterations with dop>1:
`eu.stratosphere.pact.compiler.CompilerException: Error: All functions that are part of an iteration must have the same degree-of-parallelism as that iteration.`
The dop is automatically set to 1 for the AllReducer (which absolutely makes sense). I extended Roberts test case to catch this bug.

Maybe anyone can explain why we have this restriction? Due to this restrictions I also had to remove some other optimizations where I defined the dop to be 1 for some contracts manually.

BTW: It would be nice to give a hint in the error message which node has a dop different from iteration (e.g. the name and type).
