### PR TITLE
Upgrade to newer maven surefire (integration tests) version + Fix for failing testcase in ExecutionGraphTest

### DIFF
--- a/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
+++ b/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
@@ -885,12 +885,12 @@ public class ExecutionGraphTest {
 			}
 			instanceRequestMap.clear();
 			executionStage = eg.getCurrentExecutionStage();
-			assertEquals(1, executionStage.getStageNumber());
-			executionStage.collectRequiredInstanceTypes(instanceRequestMap, ExecutionState.CREATED);
+			assertEquals(null, executionStage); // as the documentation of getCurrentExecutionStage() states, the ExecutionStage is null if the job has finished
+			/*executionStage.collectRequiredInstanceTypes(instanceRequestMap, ExecutionState.CREATED);
 			assertEquals(1, instanceRequestMap.size());
 			assertEquals(4,
 				(int) instanceRequestMap.getMaximumNumberOfInstances(INSTANCE_MANAGER
-					.getInstanceTypeByName(DEFAULT_INSTANCE_TYPE_NAME)));
+					.getInstanceTypeByName(DEFAULT_INSTANCE_TYPE_NAME))); */
 		} catch (GraphConversionException e) {
 			fail(e.getMessage());
 		} catch (JobGraphDefinitionException e) {

--- a/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
+++ b/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
@@ -848,8 +848,8 @@ public class ExecutionGraphTest {
 			o1.setVertexToShareInstancesWith(o2);
 
 			// connect vertices
-			i1.connectTo(t1, null, DistributionPattern.POINTWISE);
-			i2.connectTo(t2, null, DistributionPattern.POINTWISE);
+			i1.connectTo(t1, ChannelType.INMEMORY, DistributionPattern.POINTWISE);
+			i2.connectTo(t2, ChannelType.INMEMORY, DistributionPattern.POINTWISE);
 			t1.connectTo(t3, ChannelType.NETWORK);
 			t2.connectTo(t3, ChannelType.NETWORK);
 			t3.connectTo(t4, ChannelType.INMEMORY, DistributionPattern.POINTWISE);
@@ -866,7 +866,7 @@ public class ExecutionGraphTest {
 			ExecutionStage executionStage = eg.getCurrentExecutionStage();
 			executionStage.collectRequiredInstanceTypes(instanceRequestMap, ExecutionState.CREATED);
 			assertEquals(1, instanceRequestMap.size());
-			assertEquals(12,
+			assertEquals(8,
 				(int) instanceRequestMap.getMaximumNumberOfInstances(INSTANCE_MANAGER
 					.getInstanceTypeByName(DEFAULT_INSTANCE_TYPE_NAME)));
 			// Fake transition to next stage by triggering execution state changes manually

--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.7</version>
+				<version>2.16</version>
 				<configuration>
 					<argLine>-Xmx1024m</argLine>
 				</configuration>


### PR DESCRIPTION
I upgraded to the most recent maven surefire version. It shows more detailed error messages / summaries, which is especially useful for travis builds (because we cannot access the surefire-reports on the test machines)
The new version marks errored tests as failed.

The pull request contains a fix for a failing testcase in the ExecutionGraphTest (that was most probably introduced by https://github.com/dimalabs/ozone/pull/53) which was not detected because it errored (NullPtr)
