### PR TITLE
Support for different Hadoop versions (yarn!) using activation by properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ jdk:
   - openjdk7
   - openjdk6
 env:
-  - PROFILE=hadoop_v1
-  - PROFILE=hadoop_yarn
+  - PROFILE=
+  - PROFILE="-Dhadoop.profile=2"
 
 install: true
 
-script: "mvn -P$PROFILE clean verify"
+script: "mvn $PROFILE clean verify"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,33 @@ If you’re a Debian/Ubuntu user, you’ll find a .deb package. We will continue
 
 	cd stratosphere-dist/target/stratosphere-dist-0.2-ozone-bin/stratosphere-0.2-ozone/
 
-Note: The directory structure here looks like the contents of the official release distribution.
+The directory structure here looks like the contents of the official release distribution.
+
+#### Build for different Hadoop Versions
+This section is for advanced users that want to build Stratosphere for a different Hadoop version, for example for Hadoop Yarn support.
+
+We use the profile activation via properties (-D).
+
+##### Build hadoop v1 (default)
+Build the default (currently hadoop 1.2.1)
+```mvn clean package```
+
+Build for a specific hadoop v1 version
+```mvn -Dhadoop-one.version=1.1.2 clean package```
+
+##### Build hadoop v2 (yarn)
+
+Build the yarn using the default version defined in the pom
+```mvn -Dhadoop.profile=2 clean package```
+
+Build for a specific hadoop v1 version
+```mvn -Dhadoop.profile=2 -Dhadoop-two.version=2.1.0-beta clean package```
+
+It is necessary to generate separate POMs if you want to deploy to your local repository (`mvn install`) or somewhere else.
+We have a script in `/tools` that generates POMs for the profiles. Use 
+```mvn -f pom.hadoop2.xml clean install -DskipTests```
+to put a POM file with the right dependencies into your local repository.
+
 
 ### Run your first program
 

--- a/nephele/nephele-clustermanager/pom.xml
+++ b/nephele/nephele-clustermanager/pom.xml
@@ -5,7 +5,8 @@
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>nephele</artifactId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/nephele/nephele-common/pom.xml
+++ b/nephele/nephele-common/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-common</artifactId>
 	<name>nephele-common</name>

--- a/nephele/nephele-examples/pom.xml
+++ b/nephele/nephele-examples/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-examples</artifactId>
 	<name>nephele-examples</name>

--- a/nephele/nephele-hdfs/pom.xml
+++ b/nephele/nephele-hdfs/pom.xml
@@ -28,7 +28,28 @@
 	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>
 		<profile>
-			<id>hadoop_yarn</id>
+			<id>hadoop-1</id>
+			<activation>
+				<property>
+					<name>!hadoop.profile</name>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- "Old" Hadoop = MapReduce v1 -->
+				<dependency>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-core</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>hadoop-2</id>
+			<activation>
+				<property>
+					<name>hadoop.profile</name>
+					<value>2</value>
+				</property>
+			</activation>
 			<dependencies>
 				<!-- YARN -->
 				<dependency>
@@ -38,19 +59,6 @@
 				<dependency>
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-hdfs</artifactId>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>hadoop_v1</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<dependencies>
-				<!-- "Old" Hadoop = MapReduce v1 -->
-				<dependency>
-					<groupId>org.apache.hadoop</groupId>
-					<artifactId>hadoop-core</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>

--- a/nephele/nephele-hdfs/pom.xml
+++ b/nephele/nephele-hdfs/pom.xml
@@ -31,7 +31,8 @@
 			<id>hadoop-1</id>
 			<activation>
 				<property>
-					<name>!hadoop.profile</name>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop1--><name>!hadoop.profile</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -46,8 +47,8 @@
 			<id>hadoop-2</id>
 			<activation>
 				<property>
-					<name>hadoop.profile</name>
-					<value>2</value>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop2--><name>hadoop.profile</name><value>2</value>
 				</property>
 			</activation>
 			<dependencies>

--- a/nephele/nephele-hdfs/pom.xml
+++ b/nephele/nephele-hdfs/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-hdfs</artifactId>
 	<name>nephele-hdfs</name>

--- a/nephele/nephele-management/pom.xml
+++ b/nephele/nephele-management/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-management</artifactId>
 	<name>nephele-management</name>

--- a/nephele/nephele-profiling/pom.xml
+++ b/nephele/nephele-profiling/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-profiling</artifactId>
 	<name>nephele-profiling</name>

--- a/nephele/nephele-queuescheduler/pom.xml
+++ b/nephele/nephele-queuescheduler/pom.xml
@@ -7,7 +7,8 @@
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>nephele</artifactId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 	
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>nephele-queuescheduler</artifactId>

--- a/nephele/nephele-s3/pom.xml
+++ b/nephele/nephele-s3/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-s3</artifactId>
 	<name>nephele-s3</name>

--- a/nephele/nephele-server/pom.xml
+++ b/nephele/nephele-server/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-server</artifactId>
 	<name>nephele-server</name>

--- a/nephele/nephele-visualization/pom.xml
+++ b/nephele/nephele-visualization/pom.xml
@@ -9,7 +9,8 @@
 		<artifactId>nephele</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele-visualization</artifactId>
 	<name>nephele-visualization</name>

--- a/nephele/pom.xml
+++ b/nephele/pom.xml
@@ -36,6 +36,19 @@
 		</developer>
 	</developers>
 
+	<modules>
+		<module>nephele-common</module>
+		<module>nephele-management</module>
+		<module>nephele-profiling</module>
+		<module>nephele-queuescheduler</module>
+		<module>nephele-clustermanager</module>
+		<module>nephele-hdfs</module>
+		<module>nephele-s3</module>
+		<module>nephele-visualization</module>
+		<module>nephele-server</module>
+		<module>nephele-examples</module>
+	</modules>
+
 	<reporting>
 		<plugins>
 		</plugins>
@@ -74,17 +87,5 @@
 
 	<dependencies>
 	</dependencies>
-
-	<modules>
-		<module>nephele-common</module>
-		<module>nephele-management</module>
-		<module>nephele-profiling</module>
-		<module>nephele-queuescheduler</module>
-		<module>nephele-clustermanager</module>
-		<module>nephele-hdfs</module>
-		<module>nephele-s3</module>
-		<module>nephele-visualization</module>
-		<module>nephele-server</module>
-		<module>nephele-examples</module>
-	</modules>
+	
 </project>

--- a/nephele/pom.xml
+++ b/nephele/pom.xml
@@ -8,7 +8,8 @@
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>ozone</artifactId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>nephele</artifactId>
 	<packaging>pom</packaging>

--- a/pact/pact-array-datamodel/pom.xml
+++ b/pact/pact-array-datamodel/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 	
 	<artifactId>pact-array-datamodel</artifactId>
 	<name>pact-array-datamodel</name>

--- a/pact/pact-clients/pom.xml
+++ b/pact/pact-clients/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact-clients</artifactId>
 	<name>pact-clients</name>

--- a/pact/pact-common/pom.xml
+++ b/pact/pact-common/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+        <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact-common</artifactId>
 	<name>pact-common</name>

--- a/pact/pact-compiler-tests/pom.xml
+++ b/pact/pact-compiler-tests/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact-compiler-tests</artifactId>
 	<name>pact-compiler-tests</name>

--- a/pact/pact-compiler/pom.xml
+++ b/pact/pact-compiler/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact-compiler</artifactId>
 	<name>pact-compiler</name>

--- a/pact/pact-examples/pom.xml
+++ b/pact/pact-examples/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact-examples</artifactId>
 	<name>pact-examples</name>

--- a/pact/pact-examples/pom.xml
+++ b/pact/pact-examples/pom.xml
@@ -339,7 +339,8 @@
 			<id>hadoop-1</id>
 			<activation>
 				<property>
-					<name>!hadoop.profile</name>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop1--><name>!hadoop.profile</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -372,8 +373,8 @@
 			<id>hadoop-2</id>
 			<activation>
 				<property>
-					<name>hadoop.profile</name>
-					<value>2</value>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop2--><name>hadoop.profile</name><value>2</value>
 				</property>
 			</activation>
 			<dependencies>

--- a/pact/pact-examples/pom.xml
+++ b/pact/pact-examples/pom.xml
@@ -336,7 +336,46 @@
 	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>
 		<profile>
-			<id>hadoop_yarn</id>
+			<id>hadoop-1</id>
+			<activation>
+				<property>
+					<name>!hadoop.profile</name>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- No extra dependencies: pact-hbase is currently not compatible with Hadoop v1 -->
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>default-compile</id>
+								<phase>compile</phase>
+								<configuration>
+									<excludes>
+										<exclude>**/hbase/*.java</exclude>
+									</excludes>
+								</configuration>
+								<goals>
+									<goal>compile</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>hadoop-2</id>
+			<activation>
+				<property>
+					<name>hadoop.profile</name>
+					<value>2</value>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>eu.stratosphere</groupId>
@@ -380,37 +419,6 @@
 			</build>
 		</profile>
 		
-		<profile>
-			<id>hadoop_v1</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<dependencies>
-        		<!-- No extra dependencies: pact-hbase is currently not compatible with Hadoop v1 -->
-			</dependencies>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>default-compile</id>
-								<phase>compile</phase>
-								<configuration>
-									<excludes>
-										<exclude>**/hbase/*.java</exclude>
-									</excludes>
-								</configuration>
-								<goals>
-									<goal>compile</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
   
 </project>

--- a/pact/pact-hbase/pom.xml
+++ b/pact/pact-hbase/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
   
 	<artifactId>pact-hbase</artifactId>
 	<name>pact-hbase</name>

--- a/pact/pact-runtime/pom.xml
+++ b/pact/pact-runtime/pom.xml
@@ -36,25 +36,33 @@
 	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>
 		<profile>
-			<id>hadoop_yarn</id>
-			<dependencies>
-				<!-- YARN -->
-				<dependency>
-					<groupId>org.apache.hadoop</groupId>
-					<artifactId>hadoop-common</artifactId>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>hadoop_v1</id>
+			<id>hadoop-1</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<property>
+					<name>!hadoop.profile</name>
+				</property>
 			</activation>
 			<dependencies>
 				<!-- "Old" Hadoop = MapReduce v1 -->
 				<dependency>
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-core</artifactId>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>hadoop-2</id>
+			<activation>
+				<property>
+					<name>hadoop.profile</name>
+					<value>2</value>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- YARN -->
+				<dependency>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-common</artifactId>
 				</dependency>
 			</dependencies>
 		</profile>

--- a/pact/pact-runtime/pom.xml
+++ b/pact/pact-runtime/pom.xml
@@ -39,7 +39,8 @@
 			<id>hadoop-1</id>
 			<activation>
 				<property>
-					<name>!hadoop.profile</name>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop1--><name>!hadoop.profile</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -54,8 +55,8 @@
 			<id>hadoop-2</id>
 			<activation>
 				<property>
-					<name>hadoop.profile</name>
-					<value>2</value>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop2--><name>hadoop.profile</name><value>2</value>
 				</property>
 			</activation>
 			<dependencies>

--- a/pact/pact-runtime/pom.xml
+++ b/pact/pact-runtime/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact-runtime</artifactId>
 	<name>pact-runtime</name>

--- a/pact/pact-tests/pom.xml
+++ b/pact/pact-tests/pom.xml
@@ -8,7 +8,8 @@
 		<artifactId>pact</artifactId>
 		<groupId>eu.stratosphere</groupId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact-tests</artifactId>
 	<name>pact-tests</name>

--- a/pact/pom.xml
+++ b/pact/pom.xml
@@ -26,6 +26,17 @@
 	<developers>
 	</developers>
 
+	<modules>
+		<module>pact-common</module>
+		<module>pact-runtime</module>
+		<module>pact-compiler</module>
+		<module>pact-compiler-tests</module>
+		<module>pact-clients</module>
+		<module>pact-examples</module>
+		<module>pact-tests</module>
+		<module>pact-array-datamodel</module>
+	</modules>
+
 	<properties>
 	</properties>
 
@@ -63,32 +74,30 @@
 
 		</plugins>
 	</build>
-
-	<modules>
-		<module>pact-common</module>
-		<module>pact-runtime</module>
-		<module>pact-compiler</module>
-		<module>pact-compiler-tests</module>
-		<module>pact-clients</module>
-		<module>pact-examples</module>
-		<module>pact-tests</module>
-		<module>pact-array-datamodel</module>
-	</modules>
 	
+	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>
 		<profile>
-			<id>hadoop_yarn</id>
-			<modules>
-				<module>pact-hbase</module>
-			</modules>
-		</profile>
-		<profile>
-			<id>hadoop_v1</id>
+			<id>hadoop-1</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
+				<property>
+					<name>!hadoop.profile</name>
+				</property>
 			</activation>
 			<modules>
 				<!-- No extra modules: pact-hbase is currently not compatible with Hadoop v1 -->
+			</modules>
+		</profile>
+		<profile>
+			<id>hadoop-2</id>
+			<activation>
+				<property>
+					<name>hadoop.profile</name>
+					<value>2</value>
+				</property>
+			</activation>
+			<modules>
+				<module>pact-hbase</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/pact/pom.xml
+++ b/pact/pom.xml
@@ -81,7 +81,8 @@
 			<id>hadoop-1</id>
 			<activation>
 				<property>
-					<name>!hadoop.profile</name>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop1--><name>!hadoop.profile</name>
 				</property>
 			</activation>
 			<modules>
@@ -92,8 +93,8 @@
 			<id>hadoop-2</id>
 			<activation>
 				<property>
-					<name>hadoop.profile</name>
-					<value>2</value>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop2--><name>hadoop.profile</name><value>2</value>
 				</property>
 			</activation>
 			<modules>

--- a/pact/pom.xml
+++ b/pact/pom.xml
@@ -8,7 +8,8 @@
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>ozone</artifactId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>pact</artifactId>
 	<packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,17 @@
 	<developers>
 	</developers>
 
+	<modules>
+		<module>nephele</module>
+		<module>pact</module>
+		<module>stratosphere-dist</module>
+	</modules>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<hadoop-one.version>1.2.1</hadoop-one.version>
+		<hadoop-two.version>2.0.0-cdh4.2.1</hadoop-two.version>
 	</properties>
 
 	<pluginRepositories>
@@ -121,22 +129,38 @@
 		
 	</dependencies>
 
-	<!--
-		Usage of profiles for various hadoop versions:
-		Profile hadoop-yarn is active by default.
-		It will be deactivated whenever another profile becomes active in this pom
-
-		How to build for yarn using a specific version
-		- Call: mvn -Dhadoop.version=<version> <goal>
-
-		How to build for hadoop v1 (will use hadoop-core):
-		- Call: mvn -Phadoop_v1 -Dhadoop.version=<hadoop-version> <goal>
-	-->
 	<profiles>
 		<profile>
-			<id>hadoop_yarn</id>
+			<id>hadoop-1</id>
+			<activation>
+				<property>
+					<name>!hadoop.profile</name>
+				</property>
+			</activation>
 			<properties>
-				<hadoop.version>2.0.0-cdh4.2.1</hadoop.version>
+				<hadoop.version>${hadoop-one.version}</hadoop.version>
+			</properties>
+			<dependencyManagement>
+				<dependencies>
+					<!-- "Old" stable Hadoop = MapReduce v1 -->
+					<dependency>
+						<groupId>org.apache.hadoop</groupId>
+						<artifactId>hadoop-core</artifactId>
+						<version>${hadoop.version}</version>
+					</dependency>
+				</dependencies>
+			</dependencyManagement>
+		</profile>
+		<profile>
+			<id>hadoop-2</id>
+			<activation>
+				<property>
+					<name>hadoop.profile</name>
+					<value>2</value>
+				</property>
+			</activation>
+			<properties>
+				<hadoop.version>${hadoop-two.version}</hadoop.version>
 			</properties>
 			<dependencyManagement>
 				<dependencies>
@@ -149,25 +173,6 @@
 					<dependency>
 						<groupId>org.apache.hadoop</groupId>
 						<artifactId>hadoop-hdfs</artifactId>
-						<version>${hadoop.version}</version>
-					</dependency>
-				</dependencies>
-			</dependencyManagement>
-		</profile>
-		<profile>
-			<id>hadoop_v1</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<properties>
-				<hadoop.version>1.2.1</hadoop.version>
-			</properties>
-			<dependencyManagement>
-				<dependencies>
-					<!-- "Old" Hadoop = MapReduce v1 -->
-					<dependency>
-						<groupId>org.apache.hadoop</groupId>
-						<artifactId>hadoop-core</artifactId>
 						<version>${hadoop.version}</version>
 					</dependency>
 				</dependencies>
@@ -414,10 +419,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<modules>
-		<module>nephele</module>
-		<module>pact</module>
-		<module>stratosphere-dist</module>
-	</modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,8 @@
 			<id>hadoop-1</id>
 			<activation>
 				<property>
-					<name>!hadoop.profile</name>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop1--><name>!hadoop.profile</name>
 				</property>
 			</activation>
 			<properties>
@@ -155,8 +156,8 @@
 			<id>hadoop-2</id>
 			<activation>
 				<property>
-					<name>hadoop.profile</name>
-					<value>2</value>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop2--><name>hadoop.profile</name><value>2</value>
 				</property>
 			</activation>
 			<properties>

--- a/stratosphere-dist/pom.xml
+++ b/stratosphere-dist/pom.xml
@@ -8,7 +8,8 @@
 		<groupId>eu.stratosphere</groupId>
 		<artifactId>ozone</artifactId>
 		<version>0.2-ozone</version>
-	</parent>
+	    <relativePath>..</relativePath>
+    </parent>
 
 	<artifactId>stratosphere-dist</artifactId>
 	<name>stratosphere-dist</name>

--- a/stratosphere-dist/pom.xml
+++ b/stratosphere-dist/pom.xml
@@ -99,7 +99,8 @@
 			<id>hadoop-1</id>
 			<activation>
 				<property>
-					<name>!hadoop.profile</name>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop1--><name>!hadoop.profile</name>
 				</property>
 			</activation>
 			<dependencies>
@@ -110,8 +111,8 @@
 			<id>hadoop-2</id>
 			<activation>
 				<property>
-					<name>hadoop.profile</name>
-					<value>2</value>
+					<!-- Please do not remove the 'hadoop1' comment. See ./tools/generate_specific_pom.sh -->
+					<!--hadoop2--><name>hadoop.profile</name><value>2</value>
 				</property>
 			</activation>
 			<dependencies>

--- a/stratosphere-dist/pom.xml
+++ b/stratosphere-dist/pom.xml
@@ -96,23 +96,30 @@
 	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>
 		<profile>
-			<id>hadoop_yarn</id>
+			<id>hadoop-1</id>
+			<activation>
+				<property>
+					<name>!hadoop.profile</name>
+				</property>
+			</activation>
+			<dependencies>
+				<!-- No extra dependencies: pact-hbase is currently not compatible with Hadoop v1 -->
+			</dependencies>
+		</profile>
+		<profile>
+			<id>hadoop-2</id>
+			<activation>
+				<property>
+					<name>hadoop.profile</name>
+					<value>2</value>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>eu.stratosphere</groupId>
 					<artifactId>pact-hbase</artifactId>
 					<version>${project.version}</version>
 				</dependency>
-			</dependencies>
-		</profile>
-		
-		<profile>
-			<id>hadoop_v1</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<dependencies>
-        		<!-- No extra dependencies: pact-hbase is currently not compatible with Hadoop v1 -->
 			</dependencies>
 		</profile>
 	</profiles>

--- a/stratosphere-dist/src/main/assemblies/bin.xml
+++ b/stratosphere-dist/src/main/assemblies/bin.xml
@@ -25,9 +25,11 @@
 			<useTransitiveFiltering>true</useTransitiveFiltering>
 			
 			<excludes>
+				<!--
 				<exclude>**/*examples*.jar</exclude>
 				<exclude>**/*javadoc*</exclude>
 				<exclude>**/*sources*</exclude>
+				-->
 <!-- 				<exclude>eu.stratosphere:pact-clients:**</exclude> -->
 				<!--
 				  This is a hardcoded exclude-list containing all libraries that are exclusively used in pact-clients.
@@ -50,11 +52,13 @@
 				<include>eu.stratosphere:pact-clients:**</include>
 			</includes>
 			
+			<!--
 			<excludes>
 				<exclude>**/*examples*.jar</exclude>
 				<exclude>**/*javadoc*</exclude>
 				<exclude>**/*sources*</exclude>
 			</excludes>
+			-->
 		</dependencySet>
 	</dependencySets>
 

--- a/tools/generate_specific_pom.sh
+++ b/tools/generate_specific_pom.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+
+#
+# See https://github.com/dimalabs/ozone/issues/95
+# Inspired by: https://github.com/apache/hbase/blob/trunk/dev-support/generate-hadoopX-poms.sh
+#
+
+
+function usage {
+  echo "Usage: $0 CURRENT_VERSION NEW_VERSION"
+  echo "For example, $0 0.2-ozone 0.2-ozone-hadoop2"
+  echo "Presumes VERSION has hadoop1 or hadoop2 in it."
+  exit 1
+}
+
+if [[ "$#" -ne 2 ]]; then usage; fi
+
+old_ozone_version="$1"
+new_ozone_version="$2"
+
+# Get hadoop version from the new ozone version
+hadoop_version=`echo "$new_ozone_version" | sed -n 's/.*\(hadoop[12]\).*/\1/p'`
+if [[ -z $hadoop_version ]]; then usage ; fi
+
+echo "hadoop version $hadoop_version"
+here="`dirname \"$0\"`"              # relative
+here="`( cd \"$here\" && pwd )`"  # absolutized and normalized
+if [ -z "$here" ] ; then
+	# error; for some reason, the path is not accessible
+	# to the script (e.g. permissions re-evaled after suid)
+	exit 1  # fail
+fi
+ozone_home="`dirname \"$here\"`"
+
+
+
+hadoop1=
+hadoop2=
+default='<name>!hadoop.profile<\/name>'
+notdefault='<name>hadoop.profile<\/name>'
+case "${hadoop_version}" in
+  hadoop1)
+    h1="${default}"
+    h2="${notdefault}<value>2<\/value>"
+    ;;
+  hadoop2)
+    h1="${notdefault}<value>1<\/value>"
+    h2="${default}"
+    ;;
+ *) echo "Unknown ${hadoop_version}"
+    usage
+    ;;
+esac
+
+
+nupom="pom.${hadoop_version}.xml"
+poms=`find $ozone_home -name pom.xml`
+for p in $poms; do
+  nuname="`dirname $p`/${nupom}"
+  # Now we do search and replace of explicit strings.  The best
+  # way of seeing what the below does is by doing a diff between
+  # the original pom and the generated pom (pom.xml.hadoop1 or
+  # pom.xml.hadoop2). We replace the compat.module variable with
+  # either hbase-hadoop1-compat or hbase-hadoop2-compat, we
+  # replace the version string in all poms, we change modules
+  # to include reference to the non-standard pom name, we
+  # adjust relative paths so child modules can find the parent pom,
+  # and we enable/disable hadoop 1 and hadoop 2 profiles as
+  # appropriate removing a comment string too.  We output the
+  # new pom beside the original.
+  sed -e "s/${old_ozone_version}/${new_ozone_version}/" \
+    -e "s/\(<module>[^<]*\)/\1\/${nupom}/" \
+    -e "s/\(relativePath>\.\.\)/\1\/${nupom}/" \
+    -e "s/<!--hadoop1-->.*name>.*/${hadoop1}/" \
+    -e "s/<!--hadoop2-->.*<name>.*/${hadoop2}/" \
+  $p > "$nuname"
+done
+

--- a/tools/generate_specific_pom.sh
+++ b/tools/generate_specific_pom.sh
@@ -40,12 +40,12 @@ default='<name>!hadoop.profile<\/name>'
 notdefault='<name>hadoop.profile<\/name>'
 case "${hadoop_version}" in
   hadoop1)
-    h1="${default}"
-    h2="${notdefault}<value>2<\/value>"
+    hadoop1="${default}"
+    hadoop2="${notdefault}<value>2<\/value>"
     ;;
   hadoop2)
-    h1="${notdefault}<value>1<\/value>"
-    h2="${default}"
+    hadoop1="${notdefault}<value>1<\/value>"
+    hadoop2="${default}"
     ;;
  *) echo "Unknown ${hadoop_version}"
     usage

--- a/tools/generate_specific_pom.sh
+++ b/tools/generate_specific_pom.sh
@@ -57,17 +57,15 @@ nupom="pom.${hadoop_version}.xml"
 poms=`find $ozone_home -name pom.xml`
 for p in $poms; do
   nuname="`dirname $p`/${nupom}"
-  # Now we do search and replace of explicit strings.  The best
-  # way of seeing what the below does is by doing a diff between
-  # the original pom and the generated pom (pom.xml.hadoop1 or
-  # pom.xml.hadoop2). We replace the compat.module variable with
-  # either hbase-hadoop1-compat or hbase-hadoop2-compat, we
-  # replace the version string in all poms, we change modules
-  # to include reference to the non-standard pom name, we
-  # adjust relative paths so child modules can find the parent pom,
-  # and we enable/disable hadoop 1 and hadoop 2 profiles as
-  # appropriate removing a comment string too.  We output the
-  # new pom beside the original.
+  # Now we do search and replace of explicit strings.  The best way of
+  # seeing what the below does is by doing a diff between the original
+  # pom and the generated pom (pom.hadoop1.xml or pom.hadoop2.xml). We
+  # replace the version string in all poms, we change modules to
+  # include reference to the non- standard pom name, we adjust
+  # relative paths so child modules can find the parent pom, and we
+  # enable/disable hadoop 1 and hadoop 2 profiles as appropriate
+  # removing a comment string too. We output the new pom beside the
+  # original.
   sed -e "s/${old_ozone_version}/${new_ozone_version}/" \
     -e "s/\(<module>[^<]*\)/\1\/${nupom}/" \
     -e "s/\(relativePath>\.\.\)/\1\/${nupom}/" \


### PR DESCRIPTION
This pull request is a fix for https://github.com/dimalabs/ozone/issues/95
The results of this PR are mostly based on the work and research of [Andre](https://github.com/andrehacker).

We implemented maven profiles similar to other large projects that depend on hadoop (giraph, hbase).
Similarly to hbase, we chose to supply a little script that generates specialized POMs for the  'hadoop2` profile.
The above mentioned issue contains an extensive discussion of the problem. 

The README lists all relevant commands and the travis build system supports the new profile activation
