### PR TITLE
Add an example of using LocalExecutor in WordCount example

### DIFF
--- a/pact/pact-examples/pom.xml
+++ b/pact/pact-examples/pom.xml
@@ -23,6 +23,12 @@
 			<artifactId>pact-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		
+		<dependency>
+            <groupId>eu.stratosphere</groupId>
+            <artifactId>pact-clients</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
 	</dependencies>
 

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
@@ -18,6 +18,7 @@ package eu.stratosphere.pact.example.wordcount;
 import java.io.Serializable;
 import java.util.Iterator;
 
+import eu.stratosphere.pact.client.LocalExecutor;
 import eu.stratosphere.pact.common.contract.FileDataSink;
 import eu.stratosphere.pact.common.contract.FileDataSource;
 import eu.stratosphere.pact.common.contract.MapContract;
@@ -154,5 +155,12 @@ public class WordCount implements PlanAssembler, PlanAssemblerDescription {
 	@Override
 	public String getDescription() {
 		return "Parameters: [numSubStasks] [input] [output]";
+	}
+	
+	public static void main(String[] args) throws Exception {
+		WordCount wc = new WordCount();
+		Plan plan = wc.getPlan("1", "file:///path/to/input", "file:///path/to/output");
+		LocalExecutor.execute(plan);
+		System.exit(0);
 	}
 }

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCountClassic.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCountClassic.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.example.wordcount;
 
 import java.util.Iterator;
 
+import eu.stratosphere.pact.client.LocalExecutor;
 import eu.stratosphere.pact.common.contract.FileDataSink;
 import eu.stratosphere.pact.common.contract.FileDataSource;
 import eu.stratosphere.pact.common.contract.MapContract;
@@ -153,5 +154,13 @@ public class WordCountClassic implements PlanAssembler, PlanAssemblerDescription
 	@Override
 	public String getDescription() {
 		return "Parameters: [numSubStasks] [input] [output]";
+	}
+	
+	// This can be used to locally run a plan from within eclipse (or anywhere else)
+	public static void main(String[] args) throws Exception {
+		WordCountClassic wc = new WordCountClassic();
+		Plan plan = wc.getPlan("1", "file:///path/to/input", "file:///path/to/output");
+		LocalExecutor.execute(plan);
+		System.exit(0);
 	}
 }


### PR DESCRIPTION
Asterios pointed out that nowhere in the examples do we show that the LocalExecutor exists. So I added a static main method that shows it's usage.
