### PR TITLE
Generate source attachments for each subproject

### DIFF
--- a/pact/pom.xml
+++ b/pact/pom.xml
@@ -51,30 +51,7 @@
 	<dependencies>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.1</version>
-				<executions>
-					<execution>
-						<id>source:aggregate</id>
-						<phase>package</phase>
-						<goals>
-							<goal>aggregate</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<includes>
-						<include>eu/stratosphere/pact/*</include>
-					</includes>
-				</configuration>
-			</plugin>
 
-		</plugins>
-	</build>
 	
 	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,19 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Maven did not generate source attachments for the jars.

This change should activate it for all subprojects. This is an requirement for stable releases in maven central. It is also nice to have, if you want to look up our sources in eclipse.
