### PR TITLE
Add methods to get optimized plan from LocalExecutor

### DIFF
--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
@@ -23,6 +23,7 @@ import eu.stratosphere.pact.common.plan.PlanAssembler;
 import eu.stratosphere.pact.compiler.DataStatistics;
 import eu.stratosphere.pact.compiler.PactCompiler;
 import eu.stratosphere.pact.compiler.plan.candidate.OptimizedPlan;
+import eu.stratosphere.pact.compiler.plandump.PlanJSONDumpGenerator;
 import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
 
 /**
@@ -87,6 +88,26 @@ public class LocalExecutor {
 	}
 	
 	/**
+	 * Returns a JSON dump of the optimized plan.
+	 * 
+	 * @param plan
+	 *            The program's plan.
+	 * @return JSON dump of the optimized plan.
+	 * @throws Exception
+	 */
+	public String getOptimizerPlanAsJSON(Plan plan) throws Exception {
+		if (this.nephele == null) {
+			throw new Exception("The local executor has not been started.");
+		}
+
+		PactCompiler pc = new PactCompiler(new DataStatistics());
+		OptimizedPlan op = pc.compile(plan);
+		PlanJSONDumpGenerator gen = new PlanJSONDumpGenerator();
+
+		return gen.getOptimizerPlanAsJSON(op);
+	}
+	
+	/**
 	 * Executes the program described by the given plan assembler.
 	 * 
 	 * @param pa The program's plan assembler. 
@@ -114,6 +135,30 @@ public class LocalExecutor {
 		try {
 			exec.start();
 			return exec.executePlan(plan);
+		} finally {
+			if (exec != null) {
+				exec.stop();
+			}
+		}
+	}
+	
+	/**
+	 * Returns a JSON dump of the optimized plan.
+	 * 
+	 * @param plan
+	 *            The program's plan.
+	 * @return JSON dump of the optimized plan.
+	 * @throws Exception
+	 */
+	public static String optimizerPlanAsJSON(Plan plan) throws Exception {
+		LocalExecutor exec = new LocalExecutor();
+		try {
+			exec.start();
+			PactCompiler pc = new PactCompiler(new DataStatistics());
+			OptimizedPlan op = pc.compile(plan);
+			PlanJSONDumpGenerator gen = new PlanJSONDumpGenerator();
+
+			return gen.getOptimizerPlanAsJSON(op);
 		} finally {
 			if (exec != null) {
 				exec.stop();


### PR DESCRIPTION
After reading @sscdotopen's comment in #128, I figured it might be worthwhile to add the option to get the optimized plan from the `LocalExecutor`.

This commit adds a static and non-static method which return the optimized plan as a String (in JSON). The static method is for the case where you just want the optimized plan (start executor, get plan, stop executor) and the non-static method for the general case where you start the executor yourself and probably also run the job afterwards (thanks to @rmetzger for pointing out that this case is also important). 

Different names for basically the same thing kinda suck but I didn't have a better idea right now... open for changes. :)

(We could also add the `PrintWriter`/`FileWriter` versions from the dump generator, but the String version should be fine for now.)
