### PR TITLE
LocalDistributedExecutor

### DIFF
--- a/nephele/nephele-clustermanager/src/main/java/eu/stratosphere/nephele/instance/cluster/ClusterManager.java
+++ b/nephele/nephele-clustermanager/src/main/java/eu/stratosphere/nephele/instance/cluster/ClusterManager.java
@@ -1143,4 +1143,9 @@ public class ClusterManager implements InstanceManager {
 		// Simple remove the entire map
 		this.pendingRequestsOfJob.remove(jobID);
 	}
+
+	@Override
+	public int getNumberOfTaskTrackers() {
+		return this.registeredHosts.size();
+	}
 }

--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/configuration/Configuration.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/configuration/Configuration.java
@@ -486,4 +486,9 @@ public class Configuration implements IOReadableWritable {
 		final Configuration other = (Configuration) obj;
 		return confData.equals(other.confData);
 	}
+	
+	@Override
+	public String toString() {
+		return confData.toString();
+	}
 }

--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/execution/librarycache/LibraryCacheManager.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/execution/librarycache/LibraryCacheManager.java
@@ -470,11 +470,7 @@ public final class LibraryCacheManager {
 
 		final LibraryCacheManager lib = get();
 
-		String[] r = lib.getRequiredJarFilesInternal(id);
-		if(r == null) {
-			return new String[0];
-		}
-		return r;
+		return lib.getRequiredJarFilesInternal(id);
 	}
 
 	/**

--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/execution/librarycache/LibraryCacheManager.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/execution/librarycache/LibraryCacheManager.java
@@ -470,7 +470,11 @@ public final class LibraryCacheManager {
 
 		final LibraryCacheManager lib = get();
 
-		return lib.getRequiredJarFilesInternal(id);
+		String[] r = lib.getRequiredJarFilesInternal(id);
+		if(r == null) {
+			return new String[0];
+		}
+		return r;
 	}
 
 	/**

--- a/nephele/nephele-queuescheduler/src/test/java/eu/stratosphere/nephele/jobmanager/scheduler/queue/TestInstanceManager.java
+++ b/nephele/nephele-queuescheduler/src/test/java/eu/stratosphere/nephele/jobmanager/scheduler/queue/TestInstanceManager.java
@@ -267,4 +267,9 @@ public final class TestInstanceManager implements InstanceManager {
 	public void shutdown() {
 		throw new IllegalStateException("shutdown called on TestInstanceManager");
 	}
+
+	@Override
+	public int getNumberOfTaskTrackers() {
+		throw new IllegalStateException("getNumberOfTaskTrackers called on TestInstanceManager");
+	}
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/InstanceManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/InstanceManager.java
@@ -163,4 +163,10 @@ public interface InstanceManager {
 	 * Shuts the instance manager down and stops all its internal processes.
 	 */
 	void shutdown();
+
+	/**
+	 * 
+	 * @return the number of available (registered) TaskTrackers
+	 */
+	int getNumberOfTaskTrackers();
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalInstanceManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalInstanceManager.java
@@ -140,7 +140,7 @@ public class LocalInstanceManager implements InstanceManager {
 
 		this.instanceTypeDescriptionMap = new SerializableHashMap<InstanceType, InstanceTypeDescription>();
 
-		this.localTaskManagerThread = new LocalTaskManagerThread();
+		this.localTaskManagerThread = new LocalTaskManagerThread("Local Taskmanager IO Loop");
 		this.localTaskManagerThread.start();
 	}
 
@@ -399,5 +399,10 @@ public class LocalInstanceManager implements InstanceManager {
 	public void cancelPendingRequests(final JobID jobID) {
 
 		// The local instance manager does not support pending requests, so nothing to do here
+	}
+
+	@Override
+	public int getNumberOfTaskTrackers() {
+		return (this.localInstance == null) ? 0 : 1; // this instance manager can have at most one TaskTracker
 	}
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalTaskManagerThread.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalTaskManagerThread.java
@@ -32,8 +32,8 @@ public class LocalTaskManagerThread extends Thread {
 	/**
 	 * Constructs a new thread to run the task manager in Nephele's local mode.
 	 */
-	public LocalTaskManagerThread() {
-		super("Local Taskmanager IO Loop");
+	public LocalTaskManagerThread(String name) {
+		super(name);
 
 		TaskManager tmpTaskManager = null;
 		try {
@@ -48,8 +48,7 @@ public class LocalTaskManagerThread extends Thread {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void run() {
-
+	public void run() {	
 		this.taskManager.runIOLoop();
 
 		// Wait until the task manager is shut down

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
@@ -251,7 +251,7 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 			LOG.info("Trying to load " + instanceManagerClassName + " as instance manager");
 			this.instanceManager = JobManagerUtils.loadInstanceManager(instanceManagerClassName);
 			if (this.instanceManager == null) {
-				LOG.error("UNable to load instance manager " + instanceManagerClassName);
+				LOG.error("Unable to load instance manager " + instanceManagerClassName);
 				System.exit(FAILURERETURNCODE);
 			}
 		}
@@ -1278,5 +1278,9 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 		}
 
 		return jmp.requestData(data);
+	}
+	
+	public int getNumberOfTaskTrackers() {
+		return this.instanceManager.getNumberOfTaskTrackers();
 	}
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
@@ -578,7 +578,6 @@ public class TaskManager implements TaskOperationProtocol, PluginCommunicationPr
 		Task task = null;
 
 		synchronized (this) {
-
 			final Task runningTask = this.runningTasks.get(id);
 			boolean registerTask = true;
 			if (runningTask == null) {

--- a/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
+++ b/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
@@ -203,6 +203,11 @@ public class ExecutionGraphTest {
 			throw new IllegalStateException("cancelPendingRequests called on TestInstanceManager");
 		}
 
+		@Override
+		public int getNumberOfTaskTrackers() {
+			return 0;
+		}
+
 	}
 
 	private static final InstanceManager INSTANCE_MANAGER = new TestInstanceManager();

--- a/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/jobmanager/JobManagerITCase.java
+++ b/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/jobmanager/JobManagerITCase.java
@@ -519,7 +519,7 @@ public class JobManagerITCase {
 		}
 	}
 
-//	@Test
+	@Test
 	public void testBroadcastChannels() {
 		testBroadcast(100000, 2);
 	}

--- a/pact/pact-clients/pom.xml
+++ b/pact/pact-clients/pom.xml
@@ -30,6 +30,17 @@
 		</dependency>
 
 		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-clustermanager</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-queuescheduler</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.2</version>

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
@@ -15,6 +15,11 @@
 
 package eu.stratosphere.pact.client;
 
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+
 import eu.stratosphere.nephele.client.JobClient;
 import eu.stratosphere.nephele.jobgraph.JobGraph;
 import eu.stratosphere.pact.client.minicluster.NepheleMiniCluster;
@@ -41,6 +46,13 @@ public class LocalExecutor {
 	private NepheleMiniCluster nephele;
 
 	
+	public LocalExecutor() {
+		Logger root = Logger.getRootLogger();
+		PatternLayout layout = new PatternLayout("%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n");
+		ConsoleAppender appender = new ConsoleAppender(layout, "System.err");
+		root.addAppender(appender);
+		root.setLevel(Level.WARN);
+	}
 	
 	public void start() throws Exception {
 		synchronized (this.lock) {

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/localDistributed/LocalDistributedExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/localDistributed/LocalDistributedExecutor.java
@@ -1,0 +1,131 @@
+package eu.stratosphere.pact.client.localDistributed;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.stratosphere.nephele.client.JobClient;
+import eu.stratosphere.nephele.configuration.ConfigConstants;
+import eu.stratosphere.nephele.configuration.Configuration;
+import eu.stratosphere.nephele.configuration.GlobalConfiguration;
+import eu.stratosphere.nephele.instance.local.LocalTaskManagerThread;
+import eu.stratosphere.nephele.jobgraph.JobGraph;
+import eu.stratosphere.nephele.jobmanager.JobManager;
+import eu.stratosphere.nephele.jobmanager.JobManager.ExecutionMode;
+import eu.stratosphere.pact.client.minicluster.NepheleMiniCluster;
+import eu.stratosphere.pact.common.plan.Plan;
+import eu.stratosphere.pact.compiler.DataStatistics;
+import eu.stratosphere.pact.compiler.PactCompiler;
+import eu.stratosphere.pact.compiler.plan.candidate.OptimizedPlan;
+import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
+
+/**
+ * This executor allows to execute a Job on one machine (locally) using multiple
+ * TaskManagers that communicate via TCP/IP, not memory.
+ */
+public class LocalDistributedExecutor  {
+	
+	private static int JOBMANAGER_RPC_PORT = 6498;
+	private boolean running = false;
+	
+	public static class JobManagerThread extends Thread {
+		JobManager jm;
+		
+		public JobManagerThread(JobManager jm) {
+			this.jm = jm;
+		}
+		@Override
+		public void run() {
+			jm.runTaskLoop();
+		}
+	}
+	
+	public void startNephele(final int numTaskMgr) throws InterruptedException {
+		if(running) {
+			return;
+		}
+		
+		Configuration conf = NepheleMiniCluster.getMiniclusterDefaultConfig(JOBMANAGER_RPC_PORT, 6500,
+				7501, 7533, null, true);
+		GlobalConfiguration.includeConfiguration(conf);
+			
+		// start job manager
+		JobManager jobManager;
+		try {
+			jobManager = new JobManager(ExecutionMode.CLUSTER);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			return;
+		}
+	
+		
+		JobManagerThread jobManagerThread = new JobManagerThread(jobManager);
+		jobManagerThread.setDaemon(true);
+		jobManagerThread.start();
+		
+		// start the taskmanagers
+		List<LocalTaskManagerThread> tms = new ArrayList<LocalTaskManagerThread>();
+		for(int tm = 0; tm < numTaskMgr; tm++) {
+			// The whole thing can only work if we assign different ports to each TaskManager
+			Configuration tmConf = new Configuration();
+			tmConf.setInteger(ConfigConstants.TASK_MANAGER_IPC_PORT_KEY,
+						ConfigConstants.DEFAULT_TASK_MANAGER_IPC_PORT + tm + numTaskMgr);
+			tmConf.setInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY, ConfigConstants.DEFAULT_TASK_MANAGER_DATA_PORT+tm); // taskmanager.data.port
+			GlobalConfiguration.includeConfiguration(tmConf);
+			LocalTaskManagerThread t = new LocalTaskManagerThread("LocalDistributedExecutor: LocalTaskManagerThread-#"+tm);
+			t.start();
+			tms.add(t);
+		}
+		
+		final int sleepTime = 100;
+		final int maxSleep = 1000 * 2 * numTaskMgr; // we wait 2 seconds PER TaskManager.
+		int slept = 0;
+		// wait for all taskmanagers to register to the JM
+		while(jobManager.getNumberOfTaskTrackers() < numTaskMgr) {
+			Thread.sleep(sleepTime);
+			if(slept >= maxSleep) {
+				throw new RuntimeException("Waited for more than 2 seconds per TaskManager to register at "
+						+ "the JobManager.");
+			}
+		}
+		this.running = true;
+	}
+	
+	public void run(final JobGraph jobGraph) throws Exception {
+		if(!running) {
+			throw new IllegalStateException("Nephele has not been started");
+		}
+		runNepheleJobGraph(jobGraph);
+	}
+	
+	public void run(final Plan plan) throws Exception {
+		if(!running) {
+			throw new IllegalStateException("Nephele has not been started");
+		}
+		PactCompiler pc = new PactCompiler(new DataStatistics());
+		OptimizedPlan op = pc.compile(plan);
+		
+		NepheleJobGraphGenerator jgg = new NepheleJobGraphGenerator();
+		JobGraph jobGraph = jgg.compileJobGraph(op);
+		runNepheleJobGraph(jobGraph);
+	}
+	
+	private void runNepheleJobGraph(JobGraph jobGraph) throws Exception {
+		try {
+			JobClient jobClient = getJobClient(jobGraph);
+			jobClient.submitJobAndWait();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	
+	private JobClient getJobClient(JobGraph jobGraph) throws Exception {
+		Configuration configuration = jobGraph.getJobConfiguration();
+		configuration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, "localhost");
+		configuration.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, JOBMANAGER_RPC_PORT);
+		return new JobClient(jobGraph, configuration);
+	}
+}

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/minicluster/NepheleMiniCluster.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/minicluster/NepheleMiniCluster.java
@@ -202,7 +202,7 @@ public class NepheleMiniCluster {
 		}
 	}
 	
-	private static Configuration getMiniclusterDefaultConfig(int jobManagerRpcPort, int taskManagerRpcPort,
+	public static Configuration getMiniclusterDefaultConfig(int jobManagerRpcPort, int taskManagerRpcPort,
 			int taskManagerDataPort, int discoveryPort, String hdfsConfigFile, boolean visualization)
 	{
 		final Configuration config = new Configuration();

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
@@ -60,7 +60,7 @@ public class WordCount implements PlanAssembler, PlanAssemblerDescription {
 		public void map(PactRecord record, Collector<PactRecord> collector) {
 			// get the first field (as type PactString) from the record
 			PactString line = record.getField(0, PactString.class);
-			
+
 			// normalize the line
 			AsciiUtils.replaceNonWordChars(line, ' ');
 			AsciiUtils.toLowerCase(line);

--- a/pact/pact-tests/pom.xml
+++ b/pact/pact-tests/pom.xml
@@ -73,6 +73,27 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-clustermanager</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-queuescheduler</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>pact-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
 	</dependencies>
 
 	<reporting>

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/clients/examples/LocalExecutorTest.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/clients/examples/LocalExecutorTest.java
@@ -49,7 +49,7 @@ public class LocalExecutorTest {
 		
 	}
 	
-	private static final String TEXT = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
+	public static final String TEXT = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
 			+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
 			+ "RAPHAEL: Die Sonne toent, nach alter Weise, In Brudersphaeren Wettgesang,\n"
 			+ "Und ihre vorgeschriebne Reise Vollendet sie mit Donnergang. Ihr Anblick\n"

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/localDistributed/LocalDistributedExecutorTest.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/localDistributed/LocalDistributedExecutorTest.java
@@ -1,0 +1,54 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2012 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.pact.test.localDistributed;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import eu.stratosphere.pact.client.localDistributed.LocalDistributedExecutor;
+import eu.stratosphere.pact.clients.examples.LocalExecutorTest;
+import eu.stratosphere.pact.example.wordcount.WordCount;
+
+
+public class LocalDistributedExecutorTest {
+
+	@Test
+	public void testLocalDistributedExecutorWithWordCount() {
+		try {
+			// set up the files
+			File inFile = File.createTempFile("wctext", ".in");
+			File outFile = File.createTempFile("wctext", ".out");
+			inFile.deleteOnExit();
+			outFile.deleteOnExit();
+			
+			FileWriter fw = new FileWriter(inFile);
+			fw.write(LocalExecutorTest.TEXT);
+			fw.close();
+			
+			// run WordCount
+			WordCount wc = new WordCount();
+			LocalDistributedExecutor lde = new LocalDistributedExecutor();
+			lde.startNephele(2);
+			lde.run( wc.getPlan("4", "file://" + inFile.getAbsolutePath(), "file://" + outFile.getAbsolutePath()));
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+		
+	}
+}

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/util/TestBase2.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/util/TestBase2.java
@@ -118,7 +118,7 @@ public abstract class TestBase2 {
 			e.printStackTrace();
 			Assert.fail("Pre-submit work caused an error: " + e.getMessage());
 		}
-
+		
 		// submit job
 		JobGraph jobGraph = null;
 		try {
@@ -135,6 +135,7 @@ public abstract class TestBase2 {
 			JobClient client = this.executer.getJobClient(jobGraph);
 			client.setConsoleStreamForReporting(getNullPrintStream());
 			client.submitJobAndWait();
+			
 		} catch(Exception e) {
 			System.err.println(e.getMessage());
 			e.printStackTrace();


### PR DESCRIPTION
Fix for this issue: https://github.com/dimalabs/ozone/issues/86

The LocalDistributedExecutor simulates a Nephele-Cluster with multiple TaskManagers in one JVM. Data between the TMs is transferred using the OS network stack, not through memory. This is important to find bugs in the network stack.

It would be great to integrate the LDE with `TestBase` and `TestBase2`. I already started with this, but I had some errors.
