### PR TITLE
Single Object returned by KeyGroupedIterator

### DIFF
--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/util/KeyGroupedIterator.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/util/KeyGroupedIterator.java
@@ -154,6 +154,7 @@ public final class KeyGroupedIterator<E>
 		private final TypeComparator<E> comparator = KeyGroupedIterator.this.comparator; 
 		
 		private E staging = this.serializer.createInstance();
+		private E emission = this.serializer.createInstance();
 		private boolean currentIsUnconsumed = false;
 		
 		private ValuesIterator() {}
@@ -206,7 +207,8 @@ public final class KeyGroupedIterator<E>
 		public E next() {
 			if (this.currentIsUnconsumed || hasNext()) {
 				this.currentIsUnconsumed = false;
-				return KeyGroupedIterator.this.current;
+				this.serializer.copyTo(KeyGroupedIterator.this.current, this.emission);
+				return this.emission;
 			} else {
 				throw new NoSuchElementException();
 			}

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/util/KeyGroupedIteratorTest.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/util/KeyGroupedIteratorTest.java
@@ -17,6 +17,7 @@ package eu.stratosphere.pact.runtime.util;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -30,7 +31,6 @@ import eu.stratosphere.pact.common.type.base.PactString;
 import eu.stratosphere.pact.common.util.MutableObjectIterator;
 import eu.stratosphere.pact.runtime.plugable.pactrecord.PactRecordComparator;
 import eu.stratosphere.pact.runtime.plugable.pactrecord.PactRecordSerializer;
-import eu.stratosphere.pact.runtime.util.KeyGroupedIterator;
 
 /**
  * Test for the key grouped iterator, which advances in windows containing the same key and provides a sub-iterator
@@ -280,7 +280,7 @@ public class KeyGroupedIteratorTest
 	}
 	
 	@Test
-	public void testHasNextDoesNotOverweiteCurrentRecord() throws Exception
+	public void testHasNextDoesNotOverwriteCurrentRecord() throws Exception
 	{
 		try {
 			Iterator<PactRecord> valsIter = null;
@@ -332,6 +332,28 @@ public class KeyGroupedIteratorTest
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("The test encountered an unexpected exception.");
+		}
+	}
+	
+	/**
+	 * Tests whether the values iterator returns always the same object.
+	 */
+	@Test
+	public void testSameObjectReturned() throws Exception {
+		
+		Iterator<PactRecord> valsIter = null;
+		PactRecord rec = null;
+		
+		HashSet<Integer> objectIds = new HashSet<Integer>();
+		
+		while(this.psi.nextKey()) {
+			objectIds.clear();
+			valsIter = this.psi.getValues();
+			while(valsIter.hasNext()) {
+				rec = valsIter.next();
+				objectIds.add(System.identityHashCode(rec));
+			}
+			Assert.assertEquals("More than one object reference returned", 1, objectIds.size());
 		}
 	}
 	


### PR DESCRIPTION
Extended the KeyGroupedIteratorTest to check that the values iterator always returns the same object. 
This is the expected behavior of a mutable object iterator.
With the current implementation two alternating records are returned, where the one that was not returned with the last next() call is used as a look-a-head record and changes its value with a hasNext() call. This leads to weird behaviors, e.g., to different behavior depending on whether a group has an even or odd number of elements.
The second commit fixes the bug by copying the return record before giving it to the user code. This is less efficient, but ensures that the user always receives the same object and that the value of the (single) returned object is only changed with a next() call.
This is a fix for issue #128.
