### PR TITLE
Fixes for Combiner in Compiler and Runtime

### DIFF
--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/operators/GroupWithPartialPreGroupProperties.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/operators/GroupWithPartialPreGroupProperties.java
@@ -24,9 +24,11 @@ import eu.stratosphere.pact.compiler.dataproperties.LocalProperties;
 import eu.stratosphere.pact.compiler.dataproperties.PartitioningProperty;
 import eu.stratosphere.pact.compiler.dataproperties.RequestedGlobalProperties;
 import eu.stratosphere.pact.compiler.dataproperties.RequestedLocalProperties;
+import eu.stratosphere.pact.compiler.plan.ReduceNode;
 import eu.stratosphere.pact.compiler.plan.SingleInputNode;
 import eu.stratosphere.pact.compiler.plan.candidate.Channel;
 import eu.stratosphere.pact.compiler.plan.candidate.SingleInputPlanNode;
+import eu.stratosphere.pact.generic.contract.GenericReduceContract;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
 import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
@@ -63,7 +65,12 @@ public final class GroupWithPartialPreGroupProperties extends OperatorDescriptor
 			// non forward case. all local properties are killed anyways, so we can safely plug in a combiner
 			Channel toCombiner = new Channel(in.getSource());
 			toCombiner.setShipStrategy(ShipStrategyType.FORWARD);
-			SingleInputPlanNode combiner = new SingleInputPlanNode(node, toCombiner, DriverStrategy.PARTIAL_GROUP, this.keyList);
+			// create in input node for combine with same DOP as input node
+			ReduceNode combinerNode = new ReduceNode((GenericReduceContract<?>) node.getPactContract());
+			combinerNode.setDegreeOfParallelism(in.getSource().getDegreeOfParallelism());
+			combinerNode.setSubtasksPerInstance(in.getSource().getSubtasksPerInstance());
+			
+			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, toCombiner, DriverStrategy.PARTIAL_GROUP, this.keyList);
 			combiner.setCosts(new Costs(0, 0));
 			combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
 			

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/CrossNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/CrossNode.java
@@ -84,7 +84,7 @@ public class CrossNode extends TwoInputNode
 			} else if (PactCompiler.HINT_LOCAL_STRATEGY_NESTEDLOOP_STREAMED_OUTER_SECOND.equals(localStrategy)) {
 				fixedDriverStrat = new CrossStreamOuterSecondDescriptor();
 			} else {
-				throw new CompilerException("Invalid local strategy hint for cross contract: " + localStrategy);
+				throw new CompilerException("Invalid local strategy hint "+localStrategy+" for cross contract: " + localStrategy);
 			}
 			
 			return Collections.singletonList(fixedDriverStrat);

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/MatchNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/MatchNode.java
@@ -87,7 +87,7 @@ public class MatchNode extends TwoInputNode {
 			} else if (PactCompiler.HINT_LOCAL_STRATEGY_HASH_BUILD_SECOND.equals(localStrategy)) {
 				fixedDriverStrat = new HashJoinBuildSecondProperties(this.keys1, this.keys2);
 			} else {
-				throw new CompilerException("Invalid local strategy hint for match contract: " + localStrategy);
+				throw new CompilerException("Invalid local strategy hint "+localStrategy+" for match contract: " + localStrategy);
 			}
 			return Collections.singletonList(fixedDriverStrat);
 		} else {

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/ReduceNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/ReduceNode.java
@@ -105,7 +105,7 @@ public class ReduceNode extends SingleInputNode
 				}
 				useCombiner = true;
 			} else {
-				throw new CompilerException("Invalid local strategy hint for match contract: " + localStrategy);
+				throw new CompilerException("Invalid local strategy hint "+localStrategy+" for match contract: " + localStrategy);
 			}
 		} else {
 			useCombiner = isCombineable();

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
@@ -121,17 +121,13 @@ public class CombineDriver<T> implements PactDriver<GenericReducer<T, ?>, T>
 		this.comparator = this.taskContext.getInputComparator(0);
 
 		switch (ls) {
-		// local strategy is COMBININGSORT
-		// The Input is combined using a sort-merge strategy. Before spilling on disk, the data volume is reduced using
-		// the combine() method of the ReduceStub.
-		// An iterator on the sorted, grouped, and combined pairs is created and returned
-		case SORTED_GROUP:
+		case PARTIAL_GROUP:
 			this.input = new AsynchronousPartialSorter<T>(memoryManager, in, this.taskContext.getOwningNepheleTask(),
 						this.serializer, this.comparator.duplicate(), availableMemory);
 			break;
 		// obtain and return a grouped iterator from the combining sort-merger
 		default:
-			throw new RuntimeException("Invalid local strategy "+ls+" provided for CombineTask.");
+			throw new RuntimeException("Invalid local strategy provided for CombineTask.");
 		}
 	}
 

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
@@ -131,7 +131,7 @@ public class CombineDriver<T> implements PactDriver<GenericReducer<T, ?>, T>
 			break;
 		// obtain and return a grouped iterator from the combining sort-merger
 		default:
-			throw new RuntimeException("Invalid local strategy provided for CombineTask.");
+			throw new RuntimeException("Invalid local strategy "+ls+" provided for CombineTask.");
 		}
 	}
 

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CrossDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CrossDriver.java
@@ -128,7 +128,7 @@ public class CrossDriver<T1, T2, OT> implements PactDriver<GenericCrosser<T1, T2
 			this.firstIsOuter = false;
 			break;
 		default:
-			throw new RuntimeException("Invalid local strategy for CROSS: " + ls);
+			throw new RuntimeException("Invalid local strategy "+ls+" for CROSS: " + ls);
 		}
 		
 		this.memManager = this.taskContext.getMemoryManager();

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/ChainedCombineDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/ChainedCombineDriver.java
@@ -115,7 +115,7 @@ public class ChainedCombineDriver<T> extends ChainedDriver<T, T> {
 				this.inputCollector = this.sorter.getInputCollector();
 				break;
 			default:
-				throw new RuntimeException("Invalid local strategy provided for CombineTask.");
+				throw new RuntimeException("Invalid local strategy "+ds+" provided for CombineTask.");
 		}
 		
 		// ----------------- Set up the combiner thread -------------------------


### PR DESCRIPTION
Fixes for #138.
1. Compiler assigns the same DOP to Combiners as to its preceding node
2. Fixed local strategy for stand-alone (non-chained) combine driver

In addition, some strategy selection related exceptions in compiler and runtime are extended to make them more usable.
