### PR TITLE
Scala examples for Triangle Enumeration

### DIFF
--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/graph/ComputeEdgeDegrees.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/graph/ComputeEdgeDegrees.scala
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.examples.graph
+
+import eu.stratosphere.pact.client.LocalExecutor
+import eu.stratosphere.pact.common.plan.PlanAssemblerDescription
+import eu.stratosphere.scala.Args
+import eu.stratosphere.scala.DataSource
+import eu.stratosphere.scala.ScalaPlan
+import eu.stratosphere.scala.ScalaPlanAssembler
+import eu.stratosphere.scala.analysis.GlobalSchemaPrinter
+import eu.stratosphere.scala.operators.RecordDataSourceFormat
+import eu.stratosphere.scala.operators.optionToIterator
+import eu.stratosphere.scala.operators.DelimitedDataSinkFormat
+
+
+object RunComputeEdgeDegrees {
+  def main(args: Array[String]) {
+    val plan = ComputeEdgeDegrees.getPlan(
+      "file:///tmp/edges",
+      "file:///tmp/edgeDegrees")
+
+    GlobalSchemaPrinter.printSchema(plan)
+    LocalExecutor.execute(plan)
+
+    System.exit(0)
+  }
+}
+
+class ComputeEdgeDegrees extends ScalaPlanAssembler with PlanAssemblerDescription {
+  override def getDescription = "-input <file>  -output <file>"
+
+  override def getScalaPlan(args: Args) = ComputeEdgeDegrees.getPlan(args("input"), args("output"))
+}
+
+/**
+ * Annotates edges with associated vertice degrees.
+ */
+object ComputeEdgeDegrees {
+  
+  /*
+   * Output formatting function for edges with annotated degrees
+   */
+  def formatEdgeWithDegrees = (v1: Int, v2: Int, c1: Int, c2: Int) => "%d %d %d %d".format(v1, v2, c1, c2)
+  
+  def getPlan(edgeInput: String, annotatedEdgeOutput: String) = {
+    
+    /*
+     * Input format for edges. 
+     * Edges are separated by new line '\n'. 
+     * An edge is represented as two Integer vertex IDs which are separated by a blank ' '.
+     */
+    val edges = DataSource(edgeInput, RecordDataSourceFormat[(Int, Int)]("\n", " "))
+
+    /*
+     * Project all edges such that the lower vertex ID is the first vertex ID.
+     */
+    val projEdges = edges map { e => if (e._1 < e._2) e else (e._2, e._1) }
+    
+    /*
+     * Remove duplicate edges by grouping on the whole edge and returning the first edge of the group.
+     */
+    val uniqEdges = projEdges groupBy { e => e } hadoopReduce { i => i.next }
+    
+    /*
+     * Extract both vertex IDs from an edge.
+     */
+    val vertices = uniqEdges flatMap { (e) => Iterator(e._1, e._2) map {v => (v, 1)} }
+    
+    /*
+     * Count the occurrences of each vertex ID.
+     */
+    val vertexCnts = vertices groupBy { _._1 } reduce { (v1, v2) => (v1._1, v1._2 + v2._2) } 
+    
+    /*
+     * Join the first vertex of each edge with its count. 
+     */
+    val firstDegreeEdges = uniqEdges join vertexCnts where {_._1} isEqualTo {_._1} map { (e, vc) => (e._1, e._2, vc._2) }
+    
+    /*
+     * Join the second vertex of each edge with its count.
+     */
+    val bothDegreeEdges = firstDegreeEdges join vertexCnts where {_._2} isEqualTo {_._1} map { (e, vc) => (e._1, e._2, e._3, vc._2) }
+    
+    /*
+     * Emit annotated edges.
+     */
+    val output = bothDegreeEdges.write(annotatedEdgeOutput, DelimitedDataSinkFormat(formatEdgeWithDegrees.tupled))
+  
+    new ScalaPlan(Seq(output), "Compute Edge Degrees")
+  }
+}

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/graph/EnumTrianglesOnEdgesWithDegrees.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/graph/EnumTrianglesOnEdgesWithDegrees.scala
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.examples.graph
+
+import eu.stratosphere.pact.client.LocalExecutor
+import eu.stratosphere.pact.common.`type`.base.PactInteger
+import eu.stratosphere.pact.common.plan.PlanAssemblerDescription
+import eu.stratosphere.scala.Args
+import eu.stratosphere.scala.DataSource
+import eu.stratosphere.scala.ScalaPlan
+import eu.stratosphere.scala.ScalaPlanAssembler
+import eu.stratosphere.scala.analysis.GlobalSchemaPrinter
+import eu.stratosphere.scala.operators.optionToIterator
+import eu.stratosphere.scala.operators.RecordDataSourceFormat
+import eu.stratosphere.scala.operators.DelimitedDataSinkFormat
+
+
+object RunEnumTrianglesOnEdgesWithDegrees {
+  def main(args: Array[String]) {
+    
+    val plan = EnumTrianglesOnEdgesWithDegrees.getPlan(
+      "file:///tmp/edgeDegrees",
+      "file:///tmp/triangles")
+
+    GlobalSchemaPrinter.printSchema(plan)
+    LocalExecutor.execute(plan)
+
+    System.exit(0)
+  }
+}
+
+class EnumTrianglesOnEdgesWithDegreesDescriptor extends ScalaPlanAssembler with PlanAssemblerDescription {
+  override def getDescription = "-input <file>  -output <file>"
+
+  override def getScalaPlan(args: Args) = EnumTrianglesOnEdgesWithDegrees.getPlan(args("input"), args("output"))
+}
+
+/**
+ * Enumerates all triangles build by three connected vertices in a graph.
+ * The graph is represented as edges (pairs of vertices) with annotated vertex degrees. * 
+ */
+object EnumTrianglesOnEdgesWithDegrees {
+  
+  /*
+   * Output formatting function for triangles.
+   */
+  def formatTriangle = (v1: Int, v2: Int, v3: Int) => "%d %d %d".format(v1, v2, v3)
+  
+  def getPlan(edgeInput: String, triangleOutput: String) = {
+    
+    /*
+     * Input format for edges with degrees
+     * Edges are separated by new line '\n'. 
+     * An edge with degrees is represented by four Integers (vertex IDs) separated by one space ' '.
+     * The first two Integers are the vertex IDs.
+     * The third and forth Integer are the degrees of the first and second vertex, respectively. 
+     */
+    val edgeWithDegrees = DataSource(edgeInput, RecordDataSourceFormat[(Int, Int, Int, Int)]("\n", " "))
+
+    /*
+     * Project edges such that vertex with higher degree comes first (record position 1) and remove the degrees.
+     */
+    val projEdges = edgeWithDegrees map { (x) => if (x._3 > x._4) (x._1, x._2) else (x._2, x._1) }
+    
+    /*
+     * Join projected edges with themselves on lower vertex id.
+     * Emit a triad (triangle candidate with one missing edge) for each unique combination of edges. 
+     * Ensure that vertices are ordered by vertex id. 
+     */   
+    val triads = projEdges join projEdges where { _._1 } isEqualTo { _._1 } flatMap { (e1, e2) =>
+        (e1, e2) match {
+          case ((v11, v12), (_, v22)) if v12 < v22 => Some((v11, v12, v22))
+          case _ => None
+        }
+      }
+    
+    /*
+     * Join triads with projected edges to 'close' triads.
+     * This filters triads without a closing edge.
+     */
+    val triangles = triads join projEdges where { t => (t._2, t._3) } isEqualTo { e => (e._1, e._2) } map { (t, e) => t }
+    
+    /*
+     * Emit triangles
+     */
+    val output = triangles.write(triangleOutput, DelimitedDataSinkFormat(formatTriangle.tupled))
+  
+    new ScalaPlan(Seq(output), "Enumerate Triangles on Edges with Degrees")
+  }
+}

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/operators/GroupWithPartialPreGroupProperties.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/operators/GroupWithPartialPreGroupProperties.java
@@ -24,9 +24,11 @@ import eu.stratosphere.pact.compiler.dataproperties.LocalProperties;
 import eu.stratosphere.pact.compiler.dataproperties.PartitioningProperty;
 import eu.stratosphere.pact.compiler.dataproperties.RequestedGlobalProperties;
 import eu.stratosphere.pact.compiler.dataproperties.RequestedLocalProperties;
+import eu.stratosphere.pact.compiler.plan.ReduceNode;
 import eu.stratosphere.pact.compiler.plan.SingleInputNode;
 import eu.stratosphere.pact.compiler.plan.candidate.Channel;
 import eu.stratosphere.pact.compiler.plan.candidate.SingleInputPlanNode;
+import eu.stratosphere.pact.generic.contract.GenericReduceContract;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
 import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
@@ -63,7 +65,12 @@ public final class GroupWithPartialPreGroupProperties extends OperatorDescriptor
 			// non forward case. all local properties are killed anyways, so we can safely plug in a combiner
 			Channel toCombiner = new Channel(in.getSource());
 			toCombiner.setShipStrategy(ShipStrategyType.FORWARD);
-			SingleInputPlanNode combiner = new SingleInputPlanNode(node, toCombiner, DriverStrategy.PARTIAL_GROUP, this.keyList);
+			// create in input node for combine with same DOP as input node
+			ReduceNode combinerNode = new ReduceNode((GenericReduceContract<?>) node.getPactContract());
+			combinerNode.setDegreeOfParallelism(in.getSource().getDegreeOfParallelism());
+			combinerNode.setSubtasksPerInstance(in.getSource().getSubtasksPerInstance());
+			
+			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, toCombiner, DriverStrategy.PARTIAL_GROUP, this.keyList);
 			combiner.setCosts(new Costs(0, 0));
 			combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
 			

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/CrossNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/CrossNode.java
@@ -84,7 +84,7 @@ public class CrossNode extends TwoInputNode
 			} else if (PactCompiler.HINT_LOCAL_STRATEGY_NESTEDLOOP_STREAMED_OUTER_SECOND.equals(localStrategy)) {
 				fixedDriverStrat = new CrossStreamOuterSecondDescriptor();
 			} else {
-				throw new CompilerException("Invalid local strategy hint for cross contract: " + localStrategy);
+				throw new CompilerException("Invalid local strategy hint "+localStrategy+" for cross contract: " + localStrategy);
 			}
 			
 			return Collections.singletonList(fixedDriverStrat);

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/MatchNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/MatchNode.java
@@ -87,7 +87,7 @@ public class MatchNode extends TwoInputNode {
 			} else if (PactCompiler.HINT_LOCAL_STRATEGY_HASH_BUILD_SECOND.equals(localStrategy)) {
 				fixedDriverStrat = new HashJoinBuildSecondProperties(this.keys1, this.keys2);
 			} else {
-				throw new CompilerException("Invalid local strategy hint for match contract: " + localStrategy);
+				throw new CompilerException("Invalid local strategy hint "+localStrategy+" for match contract: " + localStrategy);
 			}
 			return Collections.singletonList(fixedDriverStrat);
 		} else {

--- a/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/ReduceNode.java
+++ b/pact/pact-compiler/src/main/java/eu/stratosphere/pact/compiler/plan/ReduceNode.java
@@ -105,7 +105,7 @@ public class ReduceNode extends SingleInputNode
 				}
 				useCombiner = true;
 			} else {
-				throw new CompilerException("Invalid local strategy hint for match contract: " + localStrategy);
+				throw new CompilerException("Invalid local strategy hint "+localStrategy+" for match contract: " + localStrategy);
 			}
 		} else {
 			useCombiner = isCombineable();

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
@@ -121,17 +121,13 @@ public class CombineDriver<T> implements PactDriver<GenericReducer<T, ?>, T>
 		this.comparator = this.taskContext.getInputComparator(0);
 
 		switch (ls) {
-		// local strategy is COMBININGSORT
-		// The Input is combined using a sort-merge strategy. Before spilling on disk, the data volume is reduced using
-		// the combine() method of the ReduceStub.
-		// An iterator on the sorted, grouped, and combined pairs is created and returned
-		case SORTED_GROUP:
+		case PARTIAL_GROUP:
 			this.input = new AsynchronousPartialSorter<T>(memoryManager, in, this.taskContext.getOwningNepheleTask(),
 						this.serializer, this.comparator.duplicate(), availableMemory);
 			break;
 		// obtain and return a grouped iterator from the combining sort-merger
 		default:
-			throw new RuntimeException("Invalid local strategy "+ls+" provided for CombineTask.");
+			throw new RuntimeException("Invalid local strategy provided for CombineTask.");
 		}
 	}
 

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CombineDriver.java
@@ -131,7 +131,7 @@ public class CombineDriver<T> implements PactDriver<GenericReducer<T, ?>, T>
 			break;
 		// obtain and return a grouped iterator from the combining sort-merger
 		default:
-			throw new RuntimeException("Invalid local strategy provided for CombineTask.");
+			throw new RuntimeException("Invalid local strategy "+ls+" provided for CombineTask.");
 		}
 	}
 

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CrossDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/CrossDriver.java
@@ -128,7 +128,7 @@ public class CrossDriver<T1, T2, OT> implements PactDriver<GenericCrosser<T1, T2
 			this.firstIsOuter = false;
 			break;
 		default:
-			throw new RuntimeException("Invalid local strategy for CROSS: " + ls);
+			throw new RuntimeException("Invalid local strategy "+ls+" for CROSS: " + ls);
 		}
 		
 		this.memManager = this.taskContext.getMemoryManager();

--- a/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/ChainedCombineDriver.java
+++ b/pact/pact-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/ChainedCombineDriver.java
@@ -115,7 +115,7 @@ public class ChainedCombineDriver<T> extends ChainedDriver<T, T> {
 				this.inputCollector = this.sorter.getInputCollector();
 				break;
 			default:
-				throw new RuntimeException("Invalid local strategy provided for CombineTask.");
+				throw new RuntimeException("Invalid local strategy "+ds+" provided for CombineTask.");
 		}
 		
 		// ----------------- Set up the combiner thread -------------------------

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskExternalITCase.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskExternalITCase.java
@@ -56,7 +56,7 @@ public class CombineTaskExternalITCase extends DriverTestBase<GenericReducer<Pac
 		addInputComparator(this.comparator);
 		setOutput(this.outList);
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		
@@ -109,7 +109,7 @@ public class CombineTaskExternalITCase extends DriverTestBase<GenericReducer<Pac
 		addInputComparator(this.comparator);
 		setOutput(this.outList);
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		

--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskTest.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskTest.java
@@ -61,7 +61,7 @@ public class CombineTaskTest extends DriverTestBase<GenericReducer<PactRecord, ?
 		addInputComparator(this.comparator);
 		setOutput(this.outList);
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		
@@ -97,7 +97,7 @@ public class CombineTaskTest extends DriverTestBase<GenericReducer<PactRecord, ?
 		addInputComparator(this.comparator);
 		setOutput(new DiscardingOutputCollector());
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		
@@ -121,7 +121,7 @@ public class CombineTaskTest extends DriverTestBase<GenericReducer<PactRecord, ?
 		addInputComparator(this.comparator);
 		setOutput(new DiscardingOutputCollector());
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		


### PR DESCRIPTION
Added first versions of the Scala examples for triangle enumeration.
The examples include:
- Annotation of edges with the corresponding vertex degrees (+ unique projection of vertexes and duplicate removal)
- Enumeration of triangles on edges with degrees.

The examples perform the same job as the corresponding Java versions. However, they use different strategies (joins instead of reduce in some places). Exactly following the Java strategies didn't work for a Scala novice ;-)
However, this might be changed later.
