### PR TITLE
Remove commons-io from pact-clients.

### DIFF
--- a/pact/pact-clients/pom.xml
+++ b/pact/pact-clients/pom.xml
@@ -69,15 +69,15 @@
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
-
+		<!-- commons-io is required by commons-fileupload
+			See http://commons.apache.org/proper/commons-fileupload/dependencies.html
+			and https://github.com/dimalabs/ozone/pull/157 -->
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
-			<type>jar</type>
+			<version>2.1</version>
 			<scope>compile</scope>
 		</dependency>
-
 	</dependencies>
 
 	<reporting>

--- a/pact/pact-hbase/pom.xml
+++ b/pact/pact-hbase/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>pact-common</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
- it does not seem to be used there
- It is in conflict with commons-io from hadoop yarn (which uses commons-io 2.1)
- The coordinates of the artifact changed (and Andre and I forgot to rename it)
- My Telecom use-cases were breaking because of this: My code expected a method from commons-io:2.1 but 1.3.2 was loaded. I had no troubles loading my code with pact-client.sh, I did, however, not check if the pact webinterface still works. But eclipse did not show any errors after removing commons-io.
