### PR TITLE
Added getUserCodeClass to UserCodeWrapper

### DIFF
--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeClassWrapper.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeClassWrapper.java
@@ -61,4 +61,9 @@ public class UserCodeClassWrapper<T> implements UserCodeWrapper<T> {
 			Class<A> annotationClass) {
 		return userCodeClass.getAnnotation(annotationClass);
 	}
+	
+	@Override
+	public Class<? extends T> getUserCodeClass() {
+		return userCodeClass;
+	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeObjectWrapper.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeObjectWrapper.java
@@ -57,4 +57,10 @@ public class UserCodeObjectWrapper<T> implements UserCodeWrapper<T> {
 			Class<A> annotationClass) {
 		return userCodeObject.getClass().getAnnotation(annotationClass);
 	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<? extends T> getUserCodeClass() {
+		return (Class<? extends T>) userCodeObject.getClass();
+	}
 }

--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeWrapper.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/contract/UserCodeWrapper.java
@@ -55,4 +55,12 @@ public interface UserCodeWrapper<T> extends Serializable {
 	 * @return the annotation, or null if no annotation of the requested type was found
 	 */
 	public <A extends Annotation> A getUserCodeAnnotation(Class<A> annotationClass);
+	
+	/**
+	 * Gets the class of the user code. If the user code is provided as a class, this class is just returned.
+	 * If the user code is provided as an object, {@link Object#getClass()} is called on the user code object.
+	 * 
+	 * @return The class of the user code object.
+	 */
+	public Class<? extends T> getUserCodeClass ();
 }


### PR DESCRIPTION
This pull request adds getUserCodeClass () to UserCodeWrapper to allow for quick access to the class.

Sopremo and Meteor make heavy use of reflection and often require access to the class of the user code.
Currently, the UserCodeWrapper only allows to return instances of the user code, not the class.
It would be possible to just call getClass() on the user code object, however this leads to unnecessary instantiations of the user code if it is provided as a class, not as object.
