### PR TITLE
PactRecord allocating too few memory when writing UTF encoded strings

### DIFF
--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/PactRecord.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/common/type/PactRecord.java
@@ -1556,7 +1556,7 @@ public final class PactRecord implements Value {
 				throw new UTFDataFormatException("Encoded string is too long: " + utflen);
 			
 			else if (this.position > this.memory.length - utflen - 2) {
-				resize(utflen);
+				resize(utflen + 2);
 			}
 			
 			byte[] bytearr = this.memory;


### PR DESCRIPTION
PactRecord serializes UTF strings by writing the size of the encoded string (2 bytes) and the actual data.
The current code correctly checks whether size+data actually fit in memory, but it only allocates the memory for the data, not the 2 size bytes.
