### PR TITLE
Remote executor feature

### DIFF
--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
@@ -35,7 +35,7 @@ import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
  * When the class is instantiated a local nephele instance is started, this can
  * be stopped by calling stopNephele.
  */
-public class LocalExecutor {
+public class LocalExecutor implements PlanExecutor {
 
 	private final Object lock = new Object();	// we lock to ensure singleton execution
 	
@@ -60,16 +60,10 @@ public class LocalExecutor {
 		}
 	}
 
-	/**
-	 * Execute the given plan on the local Nephele instance, wait for the job to
-	 * finish and return the runtime in milliseconds.
-	 * 
-	 * @param plan The plan of the program to execute.
-	 * @return The net runtime of the program, in milliseconds.
-	 * 
-	 * @throws Exception Thrown, if either the startup of the local execution context, or the execution
-	 *                   caused an exception.
+	/* (non-Javadoc)
+	 * @see eu.stratosphere.pact.client.PlanExecutor#executePlan(eu.stratosphere.pact.common.plan.Plan)
 	 */
+	@Override
 	public long executePlan(Plan plan) throws Exception {
 		synchronized (this.lock) {
 			if (this.nephele == null) {

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/PlanExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/PlanExecutor.java
@@ -1,0 +1,17 @@
+package eu.stratosphere.pact.client;
+
+import eu.stratosphere.pact.common.plan.Plan;
+
+public interface PlanExecutor {
+
+	/**
+	 * Execute the given plan and return the runtime in milliseconds.
+	 * 
+	 * @param plan The plan of the program to execute.
+	 * @return The net runtime of the program, in milliseconds.
+	 * 
+	 * @throws Exception Thrown, i job submission caused an exception.
+	 */
+	public abstract long executePlan(Plan plan) throws Exception;
+
+}

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/RemoteExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/RemoteExecutor.java
@@ -1,0 +1,33 @@
+package eu.stratosphere.pact.client;
+
+import java.net.InetSocketAddress;
+import java.util.LinkedList;
+import java.util.List;
+
+import eu.stratosphere.pact.client.nephele.api.Client;
+import eu.stratosphere.pact.client.nephele.api.PlanWithJars;
+import eu.stratosphere.pact.common.plan.Plan;
+
+public class RemoteExecutor implements PlanExecutor {
+	private Client client;
+	private List<String> jarFiles;
+	
+	public RemoteExecutor(String hostname, int port, List<String> jarFiles) {
+		client = new Client(new InetSocketAddress(hostname, port));
+		this.jarFiles = jarFiles;
+
+	}
+
+	public RemoteExecutor(String hostname, int port, String jarFile) {
+		this(hostname, port, new LinkedList<String>());
+		jarFiles.add(jarFile);
+
+	}
+
+	@Override
+	public long executePlan(Plan plan) throws Exception {
+		PlanWithJars p = new PlanWithJars(plan, jarFiles);
+		client.run(p, true);
+		return 0;
+	}
+}

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/Client.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/Client.java
@@ -224,8 +224,8 @@ public class Client {
 	 *                                    on the nephele system failed.
 	 * @throws ErrorInPlanAssemblerException Thrown, if the plan assembler function causes an exception.
 	 */
-	public void run(PlanWithJars prog) throws CompilerException, ProgramInvocationException, ErrorInPlanAssemblerException {
-		run(prog, false);
+	public long run(PlanWithJars prog) throws CompilerException, ProgramInvocationException, ErrorInPlanAssemblerException {
+		return run(prog, false);
 	}
 	
 	/**
@@ -241,8 +241,8 @@ public class Client {
 	 *                                    on the nephele system failed.
 	 * @throws ErrorInPlanAssemblerException Thrown, if the plan assembler function causes an exception.
 	 */
-	public void run(PlanWithJars prog, boolean wait) throws CompilerException, ProgramInvocationException, ErrorInPlanAssemblerException {
-		run(prog, getOptimizedPlan(prog), wait);
+	public long run(PlanWithJars prog, boolean wait) throws CompilerException, ProgramInvocationException, ErrorInPlanAssemblerException {
+		return run(prog, getOptimizedPlan(prog), wait);
 	}
 	
 	/**
@@ -256,8 +256,8 @@ public class Client {
 	 *                                    i.e. the job-manager is unreachable, or due to the fact that the execution
 	 *                                    on the nephele system failed.
 	 */
-	public void run(PlanWithJars prog, OptimizedPlan compiledPlan) throws ProgramInvocationException {
-		run(prog, compiledPlan, false);
+	public long run(PlanWithJars prog, OptimizedPlan compiledPlan) throws ProgramInvocationException {
+		return run(prog, compiledPlan, false);
 	}
 	
 	/**
@@ -272,9 +272,9 @@ public class Client {
 	 *                                    i.e. the job-manager is unreachable, or due to the fact that the execution
 	 *                                    on the nephele system failed.
 	 */
-	public void run(PlanWithJars prog, OptimizedPlan compiledPlan, boolean wait) throws ProgramInvocationException {
+	public long run(PlanWithJars prog, OptimizedPlan compiledPlan, boolean wait) throws ProgramInvocationException {
 		JobGraph job = getJobGraph(prog, compiledPlan);
-		run(prog, job, wait);
+		return run(prog, job, wait);
 	}
 
 	/**
@@ -285,8 +285,8 @@ public class Client {
 	 *                                    i.e. the job-manager is unreachable, or due to the fact that the execution
 	 *                                    on the nephele system failed.
 	 */
-	public void run(PlanWithJars program, JobGraph jobGraph) throws ProgramInvocationException {
-		run(program, jobGraph, false);
+	public long run(PlanWithJars program, JobGraph jobGraph) throws ProgramInvocationException {
+		return run(program, jobGraph, false);
 	}
 	/**
 	 * Submits the job-graph to the nephele job-manager for execution.
@@ -298,7 +298,7 @@ public class Client {
 	 *                                    i.e. the job-manager is unreachable, or due to the fact that the execution
 	 *                                    on the nephele system failed.
 	 */
-	public void run(PlanWithJars program, JobGraph jobGraph, boolean wait) throws ProgramInvocationException
+	public long run(PlanWithJars program, JobGraph jobGraph, boolean wait) throws ProgramInvocationException
 	{
 		JobClient client;
 		try {
@@ -310,7 +310,7 @@ public class Client {
 
 		try {
 			if (wait) {
-				client.submitJobAndWait();
+				return client.submitJobAndWait();
 			}
 			else {
 				JobSubmissionResult result = client.submitJob();
@@ -331,5 +331,6 @@ public class Client {
 				throw new ProgramInvocationException("The program execution failed: " + jex.getMessage());
 			}
 		}
+		return -1;
 	}
 }

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/Client.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/Client.java
@@ -21,15 +21,16 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.InetSocketAddress;
 
+import eu.stratosphere.nephele.client.AbstractJobResult.ReturnCode;
 import eu.stratosphere.nephele.client.JobClient;
 import eu.stratosphere.nephele.client.JobExecutionException;
 import eu.stratosphere.nephele.client.JobSubmissionResult;
-import eu.stratosphere.nephele.client.AbstractJobResult.ReturnCode;
 import eu.stratosphere.nephele.configuration.ConfigConstants;
 import eu.stratosphere.nephele.configuration.Configuration;
 import eu.stratosphere.nephele.configuration.GlobalConfiguration;
 import eu.stratosphere.nephele.fs.Path;
 import eu.stratosphere.nephele.jobgraph.JobGraph;
+import eu.stratosphere.pact.common.plan.Plan;
 import eu.stratosphere.pact.compiler.CompilerException;
 import eu.stratosphere.pact.compiler.DataStatistics;
 import eu.stratosphere.pact.compiler.PactCompiler;
@@ -37,6 +38,7 @@ import eu.stratosphere.pact.compiler.costs.DefaultCostEstimator;
 import eu.stratosphere.pact.compiler.plan.candidate.OptimizedPlan;
 import eu.stratosphere.pact.compiler.plandump.PlanJSONDumpGenerator;
 import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
+import eu.stratosphere.pact.contextcheck.ContextChecker;
 
 /**
  * Encapsulates the functionality necessary to compile and submit a pact program to a nephele cluster.
@@ -104,8 +106,10 @@ public class Client {
 	 * @throws ErrorInPlanAssemblerException Thrown, if the plan assembler function causes an exception.
 	 */
 	public OptimizedPlan getOptimizedPlan(PactProgram prog) throws CompilerException, ProgramInvocationException, ErrorInPlanAssemblerException {
-		prog.checkPlan();
-		return this.compiler.compile(prog.getPlan());
+		Plan plan = prog.getPlan();
+		ContextChecker checker = new ContextChecker();
+		checker.check(plan);
+		return this.compiler.compile(plan);
 	}
 	
 	/**

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/PactProgram.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/PactProgram.java
@@ -40,7 +40,6 @@ import eu.stratosphere.pact.common.plan.PlanAssembler;
 import eu.stratosphere.pact.common.plan.PlanAssemblerDescription;
 import eu.stratosphere.pact.compiler.PactCompiler;
 import eu.stratosphere.pact.compiler.plan.DataSinkNode;
-import eu.stratosphere.pact.contextcheck.ContextChecker;
 
 /**
  * This class encapsulates most of the plan related functions. Based on the given jar file,
@@ -129,22 +128,6 @@ public class PactProgram {
 			this.plan = createPlanFromJar(this.assemblerClass, this.args);
 		}
 		return this.plan;
-	}
-
-	/**
-	 * Semantic check of generated plan
-	 * 
-	 * @throws ProgramInvocationException
-	 *         This invocation is thrown if the PlanAssembler can't be properly loaded. Causes
-	 *         may be a missing / wrong class or manifest files.
-	 * @throws ErrorInPlanAssemblerException
-	 *         Thrown if an error occurred in the user-provided pact assembler. This may indicate
-	 *         missing parameters for generation.
-	 */
-	public void checkPlan() throws ProgramInvocationException, ErrorInPlanAssemblerException {
-		// semantic context check of the generated plan
-		ContextChecker checker = new ContextChecker();
-		checker.check(getPlan());
 	}
 
 	/**

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/PactProgram.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/PactProgram.java
@@ -25,6 +25,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Random;
@@ -64,7 +65,7 @@ public class PactProgram {
 
 	private final String[] args;
 	
-	private File[] extractedTempLibraries;
+	private List<File> extractedTempLibraries;
 	
 	private Plan plan;
 
@@ -110,6 +111,21 @@ public class PactProgram {
 		this.args = args == null ? new String[0] : args;
 		this.assemblerClass = getPactAssemblerFromJar(jarFile, className);
 	}
+	
+	/**
+	 * Returns the plan with all required jars.
+	 * @throws IOException 
+	 * @throws ErrorInPlanAssemblerException 
+	 * @throws ProgramInvocationException 
+	 */
+	public PlanWithJars getPlanWithJars() throws ProgramInvocationException, ErrorInPlanAssemblerException, IOException {
+		List<String> result = new ArrayList<String>();
+		for (File jar: extractContainedLibaries(jarFile)) {
+			result.add(jar.getAbsolutePath());
+		}
+		result.add(jarFile.getAbsolutePath());
+		return new PlanWithJars(getPlan(), result);
+	}
 
 	/**
 	 * Returns the plan as generated from the Pact Assembler.
@@ -123,10 +139,10 @@ public class PactProgram {
 	 *         Thrown if an error occurred in the user-provided pact assembler. This may indicate
 	 *         missing parameters for generation.
 	 */
-	public Plan getPlan() throws ProgramInvocationException, ErrorInPlanAssemblerException {
+	private Plan getPlan() throws ProgramInvocationException, ErrorInPlanAssemblerException {
 		if (this.plan == null) {
-			this.plan = createPlanFromJar(this.assemblerClass, this.args);
 		}
+		this.plan = createPlanFromJar(this.assemblerClass, this.args);
 		return this.plan;
 	}
 
@@ -149,16 +165,6 @@ public class PactProgram {
 		} else {
 			return null;
 		}
-	}
-
-	/**
-	 * Returns the File object of the jar file that is used as base for the
-	 * pact program.
-	 * 
-	 * @return The jar-file of the PactProgram.
-	 */
-	public File getJarFile() {
-		return this.jarFile;
 	}
 
 	/**
@@ -216,7 +222,7 @@ public class PactProgram {
 	 * @return The file names of the extracted temporary files.
 	 * @throws IOException Thrown, if the extraction process failed.
 	 */
-	public File[] extractContainedLibaries() throws IOException {
+	public List<File> extractContainedLibaries(File jarFile) throws IOException {
 		if (this.extractedTempLibraries != null) {
 			return this.extractedTempLibraries;
 			
@@ -240,20 +246,20 @@ public class PactProgram {
 			}
 			
 			if (containedJarFileEntries.isEmpty()) {
-				this.extractedTempLibraries = new File[0];
+				this.extractedTempLibraries = Collections.emptyList();
 				return this.extractedTempLibraries;
 			}
 			
 			// go over all contained jar files
-			this.extractedTempLibraries = new File[containedJarFileEntries.size()];
-			for (int i = 0; i < this.extractedTempLibraries.length; i++)
+			this.extractedTempLibraries = new ArrayList<File>(containedJarFileEntries.size());
+			for (int i = 0; i < this.extractedTempLibraries.size(); i++)
 			{
 				final JarEntry entry = containedJarFileEntries.get(i);
 				String name = entry.getName();
 				name = name.replace(File.separatorChar, '_');
 				
 				File tempFile = File.createTempFile(String.valueOf(Math.abs(rnd.nextInt()) + "_"), name);
-				this.extractedTempLibraries[i] = tempFile;
+				this.extractedTempLibraries.set(i, tempFile);
 			
 				// copy the temp file contents to a temporary File
 				OutputStream out = null;
@@ -292,9 +298,9 @@ public class PactProgram {
 	 */
 	public void deleteExtractedLibraries() {
 		if (this.extractedTempLibraries != null) {
-			for (int i = 0; i < this.extractedTempLibraries.length; i++) {
-				this.extractedTempLibraries[i].delete();
-				this.extractedTempLibraries[i] = null;
+			for (int i = 0; i < this.extractedTempLibraries.size(); i++) {
+				this.extractedTempLibraries.get(i).delete();
+				this.extractedTempLibraries.set(i, null);
 			}
 			this.extractedTempLibraries = null;
 		}
@@ -364,10 +370,9 @@ public class PactProgram {
 		Manifest manifest = null;
 		String className = null;
 
-		checkJarFile(jarFile);
-
 		// Open jar file
 		try {
+			PlanWithJars.checkJarFile(jarFile);
 			jar = new JarFile(jarFile);
 		} catch (IOException ioex) {
 			throw new ProgramInvocationException("Error while opening jar file '" + jarFile.getPath() + "'. "
@@ -407,17 +412,17 @@ public class PactProgram {
 	{
 		Class<? extends PlanAssembler> clazz = null;
 
-		checkJarFile(jarFile);
 
 		try {
-			File[] nestedJars = extractContainedLibaries();
+			PlanWithJars.checkJarFile(jarFile);
+			List<File> nestedJars = extractContainedLibaries(jarFile);
 			
-			URL[] urls = new URL[1 + nestedJars.length];
+			URL[] urls = new URL[1 + nestedJars.size()];
 			urls[0] = jarFile.getAbsoluteFile().toURI().toURL();
 			
 			// add the nested jars
-			for (int i = 0; i < nestedJars.length; i++) {
-				urls[i+1] = nestedJars[i].getAbsoluteFile().toURI().toURL();
+			for (int i = 0; i < nestedJars.size(); i++) {
+				urls[i+1] = nestedJars.get(i).getAbsoluteFile().toURI().toURL();
 			}
 			
 			ClassLoader loader = new URLClassLoader(urls, this.getClass().getClassLoader());
@@ -447,13 +452,4 @@ public class PactProgram {
 		return clazz;
 	}
 
-	private void checkJarFile(File jar) throws ProgramInvocationException {
-		if (!jar.exists()) {
-			throw new ProgramInvocationException("JAR file does not exist '" + jarFile.getPath() + "'");
-		}
-		if (!jar.canRead()) {
-			throw new ProgramInvocationException("JAR file can't be read '" + jarFile.getPath() + "'");
-		}
-		// TODO: Check if proper JAR file
-	}
 }

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/PlanWithJars.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/PlanWithJars.java
@@ -1,0 +1,58 @@
+package eu.stratosphere.pact.client.nephele.api;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import eu.stratosphere.pact.common.plan.Plan;
+
+public class PlanWithJars {
+	private Plan plan;
+	private List<String> jarFiles;
+
+	public PlanWithJars(Plan plan, List<String> jarFiles) throws IOException {
+		this.plan = plan;
+		this.jarFiles = jarFiles;
+		for (String jar: jarFiles) {
+			File file = new File(jar);
+			checkJarFile(file);
+		}
+	}
+	
+	public PlanWithJars(Plan plan, String jarFile) throws IOException {
+		this(plan, new LinkedList<String>());
+		checkJarFile(new File(jarFile));
+		jarFiles.add(jarFile);
+	}
+
+	/**
+	 * Returns the plan
+	 */
+	public Plan getPlan() {
+		return this.plan;
+	}
+
+	/**
+	 * Returns list of jar files that need to be submitted with the plan.
+	 */
+	public List<File> getJarFiles() throws IOException {
+		List<File> result = new ArrayList<File>(jarFiles.size());
+		for (String jar: jarFiles) {
+			result.add(new File(jar));
+		}
+		return result;
+	}
+	
+
+	public static void checkJarFile(File jar) throws IOException {
+		if (!jar.exists()) {
+			throw new IOException("JAR file does not exist '" + jar.getAbsolutePath() + "'");
+		}
+		if (!jar.canRead()) {
+			throw new IOException("JAR file can't be read '" + jar.getAbsolutePath() + "'");
+		}
+		// TODO: Check if proper JAR file
+	}
+}

--- a/pact/pact-clients/src/test/java/eu/stratosphere/pact/client/nephele/api/ClientTest.java
+++ b/pact/pact-clients/src/test/java/eu/stratosphere/pact/client/nephele/api/ClientTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
@@ -63,9 +62,9 @@ public class ClientTest {
 	@Mock
 	PactProgram program;
 	@Mock
+	PlanWithJars planWithJarsMock;
+	@Mock
 	Plan planMock;
-	@Mock 
-	File mockJarFile;
 	
 	@Mock
 	PactCompiler compilerMock;
@@ -91,10 +90,10 @@ public class ClientTest {
 		when(configMock.getInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, ConfigConstants.DEFAULT_JOB_MANAGER_IPC_PORT)).thenReturn(6123);
 		
 		when(planMock.getJobName()).thenReturn("MockPlan");
-		when(mockJarFile.getAbsolutePath()).thenReturn("mockFilePath");
+//		when(mockJarFile.getAbsolutePath()).thenReturn("mockFilePath");
 		
-		when(program.getJarFile()).thenReturn(mockJarFile);
-		when(program.getPlan()).thenReturn(planMock);
+		when(program.getPlanWithJars()).thenReturn(planWithJarsMock);
+		when(planWithJarsMock.getPlan()).thenReturn(planMock);
 		
 		whenNew(PactCompiler.class).withArguments(any(DataStatistics.class), any(CostEstimator.class), any(InetSocketAddress.class)).thenReturn(this.compilerMock);
 		when(compilerMock.compile(planMock)).thenReturn(optimizedPlanMock);
@@ -113,7 +112,8 @@ public class ClientTest {
 		when(jobSubmissionResultMock.getReturnCode()).thenReturn(ReturnCode.SUCCESS);
 		
 		Client out = new Client(configMock);
-		out.run(program);
+		out.run(program.getPlanWithJars());
+		program.deleteExtractedLibraries();
 		
 		verify(this.compilerMock, times(1)).compile(planMock);
 		verify(this.generatorMock, times(1)).compileJobGraph(optimizedPlanMock);
@@ -129,7 +129,9 @@ public class ClientTest {
 		when(jobSubmissionResultMock.getReturnCode()).thenReturn(ReturnCode.ERROR);
 		
 		Client out = new Client(configMock);
-		out.run(program);
+		out.run(program.getPlanWithJars());
+		program.deleteExtractedLibraries();
+		
 		verify(this.jobClientMock).submitJob();
 	}
 }

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
@@ -18,7 +18,8 @@ package eu.stratosphere.pact.example.wordcount;
 import java.io.Serializable;
 import java.util.Iterator;
 
-import eu.stratosphere.pact.client.LocalExecutor;
+import eu.stratosphere.pact.client.PlanExecutor;
+import eu.stratosphere.pact.client.RemoteExecutor;
 import eu.stratosphere.pact.common.contract.FileDataSink;
 import eu.stratosphere.pact.common.contract.FileDataSource;
 import eu.stratosphere.pact.common.contract.MapContract;
@@ -159,8 +160,11 @@ public class WordCount implements PlanAssembler, PlanAssemblerDescription {
 	
 	public static void main(String[] args) throws Exception {
 		WordCount wc = new WordCount();
-		Plan plan = wc.getPlan("1", "file:///path/to/input", "file:///path/to/output");
-		LocalExecutor.execute(plan);
-		System.exit(0);
+		Plan plan = wc.getPlan(args[0], args[1], args[2]);
+		// This will create an executor to run the plan on a cluster. We assume
+		// that the JobManager is running on the local machine on the default
+		// port. Change this according to your configuration.
+		PlanExecutor ex = new RemoteExecutor("localhost", 6123, "target/pact-examples-0.4-SNAPSHOT-WordCount.jar");
+		ex.executePlan(plan);
 	}
 }


### PR DESCRIPTION
This pull request will in the end have a RemoteExecutor which will be used like:
val exec = new RemoteExecutor("localhost:666", "some.jar")
exec.execute(myPlan)

(Also usable from Java and written in Java)

For now I just have some refactoring of how Client.run() works and of PactProgram, what do you think of these?

Client.run() now accepts a PlanWithJars which is a wrapper of a Plan and a list of jars required for the job. I removed the jar extraction/deletion logic from Client.
