### PR TITLE
Use JAVA_RUN in all start scripts

### DIFF
--- a/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-visualization.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/bin/nephele-visualization.sh
@@ -43,4 +43,4 @@ log_setting="-Dlog.file="$log" -Dlog4j.configuration=file://"$NEPHELE_CONF_DIR"/
 
 NEPHELE_VS_CLASSPATH=$(constructVisualizationClassPath)
 
-$JAVA_HOME/bin/java $JVM_ARGS $NEPHELE_OPTS $log_setting -classpath $NEPHELE_VS_CLASSPATH eu.stratosphere.nephele.visualization.swt.SWTVisualization -configDir $NEPHELE_CONF_DIR
+$JAVA_RUN $JVM_ARGS $NEPHELE_OPTS $log_setting -classpath $NEPHELE_VS_CLASSPATH eu.stratosphere.nephele.visualization.swt.SWTVisualization -configDir $NEPHELE_CONF_DIR


### PR DESCRIPTION
See issue #207 for details.

We would still need to change the last `/` in `DEFAULT_ENV_JAVA_HOME`, but I didn't want to have a conflict with the pull request in #207. 
