### PR TITLE
change deploy tool to detect current stratosphere version

### DIFF
--- a/tools/deploy_to_maven.sh
+++ b/tools/deploy_to_maven.sh
@@ -1,8 +1,31 @@
 #!/usr/bin/env bash
 
+#Please ask @rmetzger (on GitHub) before changing anything here. It contains some magic.
 
-CURRENT_STRATOSPHERE_VERSION=0.4-SNAPSHOT
-CURRENT_STRATOSPHERE_VERSION_YARN=0.4-hadoop2-SNAPSHOT
+function getVersion() {
+	here="`dirname \"$0\"`"              # relative
+	here="`( cd \"$here\" && pwd )`"  # absolutized and normalized
+	if [ -z "$here" ] ; then
+	  # error; for some reason, the path is not accessible
+	  # to the script (e.g. permissions re-evaled after suid)
+	  exit 1  # fail
+	fi
+	stratosphere_home="`dirname \"$here\"`"
+	cd $stratosphere_home
+	echo `mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`
+}
+
+# this will take a while
+CURRENT_STRATOSPHERE_VERSION=`getVersion`
+if [[ "$CURRENT_STRATOSPHERE_VERSION" == *-SNAPSHOT ]]; then
+	CURRENT_STRATOSPHERE_VERSION_YARN=${CURRENT_STRATOSPHERE_VERSION/-SNAPSHOT/-hadoop2-SNAPSHOT}
+else
+	CURRENT_STRATOSPHERE_VERSION_YARN="$CURRENT_STRATOSPHERE_VERSION-hadoop2"
+fi
+
+
+echo "detected current version as: $CURRENT_STRATOSPHERE_VERSION ; yarn: $CURRENT_STRATOSPHERE_VERSION_YARN "
+
 
 # Check if push/commit is eligible for pushing
 echo "Job: $TRAVIS_JOB_NUMBER ; isPR: $TRAVIS_PULL_REQUEST"


### PR DESCRIPTION
 and dynamically generate the yarn build.

This should be merged before https://github.com/stratosphere/stratosphere/pull/219

This is how the tools builds the versions:

```
robert@robert-tower ~/Projekte/ozone/ozone (git)-[fix_deploy_tool] % ./tools/deploy_to_maven.sh
detected current version as: 0.4-SNAPSHOT ; yarn: 0.4-hadoop2-SNAPSHOT 
robert@robert-tower ~/Projekte/ozone/ozone (git)-[fix_deploy_tool] % ./tools/deploy_to_maven.sh
detected current version as: 0.4-alpta.2 ; yarn: 0.4-alpta.2-hadoop2 
```
