### PR TITLE
Show version and git revision on JobManager startup (in log)

### DIFF
--- a/nephele/nephele-server/pom.xml
+++ b/nephele/nephele-server/pom.xml
@@ -58,6 +58,42 @@
 					</excludes>
 				</configuration>
 			</plugin>
+				<plugin>
+				<!-- Description: https://github.com/ktoso/maven-git-commit-id-plugin
+					Used to show the git ref when starting the jobmanager.
+						-->
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>2.1.5</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>revision</goal>
+						 </goals>
+					</execution>
+				</executions>
+				<configuration>
+					<dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<skipPoms>false</skipPoms>
+					<generateGitPropertiesFilename>src/main/resources/.version.properties</generateGitPropertiesFilename>
+				</configuration>
+			</plugin>
+			<!-- Add version to jar http://stackoverflow.com/questions/2712970/how-to-get-maven-artifact-version-at-runtime
+				-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<inherited>true</inherited>
+				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+						</manifest>
+					</archive>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
@@ -169,7 +169,6 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 	private volatile boolean isShutDown = false;
 	
 	public JobManager(ExecutionMode executionMode) {
-		logVersionInformation();
 		
 		final String ipcAddressString = GlobalConfiguration
 			.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null);
@@ -345,12 +344,12 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 	/**
 	 * Log Stratosphere version information.
 	 */
-	private void logVersionInformation() {
-		String version = getClass().getPackage().getImplementationVersion();
+	private static void logVersionInformation() {
+		String version = JobManager.class.getPackage().getImplementationVersion();
 		String revision = null;
 		try {
 	    	Properties properties = new Properties();
-	    	InputStream propFile = getClass().getClassLoader().getResourceAsStream(".version.properties");
+	    	InputStream propFile = JobManager.class.getClassLoader().getResourceAsStream(".version.properties");
 			if(propFile != null) {
 				properties.load(propFile);
 				revision = properties.getProperty("git.commit.id.abbrev");
@@ -370,7 +369,8 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 	 */
 	@SuppressWarnings("static-access")
 	public static void main(final String[] args) {
-
+		logVersionInformation();
+		
 		final Option configDirOpt = OptionBuilder.withArgName("config directory").hasArg()
 			.withDescription("Specify configuration directory.").create("configDir");
 

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
@@ -34,6 +34,7 @@
 package eu.stratosphere.nephele.jobmanager;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -42,6 +43,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -167,7 +169,8 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 	private volatile boolean isShutDown = false;
 	
 	public JobManager(ExecutionMode executionMode) {
-
+		logVersionInformation();
+		
 		final String ipcAddressString = GlobalConfiguration
 			.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null);
 
@@ -339,6 +342,26 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 		LOG.debug("Shutdown of job manager completed");
 	}
 
+	/**
+	 * Log Stratosphere version information.
+	 */
+	private void logVersionInformation() {
+		String version = getClass().getPackage().getImplementationVersion();
+		String revision = null;
+		try {
+	    	Properties properties = new Properties();
+	    	InputStream propFile = getClass().getClassLoader().getResourceAsStream(".version.properties");
+			if(propFile != null) {
+				properties.load(propFile);
+				revision = properties.getProperty("git.commit.id.abbrev");
+			}
+		} catch (IOException e1) {}
+		// if version == null, then the JobManager runs from inside Eclipse (or somehow not from the maven build jar)
+		if(version != null) {
+			LOG.info("Starting Stratosphere JobManager (Version: "+version+", Rev:"+revision+")");
+		}
+	}
+	
 	/**
 	 * Entry point for the program
 	 * 

--- a/stratosphere-dist/pom.xml
+++ b/stratosphere-dist/pom.xml
@@ -294,6 +294,25 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<!-- Description: https://github.com/ktoso/maven-git-commit-id-plugin -->
+				<groupId>pl.project13.maven</groupId>
+				<artifactId>git-commit-id-plugin</artifactId>
+				<version>2.1.5</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>revision</goal>
+						 </goals>
+					</execution>
+				</executions>
+				<configuration>
+					<dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
+					<generateGitPropertiesFile>true</generateGitPropertiesFile>
+					<skipPoms>false</skipPoms>
+					<generateGitPropertiesFilename>src/main/stratosphere-bin/.version.properties</generateGitPropertiesFilename>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/stratosphere-dist/src/main/assemblies/bin.xml
+++ b/stratosphere-dist/src/main/assemblies/bin.xml
@@ -105,6 +105,7 @@
 			<fileMode>0644</fileMode>
 			<includes>
 				<include>*.txt</include>
+				<include>*.properties</include>
 			</includes>
 		</fileSet>
 


### PR DESCRIPTION
Hi, 

as a follow up of this discussion https://github.com/stratosphere/stratosphere/issues/208 I propose to include the version and git revision into the JobManager log file like this:

```
00:07:27,186 INFO  eu.stratosphere.nephele.jobmanager.JobManager                 - Starting Stratosphere JobManager (Version: 0.4-SNAPSHOT, Rev:55bfa06)
00:07:27,195 INFO  eu.stratosphere.nephele.discovery.DiscoveryService            - Discovery service socket is bound to /127.0.0.1:7001
00:07:27,209 INFO  eu.stratosphere.nephele.ipc.Server                            - IPC Server Responder: starting
```

There will be also a file in the root directory of the build called `.version.properties` with the following contents:

```
#Generated by Git-Commit-Id-Plugin
#Sat Nov 02 00:06:43 CET 2013
git.commit.id.abbrev=55bfa06
git.commit.user.email=metzgerr@web.de
git.commit.message.full=Hotfixing version detection\nAdd renaming utility to master branch\n
git.commit.id=55bfa06e8971957b3c2896855069b121c7c650df
git.commit.message.short=Hotfixing version detection Add renaming utility to master branch
git.commit.user.name=Robert Metzger
git.build.user.name=Robert Metzger
git.commit.id.describe=55bfa06
git.build.user.email=metzgerr@web.de
git.branch=version_information
git.commit.time=30.10.2013 @ 11\:38\:27 CET
git.build.time=02.11.2013 @ 00\:06\:43 CET
git.remote.origin.url=https\://github.com/stratosphere/stratosphere.git
```

If you want, we can also add the `.version.properties` file into each jar file we deploy. Currently, its only included into `nephele-server`.
