### PR TITLE
Dump PACT plan as json, using the local executor

### DIFF
--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
@@ -15,6 +15,8 @@
 
 package eu.stratosphere.pact.client;
 
+import java.util.List;
+
 import eu.stratosphere.nephele.client.JobClient;
 import eu.stratosphere.nephele.jobgraph.JobGraph;
 import eu.stratosphere.pact.client.minicluster.NepheleMiniCluster;
@@ -22,6 +24,7 @@ import eu.stratosphere.pact.common.plan.Plan;
 import eu.stratosphere.pact.common.plan.PlanAssembler;
 import eu.stratosphere.pact.compiler.DataStatistics;
 import eu.stratosphere.pact.compiler.PactCompiler;
+import eu.stratosphere.pact.compiler.plan.DataSinkNode;
 import eu.stratosphere.pact.compiler.plan.candidate.OptimizedPlan;
 import eu.stratosphere.pact.compiler.plandump.PlanJSONDumpGenerator;
 import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
@@ -158,5 +161,15 @@ public class LocalExecutor implements PlanExecutor {
 				exec.stop();
 			}
 		}
+	}
+	
+	/**
+	 * Return unoptimized plan as JSON.
+	 * @return
+	 */
+	public static String getPlanAsJSON(Plan plan) {
+		PlanJSONDumpGenerator gen = new PlanJSONDumpGenerator();
+		List<DataSinkNode> sinks = PactCompiler.createPreOptimizedPlan(plan);
+		return gen.getPactPlanAsJSON(sinks);
 	}
 }


### PR DESCRIPTION
I needed this feature for generating graphs with graphviz

This python script converts a JSON Graph into a dot file: https://github.com/rmetzger/pact-plan-to-dot

Example: (I can't show it in a higher resolution, due to legal restrictions)
![plan](https://f.cloud.github.com/assets/89049/1458940/8d5352fa-43ae-11e3-8587-6c2b6316474c.png)
