### PR TITLE
Exclude jruby-complete from HBase.

### DIFF
--- a/pact/pact-hbase/pom.xml
+++ b/pact/pact-hbase/pom.xml
@@ -27,6 +27,12 @@
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase</artifactId>
 			<version>0.94.2-cdh4.2.1</version>
+			 <exclusions>
+		        <exclusion>  <!-- jruby is used for the hbase shell. -->
+		          <groupId>org.jruby</groupId>
+		          <artifactId>jruby-complete</artifactId>
+		        </exclusion>
+		     </exclusions> 
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
We don't need jruby-complete with hbase. It is used for the interactive HBase shell and causes troubles for Stratosphere users.
