### PR TITLE
Change how DataSourceFormats are handled internally.

### DIFF
--- a/pact-scala/pact-scala-core/pom.xml
+++ b/pact-scala/pact-scala-core/pom.xml
@@ -29,12 +29,12 @@
 	    <dependency>
 		    <groupId>org.scala-lang</groupId>
 		    <artifactId>scala-reflect</artifactId>
-		    <version>2.10.1</version>
+		    <version>2.10.3</version>
 	    </dependency>
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
-			<version>2.10.1</version>
+			<version>2.10.3</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSink.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSink.scala
@@ -28,7 +28,7 @@ object DataSinkOperator {
     val uri = getUri(url)
 
     val ret = uri.getScheme match {
-      case "file" | "hdfs" => new FileDataSink(format.format.asInstanceOf[FileOutputFormat[_]], uri.toString, input.contract)
+      case "file" | "hdfs" => new FileDataSink(format.asInstanceOf[FileOutputFormat[_]], uri.toString, input.contract)
           with OneInputScalaContract[In, Nothing] {
 
         def getUDF = format.getUDF
@@ -49,7 +49,7 @@ object DataSinkOperator {
 
 class ScalaSink[In] private[scala] (private[scala] val sink: GenericDataSink)
 
-abstract class DataSinkFormat[In](val format: OutputFormat[_], val udt: UDT[In]) {
+trait DataSinkFormat[In] { this: OutputFormat[_] =>
   def getUDF: UDF1[In, Nothing]
   def persistConfiguration(config: Configuration) = {}
 }

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSource.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSource.scala
@@ -32,7 +32,7 @@ object DataSource {
     
     val ret = uri.getScheme match {
 
-      case "file" | "hdfs" => new FileDataSource(format.format.asInstanceOf[FileInputFormat[_]], uri.toString)
+      case "file" | "hdfs" => new FileDataSource(format.asInstanceOf[FileInputFormat[_]], uri.toString)
           with ScalaContract[Out] {
 
         override def getUDF = format.getUDF
@@ -40,7 +40,7 @@ object DataSource {
         override def persistConfiguration() = format.persistConfiguration(this.getParameters())
       }
 
-      case "ext" => new GenericDataSource[GenericInputFormat[_]](format.format.asInstanceOf[GenericInputFormat[_]], uri.toString)
+      case "ext" => new GenericDataSource[GenericInputFormat[_]](format.asInstanceOf[GenericInputFormat[_]], uri.toString)
           with ScalaContract[Out] {
 
         override def getUDF = format.getUDF
@@ -61,7 +61,7 @@ object DataSource {
 }
 
 
-abstract class DataSourceFormat[Out](val format: InputFormat[_, _], val udt: UDT[Out]) {
+trait DataSourceFormat[Out] { this: InputFormat[_, _] => 
   def getUDF: UDF0[Out]
   def persistConfiguration(config: Configuration) = {}
 }

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/UserDefinedType.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/UserDefinedType.scala
@@ -15,11 +15,12 @@ package eu.stratosphere.scala.analysis
 
 import scala.collection.GenTraversableOnce
 import scala.collection.generic.CanBuildFrom
-import eu.stratosphere.pact.common.`type`.{ Key => PactKey }
-import eu.stratosphere.pact.common.`type`.{ Value => PactValue }
-import eu.stratosphere.pact.common.`type`.base.PactList
-import eu.stratosphere.pact.common.`type`.base.PactString
+import scala.language.experimental.macros
+import eu.stratosphere.pact.common.`type`.{Key => PactKey}
 import eu.stratosphere.pact.common.`type`.PactRecord
+import eu.stratosphere.pact.common.`type`.{Value => PactValue}
+import eu.stratosphere.pact.common.`type`.base.PactString
+import eu.stratosphere.scala.codegen.UDTUtil
 
 abstract class UDT[T] extends Serializable {
   protected def createSerializer(indexMap: Array[Int]): UDTSerializer[T]
@@ -59,11 +60,7 @@ abstract class UDTSerializer[T](val indexMap: Array[Int]) {
 }
 
 trait UDTLowPriorityImplicits {
-
-  class UDTAnalysisFailedException extends RuntimeException("UDT analysis failed. This should have been caught at compile time.")
-  class UDTSelectionFailedException(msg: String) extends RuntimeException(msg)
-
-  implicit def unanalyzedUDT[T]: UDT[T] = throw new UDTAnalysisFailedException
+  implicit def createUDT[T]: UDT[T] = macro UDTUtil.createUDTImpl[T]
 }
 
 object UDT extends UDTLowPriorityImplicits {

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/UDTUtil.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/UDTUtil.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.codegen
+
+import language.experimental.macros
+import scala.reflect.macros.Context
+import eu.stratosphere.scala.analysis.UDT
+
+object UDTUtil {
+  
+  implicit def createUDT[T]: UDT[T] = macro createUDTImpl[T]
+
+  def createUDTImpl[T: c.WeakTypeTag](c: Context): c.Expr[UDT[T]] = {
+    import c.universe._
+
+    val slave = MacroContextHolder.newMacroHelper(c)
+
+    val (udt, createUdt) = slave.mkUdtClass[T]
+
+    val udtResult = reify {
+      c.Expr[UDT[T]](createUdt).splice
+    }
+    
+    c.Expr[UDT[T]](Block(List(udt), udtResult.tree))
+  }
+}

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/DataSinkMacros.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/DataSinkMacros.scala
@@ -46,13 +46,11 @@ object RawDataSinkFormat {
     
     val pact4sFormat = reify {
       
-      class GeneratedOutputFormat extends RawOutput4sStub[In] {
-        override val udt = c.Expr(createUdtIn).splice
+      new RawOutput4sStub[In] with DataSinkFormat[In] {
+        val udt = c.Expr(createUdtIn).splice
         override val userFunction = writeFunction.splice
-      }
       
-      new DataSinkFormat[In](new GeneratedOutputFormat, c.Expr[UDT[In]](createUdtIn).splice) {
-        override def getUDF = this.format.asInstanceOf[DataOutput4sStub[In]].udf
+        override def getUDF = this.udf
       }
       
     }
@@ -87,16 +85,14 @@ object BinaryDataSinkFormat {
     
     val pact4sFormat = reify {
       
-      class GeneratedOutputFormat extends BinaryOutput4sStub[In] {
-        override val udt = c.Expr(createUdtIn).splice
+      new BinaryOutput4sStub[In] with DataSinkFormat[In] {
+        val udt = c.Expr(createUdtIn).splice
         override val userFunction = writeFunction.splice
-      }
       
-      new DataSinkFormat[In](new GeneratedOutputFormat, c.Expr[UDT[In]](createUdtIn).splice) {
         override def persistConfiguration(config: Configuration) {
           blockSize.splice map { config.setLong(BinaryOutputFormat.BLOCK_SIZE_PARAMETER_KEY, _) }
         }
-        override def getUDF = this.format.asInstanceOf[DataOutput4sStub[In]].udf
+        override def getUDF = this.udf
       }
       
     }
@@ -132,11 +128,11 @@ object SequentialDataSinkFormat {
     
     val pact4sFormat = reify {
       
-      new DataSinkFormat[In](new SequentialOutputFormat, c.Expr[UDT[In]](createUdtIn).splice) {
+      new SequentialOutputFormat with DataSinkFormat[In] {
         override def persistConfiguration(config: Configuration) {
           blockSize.splice map { config.setLong(BinaryOutputFormat.BLOCK_SIZE_PARAMETER_KEY, _) }
         }
-        override val udt = c.Expr[UDT[In]](createUdtIn).splice
+        val udt = c.Expr[UDT[In]](createUdtIn).splice
         lazy val udf: UDF1[In, Nothing] = new UDF1[In, Nothing](udt, UDT.NothingUDT)
         override def getUDF = udf
       }
@@ -234,16 +230,14 @@ object DelimitedDataSinkFormat {
     
     val pact4sFormat = reify {
       
-      class GeneratedOutputFormat extends DelimitedOutput4sStub[In] {
-        override val udt = c.Expr(createUdtIn).splice
+      new DelimitedOutput4sStub[In] with DataSinkFormat[In] {
+        val udt = c.Expr(createUdtIn).splice
         override val userFunction = writeFunction.splice
-      }
       
-      new DataSinkFormat[In](new GeneratedOutputFormat, c.Expr[UDT[In]](createUdtIn).splice) {
         override def persistConfiguration(config: Configuration) {
           delimiter.splice map { config.setString(DelimitedOutputFormat.RECORD_DELIMITER, _) }
         }
-        override def getUDF = this.format.asInstanceOf[DataOutput4sStub[In]].udf
+        override def getUDF = this.udf
       }
       
     }
@@ -289,7 +283,7 @@ object RecordDataSinkFormat {
     
     val pact4sFormat = reify {
       
-      new DataSinkFormat[In](new RecordOutputFormat, c.Expr[UDT[In]](createUdtIn).splice) {
+      new RecordOutputFormat with DataSinkFormat[In] {
         override def persistConfiguration(config: Configuration) {
 
           val fields = getUDF.inputFields.filter(_.isUsed)
@@ -309,7 +303,7 @@ object RecordDataSinkFormat {
           lenient.splice map { config.setBoolean(RecordOutputFormat.LENIENT_PARSING, _) }
         }
         
-        override val udt = c.Expr[UDT[In]](createUdtIn).splice
+        val udt = c.Expr[UDT[In]](createUdtIn).splice
         lazy val udf: UDF1[In, Nothing] = new UDF1[In, Nothing](udt, UDT.NothingUDT)
         override def getUDF = udf
       }


### PR DESCRIPTION
This and the addition of implicit UDT generation makes it easy to implement custom DataSourceFormats. I noticed the need for this from @rmetzger's avro input format.
