### PR TITLE
Add support for using arbitrary Pact Value classes in scala frontend

### DIFF
--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/SelectionExtractor.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/SelectionExtractor.scala
@@ -29,6 +29,7 @@ trait SelectionExtractor[C <: Context] { this: MacroContextHolder[C] with UDTDes
         }
         case Right((udtDesc, sels)) => {
           val descs: List[Option[UDTDescriptor]] = sels flatMap { sel: List[String] => udtDesc.select(sel) }
+          descs foreach { desc => desc map { desc => if (!desc.canBeKey) c.error(c.enclosingPosition, "Type " + desc.tpe + " cannot be key.") } }
           val ids = descs map { _ map { _.id } }
           ids forall { _.isDefined } match {
             case false => {

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/SerializeMethodGen.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/SerializeMethodGen.scala
@@ -40,6 +40,13 @@ trait SerializeMethodGen[C <: Context] { this: MacroContextHolder[C] with UDTDes
 
   private def genSerialize(desc: UDTDescriptor, source: Tree, target: Tree, env: GenEnvironment): Seq[Tree] = desc match {
 
+    case PactValueDescriptor(id, _) => {
+      val chk = env.mkChkIdx(id)
+      val set = env.mkSetField(id, target, source)
+
+      Seq(mkIf(chk, set))
+    }
+    
     case PrimitiveDescriptor(id, _, _, _) => {
       val chk = env.mkChkIdx(id)
       val ser = env.mkSetValue(id, source)
@@ -174,6 +181,8 @@ trait SerializeMethodGen[C <: Context] { this: MacroContextHolder[C] with UDTDes
         case PrimitiveDescriptor(_, _, _, wrapper) => (Seq(), New(TypeTree(wrapper), List(List(Ident("item": TermName)))))
 
         case BoxedPrimitiveDescriptor(_, _, _, wrapper, _, unbox) => (Seq(), New(TypeTree(wrapper), List(List(unbox(Ident("item": TermName))))))
+        
+        case PactValueDescriptor(_, tpe) => (Seq(), Ident("item": TermName))
 
         case ListDescriptor(id, _, iter, innerElem) => {
           val listTpe = env.listImpls(id)

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/SerializerGen.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/SerializerGen.scala
@@ -101,6 +101,10 @@ trait SerializerGen[C <: Context] { this: MacroContextHolder[C] with UDTDescript
         val (classDef, tpe) = mkListImplClass(c.WeakTypeTag(elem.wrapper))
         (List(classDef), Map(id -> tpe))
       }
+      case ListDescriptor(id, _, _, elem: PactValueDescriptor) => {
+        val (classDef, tpe) = mkListImplClass(c.WeakTypeTag(elem.tpe))
+        (List(classDef), Map(id -> tpe))
+      }
       case ListDescriptor(id, _, _, elem) => {
         val (classDefs, tpes) = mkListImplClasses(elem)
         val (classDef, tpe) = mkListImplClass(c.WeakTypeTag(typeOf[eu.stratosphere.pact.common.`type`.PactRecord]))
@@ -300,6 +304,7 @@ trait SerializerGen[C <: Context] { this: MacroContextHolder[C] with UDTDescript
 
     def mkSetField(fieldId: Int, record: Tree): Tree = mkSetField(fieldId, record, mkSelectWrapper(fieldId))
     def mkSetField(fieldId: Int, record: Tree, wrapper: Tree): Tree = Apply(Select(record, "setField": TermName), List(mkSelectIdx(fieldId), wrapper))
+    def mkGetField(fieldId: Int, record: Tree, tpe: Type): Tree = Apply(Select(record, "getField": TermName), List(mkSelectIdx(fieldId), Literal(Constant(tpe))))
     def mkGetFieldInto(fieldId: Int, record: Tree): Tree = mkGetFieldInto(fieldId, record, mkSelectWrapper(fieldId))
     def mkGetFieldInto(fieldId: Int, record: Tree, wrapper: Tree): Tree = Apply(Select(record, "getFieldInto": TermName), List(mkSelectIdx(fieldId), wrapper))
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/UDTAnalyzer.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/UDTAnalyzer.scala
@@ -62,6 +62,7 @@ trait UDTAnalyzer[C <: Context] { this: MacroContextHolder[C] with UDTDescriptor
           case ListType(elemTpe, iter) => analyzeList(id, normed, elemTpe, iter)
           case CaseClassType() => analyzeCaseClass(id, normed)
           case BaseClassType() => analyzeClassHierarchy(id, normed)
+          case PactValueType() => PactValueDescriptor(id, normed)
           case _ => UnsupportedDescriptor(id, normed, Seq("Unsupported type " + normed))
         }
       }
@@ -263,19 +264,21 @@ trait UDTAnalyzer[C <: Context] { this: MacroContextHolder[C] with UDTDescriptor
     }
 
     private object CaseClassType {
-
       def unapply(tpe: Type): Boolean = tpe.typeSymbol.asClass.isCaseClass
     }
 
     private object BaseClassType {
-
       def unapply(tpe: Type): Boolean = tpe.typeSymbol.asClass.isAbstractClass && tpe.typeSymbol.asClass.isSealed
+    }
+    
+    private object PactValueType {
+      def unapply(tpe: Type): Boolean = tpe.typeSymbol.asClass.baseClasses exists { s => s.fullName == "eu.stratosphere.pact.common.type.Value" }
     }
 
     private class UDTAnalyzerCache {
 
       private val caches = new DynamicVariable[Map[Type, RecursiveDescriptor]](Map())
-      private val idGen = new Counter()
+      private val idGen = new Counter
 
       def newId = idGen.next
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/UDTGen.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/codegen/UDTGen.scala
@@ -46,6 +46,7 @@ trait UDTGen[C <: Context] { this: MacroContextHolder[C] with UDTDescriptors[C] 
       val fieldTypes = getIndexFields(desc).toList map {
         case PrimitiveDescriptor(_, _, _, wrapper) => Literal(Constant(wrapper))
         case BoxedPrimitiveDescriptor(_, _, _, wrapper, _, _) => Literal(Constant(wrapper))
+        case PactValueDescriptor(_, tpe) => Literal(Constant(tpe))
         case ListDescriptor(_, _, _, _) => Literal(Constant(typeOf[PactList[eu.stratosphere.pact.common.`type`.Value]]))
         // Box inner instances of recursive types
         case RecursiveDescriptor(_, _, _) => Literal(Constant(typeOf[PactRecord]))
@@ -65,8 +66,8 @@ trait UDTGen[C <: Context] { this: MacroContextHolder[C] with UDTDescriptors[C] 
         case PrimitiveDescriptor(id, _, _, _) => Literal(Constant(id))
         case BoxedPrimitiveDescriptor(id, _, _, _, _, _) => Literal(Constant(id))
         case ListDescriptor(id, _, _, _) => Literal(Constant(id))
-        // Box inner instances of recursive types
         case RecursiveDescriptor(id, _, _) => Literal(Constant(id))
+        case PactValueDescriptor(id, _) => Literal(Constant(id))
         case BaseClassDescriptor(_, _, _, _) => throw new RuntimeException("Illegal descriptor for basic record field.")
         case CaseClassDescriptor(_, _, _, _, _) => throw new RuntimeException("Illegal descriptor for basic record field.")
         case UnsupportedDescriptor(_, _, _) => throw new RuntimeException("Illegal descriptor for basic record field.")

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/wordcount/WordCountPactValue.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/wordcount/WordCountPactValue.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.examples.wordcount
+
+import scala.Array.canBuildFrom
+import eu.stratosphere.pact.client.LocalExecutor
+import eu.stratosphere.pact.common.plan.PlanAssembler
+import eu.stratosphere.pact.common.plan.PlanAssemblerDescription
+import eu.stratosphere.pact.common.`type`.base.PactInteger
+import eu.stratosphere.pact.common.`type`.base.PactString
+
+import eu.stratosphere.scala._
+import eu.stratosphere.scala.operators._
+
+object RunWordCountPactValue {
+  def main(args: Array[String]) {
+    val wc = new WordCountPactValue
+    if (args.size < 3) {
+      println(wc.getDescription)
+      return
+    }
+    val plan = wc.getScalaPlan(args(0).toInt, args(1), args(2))
+    LocalExecutor.execute(plan)
+    System.exit(0)
+  }
+}
+
+class WordCountPactValue extends PlanAssembler with PlanAssemblerDescription with Serializable {
+  override def getDescription() = {
+    "Parameters: [numSubStasks] [input] [output]"
+  }
+  override def getPlan(args: String*) = {
+    getScalaPlan(args(0).toInt, args(1), args(2))
+  }
+
+  def formatOutput = (word: PactString, count: PactInteger) => "%s %d".format(word.toString, count.getValue)
+
+  def getScalaPlan(numSubTasks: Int, textInput: String, wordsOutput: String) = {
+    val input = TextFile(textInput)
+
+    val words = input flatMap { _.toLowerCase().split("""\W+""") filter { _ != "" } map { w => (new PactString(w), new PactInteger(1)) } }
+    val counts = words
+      .groupBy { case (word, _) => word }
+      .reduce { (w1, w2) => (w1._1, new PactInteger(w1._2.getValue + w2._2.getValue)) }
+
+    counts neglects { case (word, _) => word }
+    counts preserves({ case (word, _) => word }, { case (word, _) => word })
+    val output = counts.write(wordsOutput, DelimitedDataSinkFormat(formatOutput.tupled))
+  
+    val plan = new ScalaPlan(Seq(output), "Word Count (immutable)")
+    plan.setDefaultParallelism(numSubTasks)
+    plan
+  }
+}

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/scalaPactPrograms/WordCountPactValueITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/scalaPactPrograms/WordCountPactValueITCase.java
@@ -1,0 +1,40 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.pact.test.scalaPactPrograms;
+
+import eu.stratosphere.nephele.configuration.Configuration;
+import eu.stratosphere.pact.common.plan.Plan;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import eu.stratosphere.scala.examples.wordcount.WordCountPactValue;
+
+@RunWith(Parameterized.class)
+public class WordCountPactValueITCase extends eu.stratosphere.pact.test.pactPrograms.WordCountITCase {
+
+    public WordCountPactValueITCase(Configuration config) {
+        super(config);
+    }
+
+    @Override
+    protected Plan getPactPlan() {
+        WordCountPactValue wc = new WordCountPactValue();
+        return wc.getScalaPlan(
+                config.getInteger("WordCountTest#NumSubtasks", 1),
+                textPath, resultPath);
+    }
+
+
+}


### PR DESCRIPTION
Also add checks in key selector extraction to check whether the selected
fields can actually be part of a key.

@StephanEwen, btw, PactDouble implements Key.
