### PR TITLE
LocalDistributedExecutor: Execute multiple TaskManagers in one JVM

### DIFF
--- a/nephele/nephele-clustermanager/src/main/java/eu/stratosphere/nephele/instance/cluster/ClusterManager.java
+++ b/nephele/nephele-clustermanager/src/main/java/eu/stratosphere/nephele/instance/cluster/ClusterManager.java
@@ -1143,4 +1143,9 @@ public class ClusterManager implements InstanceManager {
 		// Simple remove the entire map
 		this.pendingRequestsOfJob.remove(jobID);
 	}
+
+	@Override
+	public int getNumberOfTaskTrackers() {
+		return this.registeredHosts.size();
+	}
 }

--- a/nephele/nephele-queuescheduler/src/test/java/eu/stratosphere/nephele/jobmanager/scheduler/queue/TestInstanceManager.java
+++ b/nephele/nephele-queuescheduler/src/test/java/eu/stratosphere/nephele/jobmanager/scheduler/queue/TestInstanceManager.java
@@ -267,4 +267,9 @@ public final class TestInstanceManager implements InstanceManager {
 	public void shutdown() {
 		throw new IllegalStateException("shutdown called on TestInstanceManager");
 	}
+
+	@Override
+	public int getNumberOfTaskTrackers() {
+		throw new IllegalStateException("getNumberOfTaskTrackers called on TestInstanceManager");
+	}
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/HardwareDescriptionFactory.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/HardwareDescriptionFactory.java
@@ -36,7 +36,6 @@ import org.apache.commons.logging.LogFactory;
  * <p>
  * This class is thread-safe.
  * 
- * @author warneke
  */
 public class HardwareDescriptionFactory {
 
@@ -117,6 +116,9 @@ public class HardwareDescriptionFactory {
 	 *         one value for the hardware description cannot be determined
 	 */
 	public static HardwareDescription extractFromSystem() {
+		return extractFromSystem(1);
+	}
+	public static HardwareDescription extractFromSystem(final int taskManagersPerJVM) {
 
 		final int numberOfCPUCores = Runtime.getRuntime().availableProcessors();
 
@@ -125,7 +127,7 @@ public class HardwareDescriptionFactory {
 			return null;
 		}
 
-		final long sizeOfFreeMemory = getSizeOfFreeMemory();
+		final long sizeOfFreeMemory = getSizeOfFreeMemory() / taskManagersPerJVM;
 		if (sizeOfFreeMemory < 0) {
 			return null;
 		}

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/InstanceManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/InstanceManager.java
@@ -163,4 +163,10 @@ public interface InstanceManager {
 	 * Shuts the instance manager down and stops all its internal processes.
 	 */
 	void shutdown();
+
+	/**
+	 * 
+	 * @return the number of available (registered) TaskTrackers
+	 */
+	int getNumberOfTaskTrackers();
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalInstanceManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalInstanceManager.java
@@ -140,7 +140,7 @@ public class LocalInstanceManager implements InstanceManager {
 
 		this.instanceTypeDescriptionMap = new SerializableHashMap<InstanceType, InstanceTypeDescription>();
 
-		this.localTaskManagerThread = new LocalTaskManagerThread();
+		this.localTaskManagerThread = new LocalTaskManagerThread("Local Taskmanager IO Loop",1);
 		this.localTaskManagerThread.start();
 	}
 
@@ -297,7 +297,6 @@ public class LocalInstanceManager implements InstanceManager {
 	 * @return the default instance type used for the local machine
 	 */
 	public static final InstanceType createDefaultInstanceType() {
-
 		final HardwareDescription hardwareDescription = HardwareDescriptionFactory.extractFromSystem();
 
 		int diskCapacityInGB = 0;
@@ -399,5 +398,10 @@ public class LocalInstanceManager implements InstanceManager {
 	public void cancelPendingRequests(final JobID jobID) {
 
 		// The local instance manager does not support pending requests, so nothing to do here
+	}
+
+	@Override
+	public int getNumberOfTaskTrackers() {
+		return (this.localInstance == null) ? 0 : 1; // this instance manager can have at most one TaskTracker
 	}
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalTaskManagerThread.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/instance/local/LocalTaskManagerThread.java
@@ -20,7 +20,6 @@ import eu.stratosphere.nephele.taskmanager.TaskManager;
 /**
  * This class represents the thread which runs the task manager when Nephele is executed in local mode.
  * 
- * @author warneke
  */
 public class LocalTaskManagerThread extends Thread {
 
@@ -32,24 +31,19 @@ public class LocalTaskManagerThread extends Thread {
 	/**
 	 * Constructs a new thread to run the task manager in Nephele's local mode.
 	 */
-	public LocalTaskManagerThread() {
-		super("Local Taskmanager IO Loop");
-
+	public LocalTaskManagerThread(final String name, final int taskManagersPerJVM) {
+		super(name);
 		TaskManager tmpTaskManager = null;
 		try {
-			tmpTaskManager = new TaskManager();
+			tmpTaskManager = new TaskManager(taskManagersPerJVM);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 		this.taskManager = tmpTaskManager;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
-	public void run() {
-
+	public void run() {	
 		this.taskManager.runIOLoop();
 
 		// Wait until the task manager is shut down

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
@@ -175,7 +175,7 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 	private WebInfoServer server;
 	
 	public JobManager(ExecutionMode executionMode) {
-		
+
 		final String ipcAddressString = GlobalConfiguration
 			.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null);
 
@@ -241,7 +241,7 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 			LOG.info("Trying to load " + instanceManagerClassName + " as instance manager");
 			this.instanceManager = JobManagerUtils.loadInstanceManager(instanceManagerClassName);
 			if (this.instanceManager == null) {
-				LOG.error("UNable to load instance manager " + instanceManagerClassName);
+				LOG.error("Unable to load instance manager " + instanceManagerClassName);
 				System.exit(FAILURERETURNCODE);
 			}
 		}
@@ -428,7 +428,7 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 		
 		// First, try to load global configuration
 		GlobalConfiguration.loadConfiguration(configDir);
-		
+
 		// Create a new job manager object
 		JobManager jobManager = new JobManager(executionMode);
 		
@@ -549,7 +549,7 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 			if (this.eventCollector != null) {
 				this.profiler.registerForProfilingData(eg.getJobID(), this.eventCollector);
 			}
-			
+
 		}
 
 		// Register job with the dynamic input split assigner
@@ -1238,4 +1238,7 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 		}
 	}
 
+	public int getNumberOfTaskTrackers() {
+		return this.instanceManager.getNumberOfTaskTrackers();
+	}
 }

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/protocols/JobManagerProtocol.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/protocols/JobManagerProtocol.java
@@ -27,7 +27,6 @@ import eu.stratosphere.nephele.taskmanager.TaskExecutionState;
  * to task managers which allows them to register themselves, send heart beat messages
  * or to report the results of a task execution.
  * 
- * @author warneke
  */
 public interface JobManagerProtocol extends VersionedProtocol {
 

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
@@ -85,7 +85,6 @@ import eu.stratosphere.nephele.util.StringUtils;
  * Task managers are able to automatically discover the job manager and receive its configuration from it
  * as long as the job manager is running on the same local network
  * 
- * @author warneke
  */
 public class TaskManager implements TaskOperationProtocol {
 
@@ -143,7 +142,7 @@ public class TaskManager implements TaskOperationProtocol {
 	 * receive an initial configuration. All parameters are obtained from the 
 	 * {@link GlobalConfiguration}, which must be loaded prior to instantiating the task manager.
 	 */
-	public TaskManager() throws Exception {
+	public TaskManager(final int taskManagersPerJVM) throws Exception {
 		
 		// IMPORTANT! At this point, the GlobalConfiguration must have been read!
 
@@ -267,7 +266,7 @@ public class TaskManager implements TaskOperationProtocol {
 		this.byteBufferedChannelManager = byteBufferedChannelManager;
 
 		// Determine hardware description
-		HardwareDescription hardware = HardwareDescriptionFactory.extractFromSystem();
+		HardwareDescription hardware = HardwareDescriptionFactory.extractFromSystem(taskManagersPerJVM);
 		if (hardware == null) {
 			LOG.warn("Cannot determine hardware description");
 		}
@@ -331,7 +330,7 @@ public class TaskManager implements TaskOperationProtocol {
 		// Create a new task manager object
 		TaskManager taskManager = null;
 		try {
-			taskManager = new TaskManager();
+			taskManager = new TaskManager(1);
 		} catch (Exception e) {
 			LOG.fatal("Taskmanager startup failed:" + StringUtils.stringifyException(e));
 			System.exit(FAILURERETURNCODE);
@@ -538,7 +537,6 @@ public class TaskManager implements TaskOperationProtocol {
 		Task task = null;
 
 		synchronized (this) {
-
 			final Task runningTask = this.runningTasks.get(id);
 			boolean registerTask = true;
 			if (runningTask == null) {

--- a/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
+++ b/nephele/nephele-server/src/test/java/eu/stratosphere/nephele/executiongraph/ExecutionGraphTest.java
@@ -203,6 +203,11 @@ public class ExecutionGraphTest {
 			throw new IllegalStateException("cancelPendingRequests called on TestInstanceManager");
 		}
 
+		@Override
+		public int getNumberOfTaskTrackers() {
+			return 0;
+		}
+
 	}
 
 	private static final InstanceManager INSTANCE_MANAGER = new TestInstanceManager();

--- a/pact/pact-clients/pom.xml
+++ b/pact/pact-clients/pom.xml
@@ -37,6 +37,17 @@
 		</dependency>
 
 		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-clustermanager</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-queuescheduler</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.2</version>

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
@@ -17,6 +17,11 @@ package eu.stratosphere.pact.client;
 
 import java.util.List;
 
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+
 import eu.stratosphere.nephele.client.JobClient;
 import eu.stratosphere.nephele.jobgraph.JobGraph;
 import eu.stratosphere.pact.client.minicluster.NepheleMiniCluster;
@@ -45,6 +50,13 @@ public class LocalExecutor implements PlanExecutor {
 	private NepheleMiniCluster nephele;
 
 	
+	public LocalExecutor() {
+		Logger root = Logger.getRootLogger();
+		PatternLayout layout = new PatternLayout("%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n");
+		ConsoleAppender appender = new ConsoleAppender(layout, "System.err");
+		root.addAppender(appender);
+		root.setLevel(Level.WARN);
+	}
 	
 	public void start() throws Exception {
 		synchronized (this.lock) {
@@ -63,10 +75,16 @@ public class LocalExecutor implements PlanExecutor {
 		}
 	}
 
-	/* (non-Javadoc)
-	 * @see eu.stratosphere.pact.client.PlanExecutor#executePlan(eu.stratosphere.pact.common.plan.Plan)
+	/**
+	 * Execute the given plan on the local Nephele instance, wait for the job to
+	 * finish and return the runtime in milliseconds.
+	 * 
+	 * @param plan The plan of the program to execute.
+	 * @return The net runtime of the program, in milliseconds.
+	 * 
+	 * @throws Exception Thrown, if either the startup of the local execution context, or the execution
+	 *                   caused an exception.
 	 */
-	@Override
 	public long executePlan(Plan plan) throws Exception {
 		synchronized (this.lock) {
 			if (this.nephele == null) {

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/localDistributed/LocalDistributedExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/localDistributed/LocalDistributedExecutor.java
@@ -1,0 +1,132 @@
+package eu.stratosphere.pact.client.localDistributed;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import eu.stratosphere.nephele.client.JobClient;
+import eu.stratosphere.nephele.configuration.ConfigConstants;
+import eu.stratosphere.nephele.configuration.Configuration;
+import eu.stratosphere.nephele.configuration.GlobalConfiguration;
+import eu.stratosphere.nephele.instance.local.LocalTaskManagerThread;
+import eu.stratosphere.nephele.jobgraph.JobGraph;
+import eu.stratosphere.nephele.jobmanager.JobManager;
+import eu.stratosphere.nephele.jobmanager.JobManager.ExecutionMode;
+import eu.stratosphere.pact.client.minicluster.NepheleMiniCluster;
+import eu.stratosphere.pact.common.plan.Plan;
+import eu.stratosphere.pact.compiler.DataStatistics;
+import eu.stratosphere.pact.compiler.PactCompiler;
+import eu.stratosphere.pact.compiler.plan.candidate.OptimizedPlan;
+import eu.stratosphere.pact.compiler.plantranslate.NepheleJobGraphGenerator;
+
+/**
+ * This executor allows to execute a Job on one machine (locally) using multiple
+ * TaskManagers that communicate via TCP/IP, not memory.
+ */
+public class LocalDistributedExecutor  {
+	
+	private static int JOBMANAGER_RPC_PORT = 6498;
+	private boolean running = false;
+	
+	
+	public static class JobManagerThread extends Thread {
+		JobManager jm;
+		
+		public JobManagerThread(JobManager jm) {
+			this.jm = jm;
+		}
+		@Override
+		public void run() {
+			jm.runTaskLoop();
+		}
+	}
+	
+	public void startNephele(final int numTaskMgr) throws InterruptedException {
+		if(running) {
+			return;
+		}
+		
+		Configuration conf = NepheleMiniCluster.getMiniclusterDefaultConfig(JOBMANAGER_RPC_PORT, 6500,
+				7501, 7533, null, true);
+		GlobalConfiguration.includeConfiguration(conf);
+			
+		// start job manager
+		JobManager jobManager;
+		try {
+			jobManager = new JobManager(ExecutionMode.CLUSTER);
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			return;
+		}
+	
+		
+		JobManagerThread jobManagerThread = new JobManagerThread(jobManager);
+		jobManagerThread.setDaemon(true);
+		jobManagerThread.start();
+		
+		// start the taskmanagers
+		List<LocalTaskManagerThread> tms = new ArrayList<LocalTaskManagerThread>();
+		for(int tm = 0; tm < numTaskMgr; tm++) {
+			// The whole thing can only work if we assign different ports to each TaskManager
+			Configuration tmConf = new Configuration();
+			tmConf.setInteger(ConfigConstants.TASK_MANAGER_IPC_PORT_KEY,
+						ConfigConstants.DEFAULT_TASK_MANAGER_IPC_PORT + tm + numTaskMgr);
+			tmConf.setInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY, ConfigConstants.DEFAULT_TASK_MANAGER_DATA_PORT+tm); // taskmanager.data.port
+			GlobalConfiguration.includeConfiguration(tmConf);
+			LocalTaskManagerThread t = new LocalTaskManagerThread("LocalDistributedExecutor: LocalTaskManagerThread-#"+tm,numTaskMgr);
+			t.start();
+			tms.add(t);
+		}
+		
+		final int sleepTime = 100;
+		final int maxSleep = 1000 * 2 * numTaskMgr; // we wait 2 seconds PER TaskManager.
+		int slept = 0;
+		// wait for all taskmanagers to register to the JM
+		while(jobManager.getNumberOfTaskTrackers() < numTaskMgr) {
+			Thread.sleep(sleepTime);
+			if(slept >= maxSleep) {
+				throw new RuntimeException("Waited for more than 2 seconds per TaskManager to register at "
+						+ "the JobManager.");
+			}
+		}
+		this.running = true;
+	}
+	
+	public void run(final JobGraph jobGraph) throws Exception {
+		if(!running) {
+			throw new IllegalStateException("Nephele has not been started");
+		}
+		runNepheleJobGraph(jobGraph);
+	}
+	
+	public void run(final Plan plan) throws Exception {
+		if(!running) {
+			throw new IllegalStateException("Nephele has not been started");
+		}
+		PactCompiler pc = new PactCompiler(new DataStatistics());
+		OptimizedPlan op = pc.compile(plan);
+		
+		NepheleJobGraphGenerator jgg = new NepheleJobGraphGenerator();
+		JobGraph jobGraph = jgg.compileJobGraph(op);
+		runNepheleJobGraph(jobGraph);
+	}
+	
+	private void runNepheleJobGraph(JobGraph jobGraph) throws Exception {
+		try {
+			JobClient jobClient = getJobClient(jobGraph);
+			jobClient.submitJobAndWait();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	
+	private JobClient getJobClient(JobGraph jobGraph) throws Exception {
+		Configuration configuration = jobGraph.getJobConfiguration();
+		configuration.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, "localhost");
+		configuration.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, JOBMANAGER_RPC_PORT);
+		return new JobClient(jobGraph, configuration);
+	}
+}

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/minicluster/NepheleMiniCluster.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/minicluster/NepheleMiniCluster.java
@@ -202,7 +202,7 @@ public class NepheleMiniCluster {
 		}
 	}
 	
-	private static Configuration getMiniclusterDefaultConfig(int jobManagerRpcPort, int taskManagerRpcPort,
+	public static Configuration getMiniclusterDefaultConfig(int jobManagerRpcPort, int taskManagerRpcPort,
 			int taskManagerDataPort, int discoveryPort, String hdfsConfigFile, boolean visualization)
 	{
 		final Configuration config = new Configuration();

--- a/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
+++ b/pact/pact-examples/src/main/java/eu/stratosphere/pact/example/wordcount/WordCount.java
@@ -64,7 +64,7 @@ public class WordCount implements PlanAssembler, PlanAssemblerDescription {
 		public void map(PactRecord record, Collector<PactRecord> collector) {
 			// get the first field (as type PactString) from the record
 			PactString line = record.getField(0, PactString.class);
-			
+
 			// normalize the line
 			AsciiUtils.replaceNonWordChars(line, ' ');
 			AsciiUtils.toLowerCase(line);

--- a/pact/pact-tests/pom.xml
+++ b/pact/pact-tests/pom.xml
@@ -81,6 +81,27 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-clustermanager</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>nephele-queuescheduler</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>pact-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
 	</dependencies>
 
 	<reporting>
@@ -102,6 +123,7 @@
 						<exclude>**/*TestBase*.class</exclude>
 					</excludes>
 					<forkMode>once</forkMode>
+					<argLine>-Xmx1024m</argLine>
 				</configuration>
 			</plugin>
 

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/localDistributed/LocalDistributedExecutorTest.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/localDistributed/LocalDistributedExecutorTest.java
@@ -12,23 +12,25 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.pact.clients.examples;
+package eu.stratosphere.pact.test.localDistributed;
 
 import java.io.File;
 import java.io.FileWriter;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
-import eu.stratosphere.pact.client.LocalExecutor;
+import eu.stratosphere.pact.client.localDistributed.LocalDistributedExecutor;
 import eu.stratosphere.pact.example.wordcount.WordCount;
 import eu.stratosphere.pact.test.pactPrograms.WordCountITCase;
 
 
-public class LocalExecutorTest {
+public class LocalDistributedExecutorTest {
 
 	@Test
-	public void testLocalExecutorWithWordCount() {
+	public void testLocalDistributedExecutorWithWordCount() {
 		try {
 			// set up the files
 			File inFile = File.createTempFile("wctext", ".in");
@@ -42,11 +44,31 @@ public class LocalExecutorTest {
 			
 			// run WordCount
 			WordCount wc = new WordCount();
-			LocalExecutor.execute(wc, "4", "file://" + inFile.getAbsolutePath(), "file://" + outFile.getAbsolutePath());
+			LocalDistributedExecutor lde = new LocalDistributedExecutor();
+			lde.startNephele(2);
+			lde.run( wc.getPlan("4", "file://" + inFile.getAbsolutePath(), "file://" + outFile.getAbsolutePath()));
+			
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail(e.getMessage());
 		}
-		
+	}
+	
+	@Before
+	public void cool() {
+		System.err.println("Cooling");
+		try {
+			Thread.sleep(1000);
+			System.gc();
+			Thread.sleep(1000);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	@After
+	public void coolDownGC() {
+		cool();
+		System.exit(0);
 	}
 }

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/util/TestBase2.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/util/TestBase2.java
@@ -111,7 +111,7 @@ public abstract class TestBase2 {
 			e.printStackTrace();
 			Assert.fail("Pre-submit work caused an error: " + e.getMessage());
 		}
-
+		
 		// submit job
 		JobGraph jobGraph = null;
 		try {
@@ -128,6 +128,7 @@ public abstract class TestBase2 {
 			JobClient client = this.executer.getJobClient(jobGraph);
 			client.setConsoleStreamForReporting(getNullPrintStream());
 			client.submitJobAndWait();
+			
 		} catch(Exception e) {
 			System.err.println(e.getMessage());
 			e.printStackTrace();


### PR DESCRIPTION
Fix for this issue: https://github.com/dimalabs/ozone/issues/86

The LocalDistributedExecutor simulates a Nephele-Cluster with multiple TaskManagers in one JVM. Data between the TMs is transferred using the OS network stack, not through memory. This is important to find bugs in the network stack.

It would be great to integrate the LDE with `TestBase` and `TestBase2`. I already started with this, but I had some errors.

(this is my second LDE PR, the first one (https://github.com/stratosphere/stratosphere/pull/130) had some issues)
