### PR TITLE
Minor changes in RemoteExecutor and LocalExecutor. 

### DIFF
--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
@@ -52,7 +52,7 @@ public class LocalExecutor implements PlanExecutor {
 			this.nephele.start();
 		}
 	}
-	
+
 	/**
 	 * Stop the local executor instance. You should not call executePlan after this.
 	 */
@@ -83,7 +83,7 @@ public class LocalExecutor implements PlanExecutor {
 			return jobClient.submitJobAndWait();
 		}
 	}
-	
+
 	/**
 	 * Returns a JSON dump of the optimized plan.
 	 * 
@@ -103,7 +103,7 @@ public class LocalExecutor implements PlanExecutor {
 
 		return gen.getOptimizerPlanAsJSON(op);
 	}
-	
+
 	/**
 	 * Executes the program described by the given plan assembler.
 	 * 
@@ -133,12 +133,10 @@ public class LocalExecutor implements PlanExecutor {
 			exec.start();
 			return exec.executePlan(plan);
 		} finally {
-			if (exec != null) {
-				exec.stop();
-			}
+			exec.stop();
 		}
 	}
-	
+
 	/**
 	 * Returns a JSON dump of the optimized plan.
 	 * 
@@ -157,12 +155,10 @@ public class LocalExecutor implements PlanExecutor {
 
 			return gen.getOptimizerPlanAsJSON(op);
 		} finally {
-			if (exec != null) {
-				exec.stop();
-			}
+			exec.stop();
 		}
 	}
-	
+
 	/**
 	 * Return unoptimized plan as JSON.
 	 * @return

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/RemoteExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/RemoteExecutor.java
@@ -9,10 +9,11 @@ import eu.stratosphere.pact.client.nephele.api.PlanWithJars;
 import eu.stratosphere.pact.common.plan.Plan;
 
 public class RemoteExecutor implements PlanExecutor {
-	
+
 	private Client client;
+
 	private List<String> jarFiles;
-	
+
 	public RemoteExecutor(String hostname, int port, List<String> jarFiles) {
 		this.client = new Client(new InetSocketAddress(hostname, port));
 		this.jarFiles = jarFiles;
@@ -25,8 +26,7 @@ public class RemoteExecutor implements PlanExecutor {
 
 	@Override
 	public long executePlan(Plan plan) throws Exception {
-		PlanWithJars p = new PlanWithJars(plan, jarFiles);
-		client.run(p, true);
-		return 0;
+		PlanWithJars p = new PlanWithJars(plan, this.jarFiles);
+		return this.client.run(p, true);
 	}
 }


### PR DESCRIPTION
- Removed obsolete null-value check in the finally clauses in LocalExecutor
- Returning proper exit code in RemoteExecutor#executePlan()
