### PR TITLE
Name escaping for jobmanager webfrontend

### DIFF
--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/util/StringUtils.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/util/StringUtils.java
@@ -103,4 +103,48 @@ public final class StringUtils {
 		}
 		return bts;
 	}
+	
+	/**
+	 * Helper function to escape Strings for display in HTML pages
+	 * 
+	 * @param str
+	 * 	String to Escape
+	 * @return escaped String
+	 */
+    public static String escapeHtml(String str) {
+        int len = str.length();
+        char[] s = str.toCharArray();
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < len; i += 1) {
+                char c = s[i];
+                if ((c == '\\') || (c == '"') || (c == '/')) {
+                        sb.append('\\');
+                        sb.append(c);
+                }
+                else if (c == '\b')
+                        sb.append("\\b");
+                else if (c == '\t')
+                        sb.append("\\t");
+                else if (c == '\n')
+                        sb.append("<br>");
+                else if (c == '\f')
+                        sb.append("\\f");
+                else if (c == '\r')
+                        sb.append("\\r");
+                else if (c == '>')
+                        sb.append("&gt;");
+                else if (c == '<')
+                        sb.append("&lt;");
+                else {
+                        if (c < ' ') {
+                                // Unreadable throw away
+                        } else {
+                                sb.append(c);
+                        }
+                }
+        }
+
+        return sb.toString();
+    }
 }

--- a/nephele/nephele-management/src/main/java/eu/stratosphere/nephele/managementgraph/ManagementGroupVertex.java
+++ b/nephele/nephele-management/src/main/java/eu/stratosphere/nephele/managementgraph/ManagementGroupVertex.java
@@ -28,6 +28,7 @@ import eu.stratosphere.nephele.execution.ExecutionState;
 import eu.stratosphere.nephele.io.IOReadableWritable;
 import eu.stratosphere.nephele.io.channels.ChannelType;
 import eu.stratosphere.nephele.util.EnumUtils;
+import eu.stratosphere.nephele.util.StringUtils;
 
 /**
  * This class implements a management group vertex of a {@link ManagementGraph}. A management group vertex is derived
@@ -431,7 +432,7 @@ public final class ManagementGroupVertex extends ManagementAttachment implements
 		
 		json.append("{");
 		json.append("\"groupvertexid\": \"" + this.getID() + "\",");
-		json.append("\"groupvertexname\": \"" + this.getName() + "\",");
+		json.append("\"groupvertexname\": \"" + StringUtils.escapeHtml(this.getName()) + "\",");
 		json.append("\"numberofgroupmembers\": " + this.getNumberOfGroupMembers() + ",");
 		json.append("\"groupmembers\": [");
 		
@@ -465,7 +466,7 @@ public final class ManagementGroupVertex extends ManagementAttachment implements
 			
 			json.append("{");
 			json.append("\"groupvertexid\": \"" + edge.getSource().getID() + "\",");
-			json.append("\"groupvertexname\": \"" +  edge.getSource().getName() + "\",");
+			json.append("\"groupvertexname\": \"" +  StringUtils.escapeHtml(edge.getSource().getName()) + "\",");
 			json.append("\"channelType\": \"" +  edge.getChannelType() + "\"");
 			json.append("}");
 			

--- a/nephele/nephele-management/src/main/java/eu/stratosphere/nephele/managementgraph/ManagementVertex.java
+++ b/nephele/nephele-management/src/main/java/eu/stratosphere/nephele/managementgraph/ManagementVertex.java
@@ -25,6 +25,7 @@ import eu.stratosphere.nephele.execution.ExecutionState;
 import eu.stratosphere.nephele.io.IOReadableWritable;
 import eu.stratosphere.nephele.types.StringRecord;
 import eu.stratosphere.nephele.util.EnumUtils;
+import eu.stratosphere.nephele.util.StringUtils;
 
 /**
  * This class implements a management vertex of a {@link ManagementGraph}. A management vertex is derived from the type
@@ -341,7 +342,7 @@ public final class ManagementVertex extends ManagementAttachment implements IORe
 		StringBuilder json = new StringBuilder("");
 		json.append("{");
 		json.append("\"vertexid\": \"" + this.getID() + "\",");
-		json.append("\"vertexname\": \"" + this + "\",");
+		json.append("\"vertexname\": \"" + StringUtils.escapeHtml(this.toString()) + "\",");
 		json.append("\"vertexstatus\": \"" + this.getExecutionState() + "\",");
 		json.append("\"vertexinstancename\": \"" + this.getInstanceName() + "\",");
 		json.append("\"vertexinstancetype\": \"" + this.getInstanceType() + "\"");

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/web/JobmanagerInfoServlet.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/web/JobmanagerInfoServlet.java
@@ -57,7 +57,7 @@ public class JobmanagerInfoServlet extends HttpServlet {
 				//Serialize job to json
 				wrt.write("{");
 				wrt.write("\"jobid\": \"" + jobEvent.getJobID() + "\",");
-				wrt.write("\"jobname\": \"" + jobEvent.getJobName()+"\",");
+				wrt.write("\"jobname\": \"" + StringUtils.escapeHtml(jobEvent.getJobName())+"\",");
 				wrt.write("\"status\": \""+ jobEvent.getJobStatus() + "\",");
 				wrt.write("\"time\": " + jobEvent.getTimestamp()+",");
 				


### PR DESCRIPTION
HTML escaping for names in the webinterface of the jobmanager. Workaround for issue #171.
