### PR TITLE
Add new way of specifying scala jobs: query {}

### DIFF
--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/Query.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/Query.scala
@@ -1,0 +1,15 @@
+package eu.stratosphere.scala
+
+import eu.stratosphere.pact.generic.contract.Contract
+import eu.stratosphere.scala.analysis.NewGlobalSchemaGenerator
+import eu.stratosphere.pact.common.contract.GenericDataSink
+import eu.stratosphere.pact.common.plan.Plan
+import scala.collection.JavaConversions._
+import java.util.Calendar
+
+object query {
+  def apply(block: => Seq[ScalaSink[_]]): ScalaPlan = {
+    val sinks = block
+    new ScalaPlan(sinks)
+  }
+}

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/scalaPactPrograms/WordCountITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/scalaPactPrograms/WordCountITCase.java
@@ -32,9 +32,9 @@ public class WordCountITCase extends eu.stratosphere.pact.test.pactPrograms.Word
 	@Override
 	protected Plan getPactPlan() {
 		WordCount wc = new WordCount();
-		return wc.getScalaPlan(
-			config.getInteger("WordCountTest#NumSubtasks", 1),
-			textPath, resultPath);
+        Plan plan = wc.getScalaPlan(textPath, resultPath);
+        plan.setDefaultParallelism(config.getInteger("WordCountTest#NumSubtasks", 1));
+		return plan;
 	}
 
 	

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/scalaPactPrograms/WordCountWithCountFunctionITCase.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/test/scalaPactPrograms/WordCountWithCountFunctionITCase.java
@@ -15,12 +15,11 @@
 
 package eu.stratosphere.pact.test.scalaPactPrograms;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import eu.stratosphere.nephele.configuration.Configuration;
 import eu.stratosphere.pact.common.plan.Plan;
 import eu.stratosphere.scala.examples.wordcount.WordCountWithCount;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class WordCountWithCountFunctionITCase extends eu.stratosphere.pact.test.pactPrograms.WordCountITCase {
@@ -31,6 +30,9 @@ public class WordCountWithCountFunctionITCase extends eu.stratosphere.pact.test.
 
 	@Override
 	protected Plan getPactPlan() {
-		return new WordCountWithCount().getScalaPlan(config.getInteger("WordCountTest#NumSubtasks", 1), textPath, resultPath);
-	}
+        WordCountWithCount wc = new WordCountWithCount();
+        Plan plan = wc.getScalaPlan(textPath, resultPath);
+        plan.setDefaultParallelism(config.getInteger("WordCountTest#NumSubtasks", 1));
+        return plan;
+    }
 }


### PR DESCRIPTION
This is just to let you know what I'm working on. Do not merge yet.

I want to get rid of ScalaPlan and let people specify queries like this:

``` scala
def getScalaPlan(textInput: String, wordsOutput: String) = {
  query {
    val input = TextFile(textInput)

    val words = input flatMap { _.toLowerCase().split(" ") }
    val counts = words groupBy { case (word, _) => word } count()

    val output = counts.write(wordsOutput, CsvOutputFormat)

    Seq(output)
  }
}
```

I want to introduce this now before the new release so that people get to know it. In the future this will allow looking at the AST of the whole query, not just at single anonymous functions. Also, we could have something like this instead of the code mentioned above:

``` scala

val ex = ExecutionContext("local") // ExecutionContext("localhost:666", <jars>)
ex.query {
  val input = TextFile(textInput)
  val words = input flatMap { _.toLowerCase().split(" ") }
  val counts = words groupBy { case (word, _) => word } count()
  val output = counts.write(wordsOutput, CsvOutputFormat)
  Seq(output)
}
```

Where the query is immediately executed on the executor.
