### PR TITLE
Fix logging

### DIFF
--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/client/JobClient.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/client/JobClient.java
@@ -328,7 +328,7 @@ public class JobClient {
 					continue;
 				}
 
-				this.console.println(event.toString());
+				LOG.info(event.toString());
 
 				this.lastProcessedEventSequenceNumber = event.getSequenceNumber();
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSet.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSet.scala
@@ -15,11 +15,11 @@ package eu.stratosphere.scala
 
 import language.experimental.macros
 import eu.stratosphere.pact.generic.contract.Contract
-import eu.stratosphere.scala.operators.CoGroupDataStream
-import eu.stratosphere.scala.operators.CrossDataStream
-import eu.stratosphere.scala.operators.JoinDataStream
+import eu.stratosphere.scala.operators.CoGroupDataSet
+import eu.stratosphere.scala.operators.CrossDataSet
+import eu.stratosphere.scala.operators.JoinDataSet
 import eu.stratosphere.scala.operators.MapMacros
-import eu.stratosphere.scala.operators.GroupByDataStream
+import eu.stratosphere.scala.operators.KeyedDataSet
 import eu.stratosphere.scala.operators.ReduceMacros
 import eu.stratosphere.scala.operators.UnionMacros
 import eu.stratosphere.scala.operators.IterateMacros
@@ -27,9 +27,9 @@ import eu.stratosphere.scala.operators.WorksetIterateMacros
 
 class DataSet[T] (val contract: Contract with ScalaContract[T]) {
   
-  def cogroup[RightIn](rightInput: DataSet[RightIn]) = new CoGroupDataStream[T, RightIn](this, rightInput)
-  def cross[RightIn](rightInput: DataSet[RightIn]) = new CrossDataStream[T, RightIn](this, rightInput)
-  def join[RightIn](rightInput: DataSet[RightIn]) = new JoinDataStream[T, RightIn](this, rightInput)
+  def cogroup[RightIn](rightInput: DataSet[RightIn]) = new CoGroupDataSet[T, RightIn](this, rightInput)
+  def cross[RightIn](rightInput: DataSet[RightIn]) = new CrossDataSet[T, RightIn](this, rightInput)
+  def join[RightIn](rightInput: DataSet[RightIn]) = new JoinDataSet[T, RightIn](this, rightInput)
   
   def map[Out](fun: T => Out) = macro MapMacros.map[T, Out]
   def flatMap[Out](fun: T => Iterator[Out]) = macro MapMacros.flatMap[T, Out]

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSet.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSet.scala
@@ -40,8 +40,9 @@ class DataSet[T] (val contract: Contract with ScalaContract[T]) {
 
   // reduce without grouping
   def reduce(fun: (T, T) => T) = macro ReduceMacros.globalReduce[T]
-  def reduceAll[Out](fun: Iterator[T] => Out) = macro ReduceMacros.globalReduceAll[T, Out]
-  
+  def reduceAll[Out](fun: Iterator[T] => Out) = macro ReduceMacros.globalReduceGroup[T, Out]
+  def combinableReduceAll[Out](fun: Iterator[T] => Out) = macro ReduceMacros.combinableGlobalReduceGroup[T]
+
   def union(secondInput: DataSet[T]) = macro UnionMacros.impl[T]
   
   def iterateWithDelta[DeltaItem](stepFunction: DataSet[T] => (DataSet[T], DataSet[DeltaItem])) = macro IterateMacros.iterateWithDelta[T, DeltaItem]

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/ScalaPlan.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/ScalaPlan.scala
@@ -26,7 +26,7 @@ import eu.stratosphere.pact.common.plan.PlanAssemblerDescription
 
 class ScalaPlan(scalaSinks: Seq[ScalaSink[_]], scalaJobName: String = "PACT SCALA Job at " + Calendar.getInstance().getTime()) extends Plan(asJavaCollection(scalaSinks map { _.sink }), scalaJobName) {
   val pactSinks = scalaSinks map { _.sink.asInstanceOf[Contract with ScalaContract[_]] }
-  GlobalSchemaGenerator.initGlobalSchema(pactSinks)
+  new GlobalSchemaGenerator().initGlobalSchema(pactSinks)
   override def getPostPassClassName() = "eu.stratosphere.scala.ScalaPostPass";
 }
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/GlobalSchemaGenerator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/GlobalSchemaGenerator.scala
@@ -165,6 +165,14 @@ object GlobalSchemaGenerator {
         contract.getUDF.setOutputGlobalIndexes(freePos1, fixedOutputs)
       }
 
+      // for key-less (global) reducers
+      case contract : ReduceContract with OneInputScalaContract[_, _] => {
+
+        val freePos1 = globalizeContract(contract.getInputs().get(0), Seq(contract.getUDF.inputFields), proxies, None, freePos)
+
+        contract.getUDF.setOutputGlobalIndexes(freePos1, fixedOutputs)
+      }
+
       case contract : MapContract with UnionScalaContract[_] => {
 
         // Determine where this contract's children should write their output 
@@ -180,7 +188,7 @@ object GlobalSchemaGenerator {
 
           if (input4s.getUDF.outputFields.isGlobalized || input4s.getUDF.outputFields.exists(_.globalPos.isReference)) {
 //            inputs.set(idx, CopyOperator(input4s))
-            throw new RuntimeException("Copy operator needed, not yet implemented properly.")
+//            throw new RuntimeException("Copy operator needed, not yet implemented properly.")
           }
         }
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/GlobalSchemaGenerator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/GlobalSchemaGenerator.scala
@@ -39,7 +39,7 @@ import eu.stratosphere.pact.generic.contract.WorksetIteration
 import eu.stratosphere.scala.WorksetIterationScalaContract
 import eu.stratosphere.pact.common.contract.GenericDataSink
 
-object GlobalSchemaGenerator {
+class GlobalSchemaGenerator {
 
   def initGlobalSchema(sinks: Seq[Contract with ScalaContract[_]]): Unit = {
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/GlobalSchemaPrinter.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/GlobalSchemaPrinter.scala
@@ -13,7 +13,7 @@
 
 package eu.stratosphere.scala.analysis
 
-import scala.Array.canBuildFrom
+
 import scala.collection.JavaConversions.asScalaBuffer
 import scala.collection.JavaConversions.collectionAsScalaIterable
 import Extractors.CoGroupNode
@@ -23,6 +23,7 @@ import Extractors.DataSourceNode
 import Extractors.JoinNode
 import Extractors.MapNode
 import Extractors.ReduceNode
+import eu.stratosphere.scala.analysis.GlobalSchemaGenerator
 import eu.stratosphere.pact.common.contract.GenericDataSink
 import eu.stratosphere.pact.common.plan.Plan
 import eu.stratosphere.pact.generic.contract.Contract
@@ -30,17 +31,19 @@ import eu.stratosphere.pact.generic.contract.DualInputContract
 import eu.stratosphere.pact.generic.contract.SingleInputContract
 import eu.stratosphere.pact.generic.contract.BulkIteration
 import eu.stratosphere.pact.generic.contract.WorksetIteration
+import org.apache.commons.logging.{LogFactory, Log}
 
 object GlobalSchemaPrinter {
 
   import Extractors._
 
+  private final val LOG: Log = LogFactory.getLog(classOf[GlobalSchemaGenerator])
+
   def printSchema(plan: Plan): Unit = {
 
-    println("### " + plan.getJobName + " ###")
+    LOG.debug("### " + plan.getJobName + " ###")
     plan.getDataSinks.foldLeft(Set[Contract]())(printSchema)
-    println("####" + ("#" * plan.getJobName.length) + "####")
-    println()
+    LOG.debug("####" + ("#" * plan.getJobName.length) + "####")
   }
 
   private def printSchema(visited: Set[Contract], node: Contract): Set[Contract] = {
@@ -201,6 +204,6 @@ object GlobalSchemaPrinter {
     val sDiscards = discards flatMap { case (pre, value) => value.sorted.map(pre + _) } mkString ", "
     val sWrites = indexesToStrings("", writes.toSerializerIndexArray) mkString ", "
 
-    println(formatString.format(name, kind, sKeys, sReads, sForwards, sDiscards, sWrites))
+    LOG.debug(formatString.format(name, kind, sKeys, sReads, sForwards, sDiscards, sWrites))
   }
 }

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/postPass/GlobalSchemaPrinter.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/analysis/postPass/GlobalSchemaPrinter.scala
@@ -29,22 +29,25 @@ import eu.stratosphere.pact.compiler.plan.SinkJoiner
 import eu.stratosphere.pact.compiler.plan.candidate.OptimizedPlan
 import eu.stratosphere.scala.analysis.FieldSet
 import eu.stratosphere.scala.analysis.FieldSelector
+import eu.stratosphere.scala.analysis.postPass.GlobalSchemaOptimizer
 import eu.stratosphere.pact.common.plan.Plan
 import eu.stratosphere.pact.generic.contract.Contract
 import eu.stratosphere.pact.generic.contract.SingleInputContract
 import eu.stratosphere.pact.generic.contract.DualInputContract
 import eu.stratosphere.pact.common.contract.GenericDataSink
+import org.apache.commons.logging.{LogFactory, Log}
 
 object GlobalSchemaPrinter {
 
   import Extractors._
 
+  private final val LOG: Log = LogFactory.getLog(classOf[GlobalSchemaOptimizer])
+
   def printSchema(plan: OptimizedPlan): Unit = {
 
-    println("### " + plan.getJobName + " ###")
+    LOG.debug("### " + plan.getJobName + " ###")
     plan.getDataSinks.map(_.getSinkNode).foldLeft(Set[OptimizerNode]())(printSchema)
-    println("####" + ("#" * plan.getJobName.length) + "####")
-    println()
+    LOG.debug("####" + ("#" * plan.getJobName.length) + "####")
   }
 
   private def printSchema(visited: Set[OptimizerNode], node: OptimizerNode): Set[OptimizerNode] = {
@@ -59,7 +62,7 @@ object GlobalSchemaPrinter {
         val newVisited = children.foldLeft(visited + node)(printSchema)
 
         node match {
-          
+
           case _: SinkJoiner | _: BinaryUnionNode =>
 
           case DataSinkNode(udf, input) => {
@@ -121,7 +124,7 @@ object GlobalSchemaPrinter {
               udf.outputFields
             )
           }
-          
+
           case UnionNode(udf, input) => {
             printInfo(node, "Union",
               Seq(),
@@ -134,7 +137,7 @@ object GlobalSchemaPrinter {
 
           case ReduceNode(udf, key, input) => {
 
-//            val contract = node.asInstanceOf[Reduce4sContract[_, _, _]] 
+//            val contract = node.asInstanceOf[Reduce4sContract[_, _, _]]
 //            contract.userCombineCode map { _ =>
 //              printInfo(node, "Combine",
 //                Seq(("", key)),
@@ -197,6 +200,6 @@ object GlobalSchemaPrinter {
     val sDiscards = discards flatMap { case (pre, value) => value.sorted.map(pre + _) } mkString ", "
     val sWrites = indexesToStrings("", writes.toSerializerIndexArray) mkString ", "
 
-    println(formatString.format(name, kind, sKeys, sReads, sForwards, sDiscards, sWrites))
+    LOG.debug(formatString.format(name, kind, sKeys, sReads, sForwards, sDiscards, sWrites))
   }
 }

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
@@ -41,7 +41,7 @@ import eu.stratosphere.scala.DataSet
 import eu.stratosphere.scala.TwoInputHintable
 import eu.stratosphere.scala.codegen.Util
 
-class CrossDataStream[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInput: DataSet[RightIn]) {
+class CrossDataSet[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInput: DataSet[RightIn]) {
   def map[Out](fun: (LeftIn, RightIn) => Out): DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out] = macro CrossMacros.map[LeftIn, RightIn, Out]
   def flatMap[Out](fun: (LeftIn, RightIn) => Iterator[Out]): DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out] = macro CrossMacros.flatMap[LeftIn, RightIn, Out]
   def filter(fun: (LeftIn, RightIn) => Boolean): DataSet[(LeftIn, RightIn)] with TwoInputHintable[LeftIn, RightIn, (LeftIn, RightIn)] = macro CrossMacros.filter[LeftIn, RightIn]
@@ -49,7 +49,7 @@ class CrossDataStream[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val right
 
 object CrossMacros {
 
-  def map[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CrossDataStream[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Out]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
+  def map[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CrossDataSet[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Out]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -59,7 +59,7 @@ object CrossMacros {
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
     
     val contract = reify {
-      val helper: CrossDataStream[LeftIn, RightIn] = c.prefix.splice
+      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
 
       val generatedStub = new CrossStub with Serializable {
         val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
@@ -129,7 +129,7 @@ object CrossMacros {
     return result
   }
   
-  def flatMap[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CrossDataStream[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Iterator[Out]]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
+  def flatMap[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CrossDataSet[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Iterator[Out]]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -139,7 +139,7 @@ object CrossMacros {
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
     
     val contract = reify {
-      val helper: CrossDataStream[LeftIn, RightIn] = c.prefix.splice
+      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
 
       val generatedStub = new CrossStub with Serializable {
         val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
@@ -214,7 +214,7 @@ object CrossMacros {
     return result
   }
   
-   def filter[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag](c: Context { type PrefixType = CrossDataStream[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Boolean]): c.Expr[DataSet[(LeftIn, RightIn)] with TwoInputHintable[LeftIn, RightIn, (LeftIn, RightIn)]] = {
+   def filter[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag](c: Context { type PrefixType = CrossDataSet[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Boolean]): c.Expr[DataSet[(LeftIn, RightIn)] with TwoInputHintable[LeftIn, RightIn, (LeftIn, RightIn)]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -224,7 +224,7 @@ object CrossMacros {
     val (udtOut, createUdtOut) = slave.mkUdtClass[(LeftIn, RightIn)]
     
     val contract = reify {
-      val helper: CrossDataStream[LeftIn, RightIn] = c.prefix.splice
+      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
 
       val generatedStub = new CrossStub with Serializable {
         val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/DataSourceMacros.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/DataSourceMacros.scala
@@ -239,10 +239,10 @@ object CsvInputFormat {
         
         // there is a problem with the reification of Class[_ <: Value], so we work with Class[_] and convert it
         // in a function outside the reify block
-        setFieldTypesArray(asValueClassArray(getUDF.outputFields.filter(_.isUsed).map(x => getUDF.outputUDT.fieldTypes(x.localPos))))
+//        setFieldTypesArray(asValueClassArray(getUDF.outputFields.filter(_.isUsed).map(x => getUDF.outputUDT.fieldTypes(x.localPos))))
         
         // is this maybe more correct? Note that null entries in the types array denote fields skipped by the CSV parser
-//      setFieldTypesArray(asValueClassArrayFromOption(getUDF.outputFields.map(x => if (x.isUsed) Some(getUDF.outputUDT.fieldTypes(x.localPos)) else None)))
+        setFieldTypesArray(asValueClassArrayFromOption(getUDF.outputFields.map(x => if (x.isUsed) Some(getUDF.outputUDT.fieldTypes(x.localPos)) else None)))
         
       }
       
@@ -271,7 +271,10 @@ object CsvInputFormat {
     def asValueClassArrayFromOption(types: Seq[Option[Class[_]]]) : Array[Class[_ <: Value]] = {
       
       val typed = types.foldRight(List[Class[_ <: Value]]())((x,y) => {
-        val t : Class[_ <: Value] = if (x.isEmpty) null else x.asInstanceOf[Class[_ <: Value]]
+        val t : Class[_ <: Value] = x match {
+          case None => null
+          case Some(x) => x.asInstanceOf[Class[_ <: Value]]
+        }
         t :: y
       })
       

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
@@ -46,7 +46,7 @@ import eu.stratosphere.scala.codegen.Util
 
 class GroupByDataStream[In](val keySelection: List[Int], val input: DataSet[In]) {
   def reduceGroup[Out](fun: Iterator[In] => Out): DataSet[Out] with OneInputHintable[In, Out] = macro ReduceMacros.reduceGroup[In, Out]
-  // def combinableReduceGroup(fun: Iterator[In] => In): DataStream[In] with OneInputHintable[In, In] = macro ReduceMacros.combinableReduce[In]
+  def combinableReduceGroup(fun: Iterator[In] => In): DataSet[In] with OneInputHintable[In, In] = macro ReduceMacros.combinableReduceGroup[In]
   
   def reduce(fun: (In, In) => In): DataSet[In] with OneInputHintable[In, In] = macro ReduceMacros.reduce[In]
   
@@ -55,7 +55,8 @@ class GroupByDataStream[In](val keySelection: List[Int], val input: DataSet[In])
 
 object ReduceMacros {
   
-  def groupBy[In: c.WeakTypeTag, Key: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })(keyFun: c.Expr[In => Key]): c.Expr[GroupByDataStream[In]] = {
+  def groupBy[In: c.WeakTypeTag, Key: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })
+                                                    (keyFun: c.Expr[In => Key]): c.Expr[GroupByDataStream[In]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -68,8 +69,49 @@ object ReduceMacros {
 
     return helper
   }
-  
-  def reduce[In: c.WeakTypeTag](c: Context { type PrefixType = GroupByDataStream[In] })(fun: c.Expr[(In, In) => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
+
+  def reduce[In: c.WeakTypeTag](c: Context { type PrefixType = GroupByDataStream[In] })
+                               (fun: c.Expr[(In, In) => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
+    import c.universe._
+
+    reduceImpl(c)(c.prefix, fun)
+  }
+
+  def globalReduce[In: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })(fun: c.Expr[(In, In) => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
+    import c.universe._
+
+    reduceImpl(c)(reify { new GroupByDataStream[In](List[Int](), c.prefix.splice) }, fun)
+  }
+
+  def reduceGroup[In: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = GroupByDataStream[In] })
+                                                        (fun: c.Expr[Iterator[In] => Out]): c.Expr[DataSet[Out] with OneInputHintable[In, Out]] = {
+    import c.universe._
+
+    reduceGroupImpl(c)(c.prefix, fun)
+  }
+
+  def globalReduceGroup[In: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })(fun: c.Expr[Iterator[In] => Out]): c.Expr[DataSet[Out] with OneInputHintable[In, Out]] = {
+    import c.universe._
+
+    reduceGroupImpl(c)(reify { new GroupByDataStream[In](List[Int](), c.prefix.splice) }, fun)
+  }
+
+  def combinableReduceGroup[In: c.WeakTypeTag](c: Context { type PrefixType = GroupByDataStream[In] })
+                                              (fun: c.Expr[Iterator[In] => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
+    import c.universe._
+
+    combinableReduceGroupImpl(c)(c.prefix, fun)
+  }
+
+  def combinableGlobalReduceGroup[In: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })
+                                              (fun: c.Expr[Iterator[In] => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
+    import c.universe._
+
+    combinableReduceGroupImpl(c)(reify { new GroupByDataStream[In](List[Int](), c.prefix.splice) }, fun)
+  }
+
+  def reduceImpl[In: c.WeakTypeTag](c: Context)
+                               (groupedInput: c.Expr[GroupByDataStream[In]], fun: c.Expr[(In, In) => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -79,7 +121,7 @@ object ReduceMacros {
     val (udtIn, createUdtIn) = slave.mkUdtClass[In]
     
     val contract = reify {
-      val helper: GroupByDataStream[In] = c.prefix.splice
+      val helper = groupedInput.splice
       val keySelection = helper.keySelection
 
       val generatedStub = new ReduceStub with Serializable {
@@ -179,7 +221,8 @@ object ReduceMacros {
     return result
   }
 
-  def reduceGroup[In: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = GroupByDataStream[In] })(fun: c.Expr[Iterator[In] => Out]): c.Expr[DataSet[Out] with OneInputHintable[In, Out]] = {
+  def reduceGroupImpl[In: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context)
+                                                            (groupedInput: c.Expr[GroupByDataStream[In]], fun: c.Expr[Iterator[In] => Out]): c.Expr[DataSet[Out] with OneInputHintable[In, Out]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -190,7 +233,7 @@ object ReduceMacros {
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
     
     val contract = reify {
-      val helper: GroupByDataStream[In] = c.prefix.splice
+      val helper: GroupByDataStream[In] = groupedInput.splice
       val keySelection = helper.keySelection
 
       val generatedStub = new ReduceStub with Serializable {
@@ -250,7 +293,8 @@ object ReduceMacros {
     return result
   }
   
-  def combinableReduce[In: c.WeakTypeTag](c: Context { type PrefixType = GroupByDataStream[In] })(fun: c.Expr[Iterator[In] => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
+  def combinableReduceGroupImpl[In: c.WeakTypeTag](c: Context)
+                                              (groupedInput: c.Expr[GroupByDataStream[In]], fun: c.Expr[Iterator[In] => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -260,7 +304,7 @@ object ReduceMacros {
     val (udtIn, createUdtIn) = slave.mkUdtClass[In]
     
     val contract = reify {
-      val helper: GroupByDataStream[In] = c.prefix.splice
+      val helper: GroupByDataStream[In] = groupedInput.splice
       val keySelection = helper.keySelection
 
       val generatedStub = new ReduceStub with Serializable {
@@ -360,169 +404,6 @@ object ReduceMacros {
     return result
   }
 
-  def globalReduce[In: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })(fun: c.Expr[(In, In) => In]): c.Expr[DataSet[In] with OneInputHintable[In, In]] = {
-    import c.universe._
-
-    val slave = MacroContextHolder.newMacroHelper(c)
-    
-//    val (paramName, udfBody) = slave.extractOneInputUdf(fun.tree)
-
-    val (udtIn, createUdtIn) = slave.mkUdtClass[In]
-    
-    val contract = reify {
-
-      val generatedStub = new ReduceStub with Serializable {
-        val inputUDT = c.Expr[UDT[In]](createUdtIn).splice
-        val outputUDT = inputUDT
-        val udf: UDF1[In, In] = new UDF1(inputUDT, outputUDT)
-        
-        private val combineRecord = new PactRecord()
-        private val reduceRecord = new PactRecord()
-
-        private var combineIterator: DeserializingIterator[In] = null
-        private var combineSerializer: UDTSerializer[In] = _
-        private var combineForwardFrom: Array[Int] = _
-        private var combineForwardTo: Array[Int] = _
-
-        private var reduceIterator: DeserializingIterator[In] = null
-        private var reduceSerializer: UDTSerializer[In] = _
-        private var reduceForwardFrom: Array[Int] = _
-        private var reduceForwardTo: Array[Int] = _
-
-        private def combinerOutputs: Set[Int] = udf.inputFields.filter(_.isUsed).map(_.globalPos.getValue).toSet
-
-        def combineForwardSetFrom: Set[Int] = udf.getForwardIndexSetFrom.diff(combinerOutputs).toSet
-        def combineForwardSetTo: Set[Int] = udf.getForwardIndexSetTo.diff(combinerOutputs).toSet
-        def combineDiscardSet: Set[Int] = udf.discardSet.map(_.getValue).diff(combinerOutputs).toSet
-
-        private def combineOutputLength = {
-          val outMax = if (combinerOutputs.isEmpty) -1 else combinerOutputs.max
-          val forwardMax = if (combineForwardSetTo.isEmpty) -1 else combineForwardSetTo.max
-          math.max(outMax, forwardMax) + 1
-        }
-
-        override def open(config: Configuration) = {
-          super.open(config)
-          this.combineRecord.setNumFields(combineOutputLength)
-          this.reduceRecord.setNumFields(udf.getOutputLength)
-
-          this.combineIterator = new DeserializingIterator(udf.getInputDeserializer)
-          // we are serializing for the input of the reduce...
-          this.combineSerializer = udf.getInputDeserializer
-          this.combineForwardFrom = combineForwardSetFrom.toArray
-          this.combineForwardTo = combineForwardSetTo.toArray
-
-          this.reduceIterator = new DeserializingIterator(udf.getInputDeserializer)
-          this.reduceSerializer = udf.getOutputSerializer
-          this.reduceForwardFrom = udf.getForwardIndexArrayFrom
-          this.reduceForwardTo = udf.getForwardIndexArrayTo
-        }
-        
-        val userCode = fun.splice
-
-        override def combine(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
-          val firstRecord = combineIterator.initialize(records)
-          combineRecord.copyFrom(firstRecord, combineForwardFrom, combineForwardTo)
-
-          val output = combineIterator.reduce(userCode)
-
-          combineSerializer.serialize(output, combineRecord)
-          out.collect(combineRecord)
-        }
-
-        override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
-          val firstRecord = reduceIterator.initialize(records)
-          reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
-
-          val output = reduceIterator.reduce(userCode)
-
-          reduceSerializer.serialize(output, reduceRecord)
-          out.collect(reduceRecord)
-        }
-
-      }
-      
-      val builder = ReduceContract.builder(generatedStub).input(c.prefix.splice.contract)
-      
-      val ret = new ReduceContract(builder) with OneInputScalaContract[In, In] {
-        override def getUDF = generatedStub.udf
-        override def annotations = Annotations.getCombinable() +: Seq(
-          Annotations.getConstantFields(
-            Util.filterNonForwards(getUDF.getForwardIndexArrayFrom, getUDF.getForwardIndexArrayTo)))
-      }
-      new DataSet[In](ret) with OneInputHintable[In, In] {}
-    }
-
-    val result = c.Expr[DataSet[In] with OneInputHintable[In, In]](Block(List(udtIn), contract.tree))
-    
-    return result
-  }
-
-  def globalReduceAll[In: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })(fun: c.Expr[Iterator[In] => Out]): c.Expr[DataSet[Out] with OneInputHintable[In, Out]] = {
-    import c.universe._
-
-    val slave = MacroContextHolder.newMacroHelper(c)
-    
-//    val (paramName, udfBody) = slave.extractOneInputUdf(fun.tree)
-
-    val (udtIn, createUdtIn) = slave.mkUdtClass[In]
-    val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
-    
-    val contract = reify {
-
-      val generatedStub = new ReduceStub with Serializable {
-        val inputUDT = c.Expr[UDT[In]](createUdtIn).splice
-        val outputUDT = c.Expr[UDT[Out]](createUdtOut).splice
-        val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
-        
-        private val reduceRecord = new PactRecord()
-
-        private var reduceIterator: DeserializingIterator[In] = null
-        private var reduceSerializer: UDTSerializer[Out] = _
-        private var reduceForwardFrom: Array[Int] = _
-        private var reduceForwardTo: Array[Int] = _
-
-        override def open(config: Configuration) = {
-          super.open(config)
-          this.reduceRecord.setNumFields(udf.getOutputLength)
-          this.reduceIterator = new DeserializingIterator(udf.getInputDeserializer)
-          this.reduceSerializer = udf.getOutputSerializer
-          this.reduceForwardFrom = udf.getForwardIndexArrayFrom
-          this.reduceForwardTo = udf.getForwardIndexArrayTo
-        }
-
-        override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
-          val firstRecord = reduceIterator.initialize(records)
-          reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
-
-          val output = fun.splice.apply(reduceIterator)
-
-          reduceSerializer.serialize(output, reduceRecord)
-          out.collect(reduceRecord)
-        }
-
-      }
-      
-      val builder = ReduceContract.builder(generatedStub).input(c.prefix.splice.contract)
-      
-      val ret = new ReduceContract(builder) with OneInputScalaContract[In, Out] {
-        override def getUDF = generatedStub.udf
-        override def annotations = Seq(
-          Annotations.getConstantFields(
-            Util.filterNonForwards(getUDF.getForwardIndexArrayFrom, getUDF.getForwardIndexArrayTo)))
-      }
-      new DataSet[Out](ret) with OneInputHintable[In, Out] {}
-    }
-
-    val result = c.Expr[DataSet[Out] with OneInputHintable[In, Out]](Block(List(udtIn, udtOut), contract.tree))
-    
-    return result
-  }
-  
-  
   def count[In: c.WeakTypeTag](c: Context { type PrefixType = GroupByDataStream[In] })() : c.Expr[DataSet[(In, Int)] with OneInputHintable[In, (In, Int)]] = {
     import c.universe._
 

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
@@ -12,6 +12,10 @@ import eu.stratosphere.scala.operators._
 
 import eu.stratosphere.scala.analysis.GlobalSchemaPrinter
 import eu.stratosphere.pact.example.util.AsciiUtils
+import org.apache.log4j.Logger
+import org.apache.log4j.Level
+import eu.stratosphere.scala.analysis.postPass.GlobalSchemaOptimizer
+import eu.stratosphere.scala.analysis.GlobalSchemaGenerator
 
 
 // Grab bag of random scala examples
@@ -33,6 +37,10 @@ object Main1 {
   def addCounts(w1: (String, Int), w2: (String, Int)) = (w1._1, w1._2 + w2._2)
   
   def main(args: Array[String]) {
+//    var logger = Logger.getLogger(classOf[GlobalSchemaOptimizer])
+//    logger.setLevel(Level.DEBUG)
+//    logger = Logger.getLogger(classOf[GlobalSchemaGenerator])
+//    logger.setLevel(Level.DEBUG)
 
     def formatOutput = (word: String, count: Int) => "%s %d".format(word, count)
     

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
@@ -37,7 +37,7 @@ object Main1 {
     def formatOutput = (word: String, count: Int) => "%s %d".format(word, count)
     
     val input = TextFile("file:///home/aljoscha/dummy-input")
-    val inputNumbers = DataSource("file:///home/aljoscha/dummy-input-numbers", CsvInputFormat[(Int, String)]("\n", ','))
+    val inputNumbers = DataSource("file:///home/aljoscha/dummy-input-numbers", CsvInputFormat[(Int, String, String)](Seq(0,2,1), "\n", ','))
     
     val counts = input.map { _.split("""\W+""") map { (_, 1) } }
       .flatMap { l => l }
@@ -45,20 +45,24 @@ object Main1 {
       .combinableReduceGroup { _.reduce { (w1, w2) => (w1._1, w1._2 + w2._2) } }
       .map(fun)
 //      .filter { case (w, c) => c == 7 }
-    
+
     val countsCross = counts.cross(counts)
       .filter { case (left, right) => left._1 == "hier" }
       .map { case (w1, w2) => (w1._1 + " + " + w2._1, w1._2 + w2._2) }
     
     val foo = counts.join(inputNumbers) where { case (_, c) => c}
+
     
-    val bar1 = foo.isEqualTo { case (c, _) => c } map { (w1, w2) => (w1._1 + " is ONE " + w2._2, w1._2) }
+    val bar1 = foo.isEqualTo { case (c, _, _) => c } map { (w1, w2) => (w1._1 + " is ONE " + w2._2, w1._2) }
+    bar1.right neglects { case (a,b,c) => c }
     
-    val bar2 = foo.isEqualTo { case (c, _) => c } map { (w1, w2) => (w1._1 + " is TWO " + w2._2, w1._2) }
-    
-    val countsJoin = counts.join(inputNumbers) where { case (_, c) => c} isEqualTo { case (c, _) => c } map { (w1, w2) => (w1._1 + " is " + w2._2, w1._2) }
+    val bar2 = foo.isEqualTo { case (c, _, _) => c } map { (w1, w2) => (w1._1 + " is TWO " + w2._2, w1._2) }
+    bar2.right neglects { case (a,b,c) => c }
+
+    val countsJoin = counts.join(inputNumbers) where { case (_, c) => c} isEqualTo { case (c, _, _) => c } map { (w1, w2) => (w1._1 + " is " + w2._2, w1._2) }
     countsJoin.left preserves({ case (_, count) => count }, { case (_, count) => count })
-    
+    countsJoin.right neglects { case (a,b,c) => c }
+
     val un = countsCross union countsJoin map { x => x }
     
     val sink0 = counts.reduce { (w1, w2) => ( "Total: " , w1._2 + w2._2) }

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
@@ -42,7 +42,7 @@ object Main1 {
     val counts = input.map { _.split("""\W+""") map { (_, 1) } }
       .flatMap { l => l }
       .groupBy { case (word, _) => word }
-      .reduce { (w1, w2) => (w1._1, w1._2 + w2._2) }
+      .combinableReduceGroup { _.reduce { (w1, w2) => (w1._1, w1._2 + w2._2) } }
       .map(fun)
 //      .filter { case (w, c) => c == 7 }
     

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/LocalExecutor.java
@@ -17,10 +17,7 @@ package eu.stratosphere.pact.client;
 
 import java.util.List;
 
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
+import org.apache.log4j.*;
 
 import eu.stratosphere.nephele.client.JobClient;
 import eu.stratosphere.nephele.jobgraph.JobGraph;
@@ -54,6 +51,7 @@ public class LocalExecutor implements PlanExecutor {
 		Logger root = Logger.getRootLogger();
 		PatternLayout layout = new PatternLayout("%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n");
 		ConsoleAppender appender = new ConsoleAppender(layout, "System.err");
+        appender.setThreshold(Level.ERROR);
 		root.addAppender(appender);
 		root.setLevel(Level.WARN);
 	}


### PR DESCRIPTION
Make the scala schema printers use log4j

Fix the additional syserr appender in LocalExecutor: add a threshold so
that it does only output error messages

Make JobClient use log4j for the event output that was annoying me

This sits on #298, so only merge after that one's in.
