### PR TITLE
fixed TableInputFormat returns no records when re-opened

### DIFF
--- a/pact/pact-hbase/src/main/java/eu/stratosphere/pact/common/io/TableInputFormat.java
+++ b/pact/pact-hbase/src/main/java/eu/stratosphere/pact/common/io/TableInputFormat.java
@@ -295,6 +295,8 @@ public class TableInputFormat implements InputFormat<PactRecord, TableInputSplit
 
 		this.hbaseKey = new HBaseKey();
 		this.hbaseResult = new HBaseResult();
+
+        endReached = false;
 	}
 
 	/**


### PR DESCRIPTION
Currently TableInputFormat can only scan a single split.

The endReached flag is not reset when a new split is opened, so once the end of any split is reached, an instance cannot be used to scan another split (which is what Stratosphere tries) to do.

This sophisticated fix should resolve the issue.
