### PR TITLE
Fix typo on startpage and make sub headlines bold

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,16 +82,18 @@ $( document ).ready(function() {
 
 
 <div class="container features-detail" style="padding-top:40px;padding-bottom:40px;">
-   <div class="row">
+  <div class="row">
     <div class="col-md-12">
-     <h1 class="text-center">Features</h1>
+     <h1 class="text-center"><strong>Features</strong></h1>
     </div>
-</div>
+  </div>
 
 <div class="container features-detail">
   <div class="row" id="feature_operators">
     <div class="col-md-12">
-      <h3>More Operators</h3>
+      <div class="page-header">
+        <h3><strong>More Operators</strong></h3>
+      </div>
     </div>
   </div>
   <div class="row">
@@ -103,11 +105,11 @@ $( document ).ready(function() {
     </div>
   </div>
 
-<hr>
-
   <div class="row">
     <div class="col-md-12">
-        <h3>Advanced Data Flow Graphs</h3>
+      <div class="page-header">
+        <h3><strong>Advanced Data Flow Graphs</strong></h3>
+      </div>
     </div>
   </div>
   <div class="row">
@@ -120,7 +122,6 @@ $( document ).ready(function() {
     </div>
   </div>
 
-
   <div class="row" id="see-how-hadoop">
     <div class="col-md-12 bs-callout-info bs-callout">
       <h4>Complex Data Flows in Hadoop</h4>
@@ -131,14 +132,13 @@ $( document ).ready(function() {
     </div>
   </div>
 
-  <hr>
-
   <div class="row">
     <div class="col-md-12">
-      <h3>Powerful Programming Interfaces</h3>
+      <div class="page-header">
+        <h3><strong>Powerful Programming Interfaces</strong></h3>
+      </div>
     </div>
   </div>
-
 
   <div class="row">
     <div class="col-md-6">
@@ -159,11 +159,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
-  <hr>
-
   <div class="row">
     <div class="col-md-12">
-        <h3>Support for Iterative Algorithms</h3>
+      <div class="page-header">
+        <h3><strong>Support for Iterative Algorithms</strong></h3>
+      </div>
     </div>
   </div>
   <div class="row">
@@ -194,11 +194,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
-  <hr>
-
   <div class="row" id="feature_optimizer">
     <div class="col-md-12">
-      <h3>Built-In Optimizer</h3>
+      <div class="page-header">
+        <h3><strong>Built-In Optimizer</strong></h3>
+      </div>
     </div>
   </div>
   <div class="row">
@@ -218,11 +218,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
-  <hr>
-
   <div class="row" id="feature_stack">
     <div class="col-md-12">
-      <h3>System Stack</h3>
+      <div class="page-header">
+        <h3><strong>System Stack</strong></h3>
+      </div>
     </div>
   </div>
 
@@ -238,11 +238,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
-<hr>
-
   <div class="row">
     <div class="col-md-12">
-      <h3>Open Source Community and Support</h3>
+      <div class="page-header">
+        <h3><strong>Open Source Community and Support</strong></h3>
+      </div>
     </div>
   </div>
 
@@ -264,11 +264,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
-  <hr>
-
   <div class="row">
     <div class="col-md-12">
-      <h3>Next Steps</h3>
+      <div class="page-header">
+        <h3><strong>Next Steps</strong></h3>
+      </div>
       <p><a href="{{ site.baseurl }}/download">Download</a> and try Stratosphere. Our Quickstart scripts make it easy for developers to create an empty Stratosphere program skeleton to start from. Dependencies are seamlessly handled by Maven without any installation. Testing and debugging is possible directly inside the IDE with Stratosphere's embedded mode.
       Ready-made binaries for cluster setups are available as well.
       </p>
@@ -282,8 +282,5 @@ val plan = new ScalaPlan(Seq(output))
       <p class="text-center" style="padding-top:60px"><a href="#top"><i class="icon-collapse-top"></i> Back to top</a></p>
     </div>
   </div>
-
 </div>
-
-
 </div>

--- a/index.html
+++ b/index.html
@@ -91,9 +91,7 @@ $( document ).ready(function() {
 <div class="container features-detail">
   <div class="row" id="feature_operators">
     <div class="col-md-12">
-      <div class="page-header">
         <h3><strong>More Operators</strong></h3>
-      </div>
     </div>
   </div>
   <div class="row">
@@ -105,11 +103,11 @@ $( document ).ready(function() {
     </div>
   </div>
 
+  <hr>
+
   <div class="row">
     <div class="col-md-12">
-      <div class="page-header">
-        <h3><strong>Advanced Data Flow Graphs</strong></h3>
-      </div>
+      <h3><strong>Advanced Data Flow Graphs</strong></h3>
     </div>
   </div>
   <div class="row">
@@ -132,11 +130,11 @@ $( document ).ready(function() {
     </div>
   </div>
 
+  <hr>
+
   <div class="row">
     <div class="col-md-12">
-      <div class="page-header">
-        <h3><strong>Powerful Programming Interfaces</strong></h3>
-      </div>
+      <h3><strong>Powerful Programming Interfaces</strong></h3>
     </div>
   </div>
 
@@ -159,11 +157,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
+  <hr>
+
   <div class="row">
     <div class="col-md-12">
-      <div class="page-header">
-        <h3><strong>Support for Iterative Algorithms</strong></h3>
-      </div>
+      <h3><strong>Support for Iterative Algorithms</strong></h3>
     </div>
   </div>
   <div class="row">
@@ -194,11 +192,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
+  <hr>
+
   <div class="row" id="feature_optimizer">
     <div class="col-md-12">
-      <div class="page-header">
-        <h3><strong>Built-In Optimizer</strong></h3>
-      </div>
+      <h3><strong>Built-In Optimizer</strong></h3>
     </div>
   </div>
   <div class="row">
@@ -214,15 +212,14 @@ val plan = new ScalaPlan(Seq(output))
           <li>Input Sampling to determine cardinalities</li>
         </ul>
         <p><i class="icon-arrow-right"></i>  Focus on your application logic rather than parallel execution.</p>
-     
     </div>
   </div>
 
+  <hr>
+
   <div class="row" id="feature_stack">
     <div class="col-md-12">
-      <div class="page-header">
-        <h3><strong>System Stack</strong></h3>
-      </div>
+      <h3><strong>System Stack</strong></h3>
     </div>
   </div>
 
@@ -238,11 +235,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
+  <hr>
+
   <div class="row">
     <div class="col-md-12">
-      <div class="page-header">
-        <h3><strong>Open Source Community and Support</strong></h3>
-      </div>
+      <h3><strong>Open Source Community and Support</strong></h3>
     </div>
   </div>
 
@@ -264,11 +261,11 @@ val plan = new ScalaPlan(Seq(output))
     </div>
   </div>
 
+  <hr>
+
   <div class="row">
     <div class="col-md-12">
-      <div class="page-header">
-        <h3><strong>Next Steps</strong></h3>
-      </div>
+      <h3><strong>Next Steps</strong></h3>
       <p><a href="{{ site.baseurl }}/download">Download</a> and try Stratosphere. Our Quickstart scripts make it easy for developers to create an empty Stratosphere program skeleton to start from. Dependencies are seamlessly handled by Maven without any installation. Testing and debugging is possible directly inside the IDE with Stratosphere's embedded mode.
       Ready-made binaries for cluster setups are available as well.
       </p>

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ $( document ).ready(function() {
       <img src="{{ site.baseurl }}/img/Stratosphere_DAG.svg" onerror="this.onerror=null; this.src='{{ site.baseurl }}/img/Stratosphere_DAG.svg'" class="img-rounded img-responsive">
     </div>
     <div class="col-md-6">
-        <p>Stratosphere allows to model analysis programs as advanced data flow graphs. For many applications, this is a more natural fit than the constraint MapReduce interface (strictly Map followed by Reduce). Furthermore, data pipelining and in-memory data transfers increase performance by drastically reducing disk and network I/O.</p>
+        <p>Stratosphere allows to model analysis programs as advanced data flow graphs. For many applications, this is a more natural fit than the constrained MapReduce interface (strictly Map followed by Reduce). Furthermore, data pipelining and in-memory data transfers increase performance by drastically reducing disk and network I/O.</p>
         <a class="text-small" id="see-how-hadoop-link">See how Hadoop does complex data flows</a>
     </div>
   </div>


### PR DESCRIPTION
1. @cboden noticed a typo on the front page: **constrainT MapReduce interface** should be **constrainED MapReduce interface**.
2. I've also put more emphasis on the headlines, which makes it imho easier to navigate the page.
