### PR TITLE
Added cobertura Maven plugin for test coverage report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,18 @@
 					<argLine>-Xmx1024m</argLine>
 				</configuration>
 			</plugin>
-
+			
+			<!-- test coverage reports -->
+			<plugin>
+			        <groupId>org.codehaus.mojo</groupId>
+			        <artifactId>cobertura-maven-plugin</artifactId>
+			        <version>2.6</version>
+				<configuration>
+					<formats>
+						<format>html</format>
+					</formats>
+				</configuration>
+			</plugin>
 
 		</plugins>
 	</reporting>


### PR DESCRIPTION
Addresses issue #305.
The regular build process is not affect by this change.

Test coverage reports can be generated by calling 

```
mvn clean cobertura:cobertura
```

The HTML reports are generated for each Maven module individually and are put into ./target/site/cobertura.
