### PR TITLE
Remove unserializable fields in UserCodeObjectWrapper.java

### DIFF
--- a/nephele/nephele-hdfs/pom.xml
+++ b/nephele/nephele-hdfs/pom.xml
@@ -41,6 +41,12 @@
 				<dependency>
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-core</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>asm</groupId>
+                            <artifactId>asm</artifactId>
+                        </exclusion>
+                    </exclusions>
 				</dependency>
 			</dependencies>
 		</profile>

--- a/pact-scala/pact-scala-core/pom.xml
+++ b/pact-scala/pact-scala-core/pom.xml
@@ -36,6 +36,16 @@
 			<artifactId>scala-library</artifactId>
 			<version>2.10.3</version>
 		</dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>2.10.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>4.0</version>
+        </dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ClosureCleaner.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ClosureCleaner.scala
@@ -1,0 +1,215 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package eu.stratosphere.scala.operators
+
+import java.lang.reflect.Field
+
+import scala.collection.mutable.Map
+import scala.collection.mutable.Set
+
+import org.objectweb.asm.{ClassReader, ClassVisitor, MethodVisitor, Type}
+import org.objectweb.asm.Opcodes._
+import java.io._
+import java.lang.reflect.Modifier
+
+object ClosureCleaner {
+  // Get an ASM class reader for a given class from the JAR that loaded it
+  private def getClassReader(cls: Class[_]): ClassReader = {
+    // Copy data over, before delegating to ClassReader - else we can run out of open file handles.
+    val className = cls.getName.replaceFirst("^.*\\.", "") + ".class"
+    val resourceStream = cls.getResourceAsStream(className)
+    // todo: Fixme - continuing with earlier behavior ...
+    if (resourceStream == null) return new ClassReader(resourceStream)
+
+    val baos = new ByteArrayOutputStream(128)
+    copyStream(resourceStream, baos, true)
+    new ClassReader(new ByteArrayInputStream(baos.toByteArray))
+  }
+
+  // Check whether a class represents a Scala closure
+  private def isClosure(cls: Class[_]): Boolean = {
+    cls.getName.contains("$anonfun$")
+  }
+
+  // Get a list of the classes of the outer objects of a given closure object, obj;
+  // the outer objects are defined as any closures that obj is nested within, plus
+  // possibly the class that the outermost closure is in, if any. We stop searching
+  // for outer objects beyond that because cloning the user's object is probably
+  // not a good idea (whereas we can clone closure objects just fine since we
+  // understand how all their fields are used).
+  private def getOuterClasses(obj: AnyRef): List[Class[_]] = {
+    for (f <- obj.getClass.getDeclaredFields if f.getName == "$outer") {
+      f.setAccessible(true)
+      if (isClosure(f.getType)) {
+        return f.getType :: getOuterClasses(f.get(obj))
+      } else {
+        return f.getType :: Nil // Stop at the first $outer that is not a closure
+      }
+    }
+    return Nil
+  }
+
+  // Get a list of the outer objects for a given closure object.
+  private def getOuterObjects(obj: AnyRef): List[AnyRef] = {
+    for (f <- obj.getClass.getDeclaredFields if f.getName == "$outer") {
+      f.setAccessible(true)
+      if (isClosure(f.getType)) {
+        return f.get(obj) :: getOuterObjects(f.get(obj))
+      } else {
+        return f.get(obj) :: Nil // Stop at the first $outer that is not a closure
+      }
+    }
+    return Nil
+  }
+
+  private def getInnerClasses(obj: AnyRef): List[Class[_]] = {
+    val seen = Set[Class[_]](obj.getClass)
+    var stack = List[Class[_]](obj.getClass)
+    while (!stack.isEmpty) {
+      val cr = getClassReader(stack.head)
+      stack = stack.tail
+      val set = Set[Class[_]]()
+      cr.accept(new InnerClosureFinder(set), 0)
+      for (cls <- set -- seen) {
+        seen += cls
+        stack = cls :: stack
+      }
+    }
+    return (seen - obj.getClass).toList
+  }
+
+  private def createNullValue(cls: Class[_]): AnyRef = {
+    if (cls.isPrimitive) {
+      new java.lang.Byte(0: Byte) // Should be convertible to any primitive type
+    } else {
+      null
+    }
+  }
+
+  def clean[F <: AnyRef](func: F): F = {
+    // TODO: cache outerClasses / innerClasses / accessedFields
+    val outerClasses = getOuterClasses(func)
+    val innerClasses = getInnerClasses(func)
+    val outerObjects = getOuterObjects(func)
+    val accessedFields = Map[Class[_], Set[String]]()
+    for (cls <- func.getClass :: outerClasses)
+      accessedFields(cls) = Set[String]()
+    for (cls <- func.getClass :: innerClasses)
+      getClassReader(cls).accept(new FieldAccessFinder(accessedFields), 0)
+
+    // Nullify all the fields that are not used, keep $outer, though.
+    // Also, do not mess with the first outer that is not a closure, this
+    // is mostly the outer class/object of the user.
+    var outer: AnyRef = func
+    while (outer != null && isClosure(outer.getClass)) {
+      //      outer = instantiateClass(cls, outer, inInterpreter)
+      val cls = outer.getClass
+      val newOuter = cls.getDeclaredFields.toList.find( _.getName == "$outer")
+        .map { f => f.setAccessible(true); if (f.get(outer) != null) f.get(outer) else null }
+        .getOrElse(null)
+
+      for (field <- cls.getDeclaredFields if !accessedFields(cls).contains(field.getName) &&
+        !Modifier.isStatic(field.getModifiers) && field.getName != "$outer") {
+        field.setAccessible(true)
+        if (field.get(outer) != null) {
+          field.set(outer, null)
+        }
+      }
+//      // when newOuter is the first non-closure, remove the outer pointer,
+//      // this would mostly be the outer user code object/class
+//      if (newOuter != null && !isClosure(newOuter.getClass)) {
+//        for (field <- cls.getDeclaredFields if !accessedFields(cls).contains(field.getName) &&
+//          !Modifier.isStatic(field.getModifiers)) {
+//          field.setAccessible(true)
+//          if (field.get(outer) != null) {
+//            field.set(outer, null)
+//          }
+//        }
+//      }
+      outer = newOuter
+    }
+    func
+  }
+
+  /** Copy all data from an InputStream to an OutputStream */
+  def copyStream(in: InputStream,
+                 out: OutputStream,
+                 closeStreams: Boolean = false)
+  {
+    val buf = new Array[Byte](8192)
+    var n = 0
+    while (n != -1) {
+      n = in.read(buf)
+      if (n != -1) {
+        out.write(buf, 0, n)
+      }
+    }
+    if (closeStreams) {
+      in.close()
+      out.close()
+    }
+  }
+}
+
+class FieldAccessFinder(output: Map[Class[_], Set[String]]) extends ClassVisitor(ASM4) {
+  override def visitMethod(access: Int, name: String, desc: String,
+                           sig: String, exceptions: Array[String]): MethodVisitor = {
+    return new MethodVisitor(ASM4) {
+      override def visitFieldInsn(op: Int, owner: String, name: String, desc: String) {
+        if (op == GETFIELD) {
+          for (cl <- output.keys if cl.getName == owner.replace('/', '.')) {
+            output(cl) += name
+          }
+        }
+      }
+
+      override def visitMethodInsn(op: Int, owner: String, name: String,
+                                   desc: String) {
+        // Check for calls a getter method for a variable in an interpreter wrapper object.
+        // This means that the corresponding field will be accessed, so we should save it.
+        if (op == INVOKEVIRTUAL && owner.endsWith("$iwC") && !name.endsWith("$outer")) {
+          for (cl <- output.keys if cl.getName == owner.replace('/', '.')) {
+            output(cl) += name
+          }
+        }
+      }
+    }
+  }
+}
+
+class InnerClosureFinder(output: Set[Class[_]]) extends ClassVisitor(ASM4) {
+  var myName: String = null
+
+  override def visit(version: Int, access: Int, name: String, sig: String,
+                     superName: String, interfaces: Array[String]) {
+    myName = name
+  }
+
+  override def visitMethod(access: Int, name: String, desc: String,
+                           sig: String, exceptions: Array[String]): MethodVisitor = {
+    return new MethodVisitor(ASM4) {
+      override def visitMethodInsn(op: Int, owner: String, name: String,
+                                   desc: String) {
+        val argTypes = Type.getArgumentTypes(desc)
+        if (op == INVOKESPECIAL && name == "<init>" && argTypes.length > 0
+          && argTypes(0).toString.startsWith("L") // is it an object?
+          && argTypes(0).getInternalName == myName)
+          output += Class.forName(
+            owner.replace('/', '.'),
+            false,
+            Thread.currentThread.getContextClassLoader)
+      }
+    }
+  }
+}
+

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CoGroupOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CoGroupOperator.scala
@@ -120,12 +120,14 @@ object CoGroupMacros {
       }
     }
     val contract = reify {
-      val generatedStub = stub.splice
       val helper: CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val leftKeySelector = new FieldSelector(generatedStub.leftInputUDT, helper.leftKeySelection)
       val rightKeySelector = new FieldSelector(generatedStub.rightInputUDT, helper.rightKeySelection)
 
-      val builder = new NoKeyCoGroupBuilder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val builder = new NoKeyCoGroupBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
       val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
@@ -189,12 +191,14 @@ object CoGroupMacros {
       }
     }
     val contract = reify {
-      val generatedStub = stub.splice
       val helper: CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val leftKeySelector = new FieldSelector(generatedStub.leftInputUDT, helper.leftKeySelection)
       val rightKeySelector = new FieldSelector(generatedStub.rightInputUDT, helper.rightKeySelection)
 
-      val builder = new NoKeyCoGroupBuilder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val builder = new NoKeyCoGroupBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
       val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
@@ -79,8 +79,10 @@ object CrossMacros {
     }
     val contract = reify {
       val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
-      val generatedStub = stub.splice
-      val builder = CrossContract.builder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
+      val builder = CrossContract.builder(generatedStub).input1(leftInput).input2(rightInput)
       
       val ret = new CrossContract(builder) with TwoInputScalaContract[LeftIn, RightIn, Out] {
         override def getUDF = generatedStub.udf
@@ -139,8 +141,10 @@ object CrossMacros {
     }
     val contract = reify {
       val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
-      val generatedStub = stub.splice
-      val builder = CrossContract.builder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
+      val builder = CrossContract.builder(generatedStub).input1(leftInput).input2(rightInput)
       
       val ret = new CrossContract(builder) with TwoInputScalaContract[LeftIn, RightIn, Out] {
         override def getUDF = generatedStub.udf
@@ -186,8 +190,10 @@ object CrossMacros {
     }
     val contract = reify {
       val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
-      val generatedStub = stub.splice
-      val builder = CrossContract.builder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
+      val builder = CrossContract.builder(generatedStub).input1(leftInput).input2(rightInput)
       
       val ret = new CrossContract(builder) with TwoInputScalaContract[LeftIn, RightIn, (LeftIn, RightIn)] {
         override def getUDF = generatedStub.udf

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/DataSourceMacros.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/DataSourceMacros.scala
@@ -142,7 +142,7 @@ object SequentialInputFormat {
         }
         
         val udt: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
-        lazy val udf: UDF0[Out] = new UDF0(udt)
+        val udf: UDF0[Out] = new UDF0(udt)
         override def getUDF = udf
       }
       
@@ -274,7 +274,7 @@ object CsvInputFormat {
       new JavaRecordInputFormat with ScalaInputFormat[Out] {
         
         val udt: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
-        lazy val udf: UDF0[Out] = new UDF0(udt)
+        val udf: UDF0[Out] = new UDF0(udt)
         override def getUDF = udf
         
         setDelimiter((recordDelim.splice.getOrElse("\n")))
@@ -346,7 +346,7 @@ object TextInputFormat {
         config.setInteger(JavaTextInputFormat.FIELD_POS, getUDF.outputFields(0).globalPos.getValue)
       }
      // override val udt: UDT[String] = UDT.StringUDT
-      lazy val udf: UDF0[String] = new UDF0(UDT.StringUDT)
+      val udf: UDF0[String] = new UDF0(UDT.StringUDT)
       override def getUDF = udf
     }
   }

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/JoinOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/JoinOperator.scala
@@ -115,12 +115,14 @@ object JoinMacros {
       }
     }
     val contract = reify {
-      val generatedStub = stub.splice
       val helper: JoinDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val leftKeySelector = new FieldSelector(generatedStub.leftInputUDT, helper.leftKey)
       val rightKeySelector = new FieldSelector(generatedStub.rightInputUDT, helper.rightKey)
 
-      val builder = new NoKeyMatchBuilder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val builder = new NoKeyMatchBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
       val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
@@ -188,11 +190,13 @@ object JoinMacros {
       }
     }
     val contract = reify {
-      val generatedStub = stub.splice
       val helper: JoinDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val leftKeySelector = new FieldSelector(generatedStub.leftInputUDT, helper.leftKey)
       val rightKeySelector = new FieldSelector(generatedStub.rightInputUDT, helper.rightKey)
-      val builder = new NoKeyMatchBuilder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val builder = new NoKeyMatchBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
       val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
@@ -248,11 +252,13 @@ object JoinMacros {
       }
     }
     val contract = reify {
-      val generatedStub = stub.splice
       val helper: JoinDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
+      val leftInput = helper.leftInput.contract
+      val rightInput = helper.rightInput.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val leftKeySelector = new FieldSelector(generatedStub.leftInputUDT, helper.leftKey)
       val rightKeySelector = new FieldSelector(generatedStub.rightInputUDT, helper.rightKey)
-      val builder = new NoKeyMatchBuilder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
+      val builder = new NoKeyMatchBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
       val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/MapOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/MapOperator.scala
@@ -46,6 +46,8 @@ object MapMacros {
       implicit val inputUDT: UDT[In] = c.Expr[UDT[In]](createUdtIn).splice
       implicit val outputUDT: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
       new MapStubBase[In, Out] {
+//        val userFun = ClosureCleaner.clean(fun.splice)
+//        val userFun = fun.splice
         override def map(record: PactRecord, out: Collector[PactRecord]) = {
           val input = deserializer.deserializeRecyclingOn(record)
           val output = fun.splice.apply(input)
@@ -60,9 +62,11 @@ object MapMacros {
         }
       }
     }
+
     val contract = reify {
-      val generatedStub = stub.splice
-      val builder = MapContract.builder(generatedStub).input((c.prefix.splice).contract)
+      val input = c.prefix.splice.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
+      val builder = MapContract.builder(generatedStub).input(input)
       
       val contract = new MapContract(builder) with OneInputScalaContract[In, Out] {
         override def getUDF = generatedStub.udf
@@ -117,8 +121,9 @@ object MapMacros {
       }
     }
     val contract = reify {
-      val generatedStub = stub.splice
-      val builder = MapContract.builder(generatedStub).input((c.prefix.splice).contract)
+      val input = c.prefix.splice.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
+      val builder = MapContract.builder(generatedStub).input(input)
       
       val contract = new MapContract(builder) with OneInputScalaContract[In, Out] {
         override def getUDF = generatedStub.udf
@@ -159,8 +164,9 @@ object MapMacros {
       }
     }
     val contract = reify {
-      val generatedStub = stub.splice
-      val builder = MapContract.builder(generatedStub).input((c.prefix.splice).contract)
+      val input = c.prefix.splice.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
+      val builder = MapContract.builder(generatedStub).input(input)
       
       val contract = new MapContract(builder) with OneInputScalaContract[In, In] {
         override def getUDF = generatedStub.udf

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
@@ -135,11 +135,12 @@ object ReduceMacros {
     }
     val contract = reify {
       val helper = groupedInput.splice
-      val generatedStub = stub.splice
+      val input = helper.input.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val keySelection = helper.keySelection
       val keySelector = new FieldSelector(generatedStub.inputUDT, keySelection)
 
-      val builder = ReduceContract.builder(generatedStub).input(helper.input.contract)
+      val builder = ReduceContract.builder(generatedStub).input(input)
 
       val keyPositions = keySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.inputUDT.getKeySet(keyPositions)
@@ -192,10 +193,11 @@ object ReduceMacros {
     }
     val contract = reify {
       val helper = groupedInput.splice
-      val generatedStub = stub.splice
+      val input = helper.input.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val keySelection = helper.keySelection
       val keySelector = new FieldSelector(generatedStub.inputUDT, keySelection)
-      val builder = ReduceContract.builder(generatedStub).input(helper.input.contract)
+      val builder = ReduceContract.builder(generatedStub).input(input)
 
       val keyPositions = keySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.inputUDT.getKeySet(keyPositions)
@@ -250,10 +252,11 @@ object ReduceMacros {
     }
     val contract = reify {
       val helper = groupedInput.splice
-      val generatedStub = stub.splice
+      val input = helper.input.contract
+      val generatedStub = ClosureCleaner.clean(stub.splice)
       val keySelection = helper.keySelection
       val keySelector = new FieldSelector(generatedStub.inputUDT, keySelection)
-      val builder = ReduceContract.builder(generatedStub).input(helper.input.contract)
+      val builder = ReduceContract.builder(generatedStub).input(input)
 
       val keyPositions = keySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.inputUDT.getKeySet(keyPositions)

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/datamining/KMeans.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/datamining/KMeans.scala
@@ -35,7 +35,7 @@ object RunKMeans {
 
 class KMeans extends PlanAssembler with PlanAssemblerDescription with Serializable {
   override def getDescription() = {
-    "Parameters: [numSubStasks] [dataPoints] [clusterCenters] [output] [numIterations]"
+    "Parameters: [numSubStasksS] [dataPoints] [clusterCenters] [output] [numIterations]"
   }
   override def getPlan(args: String*) = {
     getScalaPlan(args(0).toInt, args(1), args(2), args(3), args(4).toInt)
@@ -89,32 +89,30 @@ class KMeans extends PlanAssembler with PlanAssemblerDescription with Serializab
     val dataPoints = DataSource(dataPointInput, DelimitedInputFormat(parseInput))
     val clusterPoints = DataSource(clusterInput, DelimitedInputFormat(parseInput))
 
-    def computeNewCenters(centers: DataSet[(Int, Point)]) = {
+    val finalCenters = clusterPoints.iterate(numIterations, { centers: DataSet[(Int, Point)] =>
 
       val distances = dataPoints cross centers map computeDistance
       val nearestCenters = distances groupBy { case (pid, _) => pid } reduceGroup { ds => ds.minBy(_._2.distance) } map asPointSum.tupled
       val newCenters = nearestCenters groupBy { case (cid, _) => cid } reduceGroup sumPointSums map { case (cid, pSum) => cid -> pSum.toPoint() }
 
-//      distances.left neglects { case (pid, _) => pid }
-//      distances.left preserves({ dp => dp }, { case (pid, dist) => (pid, dist.dataPoint) })
-//      distances.right neglects { case (cid, _) => cid }
-//      distances.right preserves({ case (cid, _) => cid }, { case (_, dist) => dist.clusterId })
-//
-//      nearestCenters neglects { case (pid, _) => pid }
-//
-//      newCenters neglects { case (cid, _) => cid }
-//      newCenters.preserves({ case (cid, _) => cid }, { case (cid, _) => cid })
-//
-//      distances.avgBytesPerRecord(48)
-//      nearestCenters.avgBytesPerRecord(40)
-//      newCenters.avgBytesPerRecord(36)
-      
-//      val diff = centers join newCenters where { _._1 } isEqualTo { _._1 } map { (c1, c2) => c1._2.computeEuclidianDistance(c2._2) }
+      //      distances.left neglects { case (pid, _) => pid }
+      //      distances.left preserves({ dp => dp }, { case (pid, dist) => (pid, dist.dataPoint) })
+      //      distances.right neglects { case (cid, _) => cid }
+      //      distances.right preserves({ case (cid, _) => cid }, { case (_, dist) => dist.clusterId })
+      //
+      //      nearestCenters neglects { case (pid, _) => pid }
+      //
+      //      newCenters neglects { case (cid, _) => cid }
+      //      newCenters.preserves({ case (cid, _) => cid }, { case (cid, _) => cid })
+      //
+      //      distances.avgBytesPerRecord(48)
+      //      nearestCenters.avgBytesPerRecord(40)
+      //      newCenters.avgBytesPerRecord(36)
+
+      //      val diff = centers join newCenters where { _._1 } isEqualTo { _._1 } map { (c1, c2) => c1._2.computeEuclidianDistance(c2._2) }
 
       newCenters
-    }
-
-    val finalCenters = clusterPoints.iterate(numIterations, computeNewCenters)
+    })
 
     val output = finalCenters.write(clusterOutput, DelimitedOutputFormat(formatOutput.tupled))
 

--- a/stratosphere-addons/pact-hbase/pom.xml
+++ b/stratosphere-addons/pact-hbase/pom.xml
@@ -55,6 +55,12 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
 			<version>${hadoop.version}</version>
+			<exclusions>
+                <exclusion>
+                <groupId>asm</groupId>
+                <artifactId>asm</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 	</dependencies>
 		<!-- <dependency>


### PR DESCRIPTION
Completely change this. Add new ClosureCleaner that is based on the spark ClosureCleaner but does things a bit differently.

This one now checks whether fields it removes are actually accessed. In UserCodeObjectWrapper now throw an exception if the user code object contains non-serializable fields.

Does someone know what to do about the code-copying? Because I took this from spark.
