### PR TITLE
Rich scala stubs

### DIFF
--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSource.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/DataSource.scala
@@ -14,7 +14,7 @@
 package eu.stratosphere.scala
 import java.net.URI
 import eu.stratosphere.scala.analysis._
-import eu.stratosphere.scala.operators.stubs._
+import eu.stratosphere.scala.stubs._
 import eu.stratosphere.pact.common.`type`.base._
 import eu.stratosphere.pact.common.`type`.base.parser._
 import eu.stratosphere.pact.generic.io.InputFormat

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CoGroupOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CoGroupOperator.scala
@@ -15,36 +15,23 @@ package eu.stratosphere.scala.operators
 
 import language.experimental.macros
 import scala.reflect.macros.Context
-import eu.stratosphere.scala.codegen.MacroContextHolder
-import eu.stratosphere.scala.ScalaContract
-import eu.stratosphere.pact.common.contract.MapContract
-import eu.stratosphere.scala.analysis.UDT
+
 import eu.stratosphere.pact.common.`type`.PactRecord
-import eu.stratosphere.pact.common.stubs.MapStub
 import eu.stratosphere.pact.common.stubs.Collector
 import eu.stratosphere.pact.generic.contract.Contract
-import eu.stratosphere.scala.contracts.Annotations
-import eu.stratosphere.pact.common.contract.ReduceContract
-import eu.stratosphere.pact.common.stubs.ReduceStub
-import eu.stratosphere.scala.analysis.UDTSerializer
-import eu.stratosphere.scala.analysis.UDF1
-import eu.stratosphere.scala.operators.stubs.DeserializingIterator
-import eu.stratosphere.nephele.configuration.Configuration
-import java.util.{ Iterator => JIterator }
-import eu.stratosphere.scala.analysis.FieldSelector
-import eu.stratosphere.scala.OneInputKeyedScalaContract
-import eu.stratosphere.pact.common.contract.CrossContract
-import eu.stratosphere.scala.TwoInputScalaContract
-import eu.stratosphere.scala.analysis.UDF2
-import eu.stratosphere.pact.common.stubs.CrossStub
-import eu.stratosphere.scala.TwoInputKeyedScalaContract
-import eu.stratosphere.pact.common.stubs.MatchStub
 import eu.stratosphere.pact.common.contract.CoGroupContract
 import eu.stratosphere.pact.common.stubs.CoGroupStub
-import eu.stratosphere.scala.DataSet
 import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper
-import eu.stratosphere.scala.TwoInputHintable
-import eu.stratosphere.scala.codegen.Util
+
+import eu.stratosphere.nephele.configuration.Configuration
+
+import java.util.{ Iterator => JIterator }
+
+import eu.stratosphere.scala.codegen.{MacroContextHolder, Util}
+import eu.stratosphere.scala._
+import eu.stratosphere.scala.analysis._
+import eu.stratosphere.scala.contracts.Annotations
+import eu.stratosphere.scala.stubs.DeserializingIterator
 
 class CoGroupDataSet[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInput: DataSet[RightIn]) {
   def where[Key](keyFun: LeftIn => Key): CoGroupDataSetWithWhere[LeftIn, RightIn, Key] = macro CoGroupMacros.whereImpl[LeftIn, RightIn, Key]

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CoGroupOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CoGroupOperator.scala
@@ -20,7 +20,7 @@ import eu.stratosphere.pact.common.`type`.PactRecord
 import eu.stratosphere.pact.common.stubs.Collector
 import eu.stratosphere.pact.generic.contract.Contract
 import eu.stratosphere.pact.common.contract.CoGroupContract
-import eu.stratosphere.pact.common.stubs.CoGroupStub
+import eu.stratosphere.pact.common.stubs.{CoGroupStub => JCoGroupStub}
 import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper
 
 import eu.stratosphere.nephele.configuration.Configuration
@@ -32,6 +32,7 @@ import eu.stratosphere.scala._
 import eu.stratosphere.scala.analysis._
 import eu.stratosphere.scala.contracts.Annotations
 import eu.stratosphere.scala.stubs.DeserializingIterator
+import eu.stratosphere.scala.stubs.{CoGroupStubBase, CoGroupStub, FlatCoGroupStub}
 
 class CoGroupDataSet[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInput: DataSet[RightIn]) {
   def where[Key](keyFun: LeftIn => Key): CoGroupDataSetWithWhere[LeftIn, RightIn, Key] = macro CoGroupMacros.whereImpl[LeftIn, RightIn, Key]
@@ -46,11 +47,12 @@ class CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn](val leftKeySelection: Lis
   def flatMap[Out](fun: (Iterator[LeftIn], Iterator[RightIn]) => Iterator[Out]): DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out] = macro CoGroupMacros.flatMap[LeftIn, RightIn, Out]
 }
 
-class NoKeyCoGroupBuilder(s: CoGroupStub) extends CoGroupContract.Builder(new UserCodeObjectWrapper(s))
+class NoKeyCoGroupBuilder(s: JCoGroupStub) extends CoGroupContract.Builder(new UserCodeObjectWrapper(s))
 
 object CoGroupMacros {
   
-  def whereImpl[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Key: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSet[LeftIn, RightIn] })(keyFun: c.Expr[LeftIn => Key]): c.Expr[CoGroupDataSetWithWhere[LeftIn, RightIn, Key]] = {
+  def whereImpl[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Key: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSet[LeftIn, RightIn] })
+                                                                                  (keyFun: c.Expr[LeftIn => Key]): c.Expr[CoGroupDataSetWithWhere[LeftIn, RightIn, Key]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -65,7 +67,8 @@ object CoGroupMacros {
     return helper
   }
   
-  def isEqualToImpl[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Key: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSetWithWhere[LeftIn, RightIn, Key] })(keyFun: c.Expr[RightIn => Key]): c.Expr[CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn]] = {
+  def isEqualToImpl[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Key: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSetWithWhere[LeftIn, RightIn, Key] })
+                                                                                      (keyFun: c.Expr[RightIn => Key]): c.Expr[CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -80,7 +83,8 @@ object CoGroupMacros {
     return helper
   }
 
-  def map[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] })(fun: c.Expr[(Iterator[LeftIn], Iterator[RightIn]) => Out]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
+  def map[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] })
+                                                                            (fun: c.Expr[(Iterator[LeftIn], Iterator[RightIn]) => Out]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -88,49 +92,19 @@ object CoGroupMacros {
     val (udtLeftIn, createUdtLeftIn) = slave.mkUdtClass[LeftIn]
     val (udtRightIn, createUdtRightIn) = slave.mkUdtClass[RightIn]
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
-    
-    val contract = reify {
-      val helper: CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
-      val leftKeySelection = helper.leftKeySelection
-      val rightKeySelection = helper.rightKeySelection
 
-      val generatedStub = new CoGroupStub with Serializable {
-        val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
-        val rightInputUDT = c.Expr[UDT[RightIn]](createUdtRightIn).splice
-        val outputUDT = c.Expr[UDT[Out]](createUdtOut).splice
-        val leftKeySelector = new FieldSelector(leftInputUDT, leftKeySelection)
-        val rightKeySelector = new FieldSelector(rightInputUDT, rightKeySelection)
-        val udf: UDF2[LeftIn, RightIn, Out] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
-        
-        private val outputRecord = new PactRecord()
-
-        private var leftIterator: DeserializingIterator[LeftIn] = _
-        private var leftForwardFrom: Array[Int] = _
-        private var leftForwardTo: Array[Int] = _
-        private var rightIterator: DeserializingIterator[RightIn] = _
-        private var rightForwardFrom: Array[Int] = _
-        private var rightForwardTo: Array[Int] = _
-        private var serializer: UDTSerializer[Out] = _
-
-        override def open(config: Configuration) = {
-          super.open(config)
-
-          this.outputRecord.setNumFields(udf.getOutputLength)
-
-          this.leftIterator = new DeserializingIterator(udf.getLeftInputDeserializer)
-          this.leftForwardFrom = udf.getLeftForwardIndexArrayFrom
-          this.leftForwardTo = udf.getLeftForwardIndexArrayTo
-          this.rightIterator = new DeserializingIterator(udf.getRightInputDeserializer)
-          this.rightForwardFrom = udf.getRightForwardIndexArrayFrom
-          this.rightForwardTo = udf.getRightForwardIndexArrayTo
-          this.serializer = udf.getOutputSerializer
-        }
-
+    val stub: c.Expr[CoGroupStubBase[LeftIn, RightIn, Out]] = if (fun.actualType <:< weakTypeOf[CoGroupStub[LeftIn, RightIn, Out]])
+      reify { fun.splice.asInstanceOf[CoGroupStubBase[LeftIn, RightIn, Out]] }
+    else reify {
+      implicit val leftInputUDT: UDT[LeftIn] = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
+      implicit val rightInputUDT: UDT[RightIn] = c.Expr[UDT[RightIn]](createUdtRightIn).splice
+      implicit val outputUDT: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
+      new CoGroupStubBase[LeftIn, RightIn, Out] {
         override def coGroup(leftRecords: JIterator[PactRecord], rightRecords: JIterator[PactRecord], out: Collector[PactRecord]) = {
 
           val firstLeftRecord = leftIterator.initialize(leftRecords)
           val firstRightRecord = rightIterator.initialize(rightRecords)
-          
+
           if (firstRightRecord != null) {
             outputRecord.copyFrom(firstRightRecord, rightForwardFrom, rightForwardTo)
           }
@@ -144,19 +118,25 @@ object CoGroupMacros {
           out.collect(outputRecord)
         }
       }
-      
+    }
+    val contract = reify {
+      val generatedStub = stub.splice
+      val helper: CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
+      val leftKeySelector = new FieldSelector(generatedStub.leftInputUDT, helper.leftKeySelection)
+      val rightKeySelector = new FieldSelector(generatedStub.rightInputUDT, helper.rightKeySelection)
+
       val builder = new NoKeyCoGroupBuilder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
 
-      val leftKeyPositions = generatedStub.leftKeySelector.selectedFields.toIndexArray
-      val rightKeyPositions = generatedStub.leftKeySelector.selectedFields.toIndexArray
+      val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
+      val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.leftInputUDT.getKeySet(leftKeyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), leftKeyPositions(i), rightKeyPositions(i)) }
       
       
       val ret = new CoGroupContract(builder) with TwoInputKeyedScalaContract[LeftIn, RightIn, Out] {
-        override val leftKey: FieldSelector = generatedStub.leftKeySelector
-        override val rightKey: FieldSelector = generatedStub.rightKeySelector
+        override val leftKey: FieldSelector = leftKeySelector
+        override val rightKey: FieldSelector = rightKeySelector
         override def getUDF = generatedStub.udf
         override def annotations = Seq(
           Annotations.getConstantFieldsFirst(
@@ -172,7 +152,8 @@ object CoGroupMacros {
     return result
   }
   
-  def flatMap[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] })(fun: c.Expr[(Iterator[LeftIn], Iterator[RightIn]) => Iterator[Out]]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
+  def flatMap[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] })
+                                                                                (fun: c.Expr[(Iterator[LeftIn], Iterator[RightIn]) => Iterator[Out]]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
      import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -180,46 +161,15 @@ object CoGroupMacros {
     val (udtLeftIn, createUdtLeftIn) = slave.mkUdtClass[LeftIn]
     val (udtRightIn, createUdtRightIn) = slave.mkUdtClass[RightIn]
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
-    
-    val contract = reify {
-      val helper: CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
-      val leftKeySelection = helper.leftKeySelection
-      val rightKeySelection = helper.rightKeySelection
 
-      val generatedStub = new CoGroupStub with Serializable {
-        val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
-        val rightInputUDT = c.Expr[UDT[RightIn]](createUdtRightIn).splice
-        val outputUDT = c.Expr[UDT[Out]](createUdtOut).splice
-        val leftKeySelector = new FieldSelector(leftInputUDT, leftKeySelection)
-        val rightKeySelector = new FieldSelector(rightInputUDT, rightKeySelection)
-        val udf: UDF2[LeftIn, RightIn, Out] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
-        
-        private val outputRecord = new PactRecord()
-
-        private var leftIterator: DeserializingIterator[LeftIn] = _
-        private var leftForwardFrom: Array[Int] = _
-        private var leftForwardTo: Array[Int] = _
-        private var rightIterator: DeserializingIterator[RightIn] = _
-        private var rightForwardFrom: Array[Int] = _
-        private var rightForwardTo: Array[Int] = _
-        private var serializer: UDTSerializer[Out] = _
-
-        override def open(config: Configuration) = {
-          super.open(config)
-
-          this.outputRecord.setNumFields(udf.getOutputLength)
-
-          this.leftIterator = new DeserializingIterator(udf.getLeftInputDeserializer)
-          this.leftForwardFrom = udf.getLeftForwardIndexArrayFrom
-          this.leftForwardTo = udf.getLeftForwardIndexArrayTo
-          this.rightIterator = new DeserializingIterator(udf.getRightInputDeserializer)
-          this.rightForwardFrom = udf.getRightForwardIndexArrayFrom
-          this.rightForwardTo = udf.getRightForwardIndexArrayTo
-          this.serializer = udf.getOutputSerializer
-        }
-
+    val stub: c.Expr[CoGroupStubBase[LeftIn, RightIn, Out]] = if (fun.actualType <:< weakTypeOf[CoGroupStub[LeftIn, RightIn, Out]])
+      reify { fun.splice.asInstanceOf[CoGroupStubBase[LeftIn, RightIn, Out]] }
+    else reify {
+      implicit val leftInputUDT: UDT[LeftIn] = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
+      implicit val rightInputUDT: UDT[RightIn] = c.Expr[UDT[RightIn]](createUdtRightIn).splice
+      implicit val outputUDT: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
+      new CoGroupStubBase[LeftIn, RightIn, Out] {
         override def coGroup(leftRecords: JIterator[PactRecord], rightRecords: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
           val firstLeftRecord = leftIterator.initialize(leftRecords)
           outputRecord.copyFrom(firstLeftRecord, leftForwardFrom, leftForwardTo)
 
@@ -237,19 +187,25 @@ object CoGroupMacros {
           }
         }
       }
-      
+    }
+    val contract = reify {
+      val generatedStub = stub.splice
+      val helper: CoGroupDataSetWithWhereAndEqual[LeftIn, RightIn] = c.prefix.splice
+      val leftKeySelector = new FieldSelector(generatedStub.leftInputUDT, helper.leftKeySelection)
+      val rightKeySelector = new FieldSelector(generatedStub.rightInputUDT, helper.rightKeySelection)
+
       val builder = new NoKeyCoGroupBuilder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
 
-      val leftKeyPositions = generatedStub.leftKeySelector.selectedFields.toIndexArray
-      val rightKeyPositions = generatedStub.leftKeySelector.selectedFields.toIndexArray
+      val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
+      val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.leftInputUDT.getKeySet(leftKeyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), leftKeyPositions(i), rightKeyPositions(i)) }
       
       
       val ret = new CoGroupContract(builder) with TwoInputKeyedScalaContract[LeftIn, RightIn, Out] {
-        override val leftKey: FieldSelector = generatedStub.leftKeySelector
-        override val rightKey: FieldSelector = generatedStub.rightKeySelector
+        override val leftKey: FieldSelector = leftKeySelector
+        override val rightKey: FieldSelector = rightKeySelector
         override def getUDF = generatedStub.udf
         override def annotations = Seq(
           Annotations.getConstantFieldsFirst(

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
@@ -36,10 +36,10 @@ import eu.stratosphere.scala.analysis.FieldSelector
 import eu.stratosphere.pact.common.contract.CrossContract
 import eu.stratosphere.scala.TwoInputScalaContract
 import eu.stratosphere.scala.analysis.UDF2
-import eu.stratosphere.pact.common.stubs.CrossStub
 import eu.stratosphere.scala.DataSet
 import eu.stratosphere.scala.TwoInputHintable
 import eu.stratosphere.scala.codegen.Util
+import eu.stratosphere.scala.stubs.{CrossStubBase, CrossStub, FlatCrossStub}
 
 class CrossDataSet[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInput: DataSet[RightIn]) {
   def map[Out](fun: (LeftIn, RightIn) => Out): DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out] = macro CrossMacros.map[LeftIn, RightIn, Out]
@@ -49,7 +49,8 @@ class CrossDataSet[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInp
 
 object CrossMacros {
 
-  def map[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CrossDataSet[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Out]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
+  def map[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag, Out: c.WeakTypeTag](c: Context { type PrefixType = CrossDataSet[LeftIn, RightIn] })
+                                                                            (fun: c.Expr[(LeftIn, RightIn) => Out]): c.Expr[DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -57,42 +58,15 @@ object CrossMacros {
     val (udtLeftIn, createUdtLeftIn) = slave.mkUdtClass[LeftIn]
     val (udtRightIn, createUdtRightIn) = slave.mkUdtClass[RightIn]
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
-    
-    val contract = reify {
-      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
 
-      val generatedStub = new CrossStub with Serializable {
-        val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
-        val rightInputUDT = c.Expr[UDT[RightIn]](createUdtRightIn).splice
-        val outputUDT = c.Expr[UDT[Out]](createUdtOut).splice
-        val udf: UDF2[LeftIn, RightIn, Out] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
-
-        private var leftDeserializer: UDTSerializer[LeftIn] = _
-        private var leftForwardFrom: Array[Int] = _
-        private var leftForwardTo: Array[Int] = _
-        private var leftDiscard: Array[Int] = _
-        private var rightDeserializer: UDTSerializer[RightIn] = _
-        private var rightForwardFrom: Array[Int] = _
-        private var rightForwardTo: Array[Int] = _
-        private var serializer: UDTSerializer[Out] = _
-        private var outputLength: Int = _
-
-        override def open(config: Configuration) = {
-          super.open(config)
-
-          this.leftDeserializer = udf.getLeftInputDeserializer
-          this.leftDiscard = udf.getLeftDiscardIndexArray.filter(_ < udf.getOutputLength)
-          this.leftForwardFrom = udf.getLeftForwardIndexArrayFrom
-          this.leftForwardTo = udf.getLeftForwardIndexArrayTo
-          this.rightDeserializer = udf.getRightInputDeserializer
-          this.rightForwardFrom = udf.getRightForwardIndexArrayFrom
-          this.rightForwardTo = udf.getRightForwardIndexArrayTo
-          this.serializer = udf.getOutputSerializer
-          this.outputLength = udf.getOutputLength
-        }
-        
+    val stub: c.Expr[CrossStubBase[LeftIn, RightIn, Out]] = if (fun.actualType <:< weakTypeOf[CrossStub[LeftIn, RightIn, Out]])
+      reify { fun.splice.asInstanceOf[CrossStubBase[LeftIn, RightIn, Out]] }
+    else reify {
+      implicit val leftInputUDT: UDT[LeftIn] = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
+      implicit val rightInputUDT: UDT[RightIn] = c.Expr[UDT[RightIn]](createUdtRightIn).splice
+      implicit val outputUDT: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
+      new CrossStubBase[LeftIn, RightIn, Out] {
         override def cross(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
-
           val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
           val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
           val output = fun.splice.apply(left, right)
@@ -108,9 +82,11 @@ object CrossMacros {
           serializer.serialize(output, leftRecord)
           out.collect(leftRecord)
         }
-
       }
-      
+    }
+    val contract = reify {
+      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
+      val generatedStub = stub.splice
       val builder = CrossContract.builder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
       
       val ret = new CrossContract(builder) with TwoInputScalaContract[LeftIn, RightIn, Out] {
@@ -137,42 +113,15 @@ object CrossMacros {
     val (udtLeftIn, createUdtLeftIn) = slave.mkUdtClass[LeftIn]
     val (udtRightIn, createUdtRightIn) = slave.mkUdtClass[RightIn]
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
-    
-    val contract = reify {
-      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
 
-      val generatedStub = new CrossStub with Serializable {
-        val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
-        val rightInputUDT = c.Expr[UDT[RightIn]](createUdtRightIn).splice
-        val outputUDT = c.Expr[UDT[Out]](createUdtOut).splice
-        val udf: UDF2[LeftIn, RightIn, Out] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
-
-        private var leftDeserializer: UDTSerializer[LeftIn] = _
-        private var leftDiscard: Array[Int] = _
-        private var leftForwardFrom: Array[Int] = _
-        private var leftForwardTo: Array[Int] = _
-        private var rightDeserializer: UDTSerializer[RightIn] = _
-        private var rightForwardFrom: Array[Int] = _
-        private var rightForwardTo: Array[Int] = _
-        private var serializer: UDTSerializer[Out] = _
-        private var outputLength: Int = _
-
-        override def open(config: Configuration) = {
-          super.open(config)
-
-          this.leftDeserializer = udf.getLeftInputDeserializer
-          this.leftDiscard = udf.getLeftDiscardIndexArray.filter(_ < udf.getOutputLength)
-          this.leftForwardFrom = udf.getLeftForwardIndexArrayFrom
-          this.leftForwardTo = udf.getLeftForwardIndexArrayTo
-          this.rightDeserializer = udf.getRightInputDeserializer
-          this.rightForwardFrom = udf.getRightForwardIndexArrayFrom
-          this.rightForwardTo = udf.getRightForwardIndexArrayTo
-          this.serializer = udf.getOutputSerializer
-          this.outputLength = udf.getOutputLength
-        }
-
+    val stub: c.Expr[CrossStubBase[LeftIn, RightIn, Out]] = if (fun.actualType <:< weakTypeOf[CrossStub[LeftIn, RightIn, Out]])
+      reify { fun.splice.asInstanceOf[CrossStubBase[LeftIn, RightIn, Out]] }
+    else reify {
+      implicit val leftInputUDT: UDT[LeftIn] = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
+      implicit val rightInputUDT: UDT[RightIn] = c.Expr[UDT[RightIn]](createUdtRightIn).splice
+      implicit val outputUDT: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
+      new CrossStubBase[LeftIn, RightIn, Out] {
         override def cross(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
-
           val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
           val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
           val output = fun.splice.apply(left, right)
@@ -193,9 +142,11 @@ object CrossMacros {
             }
           }
         }
-
       }
-      
+    }
+    val contract = reify {
+      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
+      val generatedStub = stub.splice
       val builder = CrossContract.builder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
       
       val ret = new CrossContract(builder) with TwoInputScalaContract[LeftIn, RightIn, Out] {
@@ -213,39 +164,21 @@ object CrossMacros {
     
     return result
   }
-  
-   def filter[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag](c: Context { type PrefixType = CrossDataSet[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Boolean]): c.Expr[DataSet[(LeftIn, RightIn)] with TwoInputHintable[LeftIn, RightIn, (LeftIn, RightIn)]] = {
+
+  def filter[LeftIn: c.WeakTypeTag, RightIn: c.WeakTypeTag](c: Context { type PrefixType = CrossDataSet[LeftIn, RightIn] })(fun: c.Expr[(LeftIn, RightIn) => Boolean]): c.Expr[DataSet[(LeftIn, RightIn)] with TwoInputHintable[LeftIn, RightIn, (LeftIn, RightIn)]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
-    
+
     val (udtLeftIn, createUdtLeftIn) = slave.mkUdtClass[LeftIn]
     val (udtRightIn, createUdtRightIn) = slave.mkUdtClass[RightIn]
     val (udtOut, createUdtOut) = slave.mkUdtClass[(LeftIn, RightIn)]
-    
-    val contract = reify {
-      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
 
-      val generatedStub = new CrossStub with Serializable {
-        val leftInputUDT = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
-        val rightInputUDT = c.Expr[UDT[RightIn]](createUdtRightIn).splice
-        val outputUDT = c.Expr[UDT[(LeftIn, RightIn)]](createUdtOut).splice
-        val udf: UDF2[LeftIn, RightIn, (LeftIn, RightIn)] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
-
-        private var leftDeserializer: UDTSerializer[LeftIn] = _
-        private var rightDeserializer: UDTSerializer[RightIn] = _
-        private var serializer: UDTSerializer[(LeftIn, RightIn)] = _
-        private var outputLength: Int = _
-
-        override def open(config: Configuration) = {
-          super.open(config)
-
-          this.leftDeserializer = udf.getLeftInputDeserializer
-          this.rightDeserializer = udf.getRightInputDeserializer
-          this.serializer = udf.getOutputSerializer
-          this.outputLength = udf.getOutputLength
-        }
-
+    val stub = reify {
+      implicit val leftInputUDT: UDT[LeftIn] = c.Expr[UDT[LeftIn]](createUdtLeftIn).splice
+      implicit val rightInputUDT: UDT[RightIn] = c.Expr[UDT[RightIn]](createUdtRightIn).splice
+      implicit val outputUDT: UDT[(LeftIn, RightIn)] = c.Expr[UDT[(LeftIn, RightIn)]](createUdtOut).splice
+      new CrossStubBase[LeftIn, RightIn, (LeftIn, RightIn)] {
         override def cross(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
           val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
           val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
@@ -257,7 +190,10 @@ object CrossMacros {
           }
         }
       }
-      
+    }
+    val contract = reify {
+      val helper: CrossDataSet[LeftIn, RightIn] = c.prefix.splice
+      val generatedStub = stub.splice
       val builder = CrossContract.builder(generatedStub).input1(helper.leftInput.contract).input2(helper.rightInput.contract)
       
       val ret = new CrossContract(builder) with TwoInputScalaContract[LeftIn, RightIn, (LeftIn, RightIn)] {

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/CrossOperator.scala
@@ -15,31 +15,24 @@ package eu.stratosphere.scala.operators
 
 import language.experimental.macros
 import scala.reflect.macros.Context
-import eu.stratosphere.scala.codegen.MacroContextHolder
-import eu.stratosphere.scala.ScalaContract
+
 import eu.stratosphere.pact.common.contract.MapContract
-import eu.stratosphere.scala.analysis.UDT
+
 import eu.stratosphere.pact.common.`type`.PactRecord
-import eu.stratosphere.pact.common.stubs.MapStub
 import eu.stratosphere.pact.common.stubs.Collector
 import eu.stratosphere.pact.generic.contract.Contract
-import eu.stratosphere.scala.contracts.Annotations
-import eu.stratosphere.pact.common.contract.ReduceContract
-import eu.stratosphere.pact.common.stubs.ReduceStub
-import eu.stratosphere.scala.analysis.UDTSerializer
-import eu.stratosphere.scala.analysis.UDF1
-import eu.stratosphere.scala.operators.stubs.DeserializingIterator
+import eu.stratosphere.pact.common.contract.CrossContract
+
 import eu.stratosphere.nephele.configuration.Configuration
 import java.util.{ Iterator => JIterator }
-import eu.stratosphere.scala.analysis.FieldSelector
-import eu.stratosphere.scala.analysis.FieldSelector
-import eu.stratosphere.pact.common.contract.CrossContract
-import eu.stratosphere.scala.TwoInputScalaContract
-import eu.stratosphere.scala.analysis.UDF2
-import eu.stratosphere.scala.DataSet
-import eu.stratosphere.scala.TwoInputHintable
-import eu.stratosphere.scala.codegen.Util
+
+
+import eu.stratosphere.scala.contracts.Annotations
+import eu.stratosphere.scala._
+import eu.stratosphere.scala.analysis._
 import eu.stratosphere.scala.stubs.{CrossStubBase, CrossStub, FlatCrossStub}
+import eu.stratosphere.scala.codegen.{MacroContextHolder, Util}
+import eu.stratosphere.scala.stubs.DeserializingIterator
 
 class CrossDataSet[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInput: DataSet[RightIn]) {
   def map[Out](fun: (LeftIn, RightIn) => Out): DataSet[Out] with TwoInputHintable[LeftIn, RightIn, Out] = macro CrossMacros.map[LeftIn, RightIn, Out]

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/JoinOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/JoinOperator.scala
@@ -15,33 +15,22 @@ package eu.stratosphere.scala.operators
 
 import language.experimental.macros
 import scala.reflect.macros.Context
-import eu.stratosphere.scala.ScalaContract
-import eu.stratosphere.pact.common.contract.MapContract
-import eu.stratosphere.scala.analysis.UDT
+
 import eu.stratosphere.pact.common.`type`.PactRecord
-import eu.stratosphere.pact.common.stubs.MapStub
 import eu.stratosphere.pact.common.stubs.Collector
 import eu.stratosphere.pact.generic.contract.Contract
-import eu.stratosphere.scala.contracts.Annotations
-import eu.stratosphere.pact.common.contract.ReduceContract
-import eu.stratosphere.pact.common.stubs.ReduceStub
-import eu.stratosphere.scala.analysis.UDTSerializer
-import eu.stratosphere.scala.analysis.UDF1
-import eu.stratosphere.scala.operators.stubs.DeserializingIterator
-import eu.stratosphere.nephele.configuration.Configuration
-import java.util.{ Iterator => JIterator }
-import eu.stratosphere.scala.analysis.FieldSelector
-import eu.stratosphere.scala.OneInputKeyedScalaContract
-import eu.stratosphere.pact.common.contract.CrossContract
-import eu.stratosphere.scala.analysis.UDF2
 import eu.stratosphere.pact.common.contract.MatchContract
-import eu.stratosphere.scala.TwoInputKeyedScalaContract
 import eu.stratosphere.pact.common.stubs.MatchStub
-import eu.stratosphere.scala.codegen.MacroContextHolder
-import eu.stratosphere.scala.DataSet
 import eu.stratosphere.pact.generic.contract.UserCodeObjectWrapper
-import eu.stratosphere.scala.TwoInputHintable
-import eu.stratosphere.scala.codegen.Util
+
+import eu.stratosphere.nephele.configuration.Configuration
+
+import java.util.{ Iterator => JIterator }
+
+import eu.stratosphere.scala._
+import eu.stratosphere.scala.analysis._
+import eu.stratosphere.scala.contracts.Annotations
+import eu.stratosphere.scala.codegen.{MacroContextHolder, Util}
 
 class JoinDataSet[LeftIn, RightIn](val leftInput: DataSet[LeftIn], val rightInput: DataSet[RightIn]) {
   def where[Key](keyFun: LeftIn => Key) = macro JoinMacros.whereImpl[LeftIn, RightIn, Key]

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/MapOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/MapOperator.scala
@@ -15,21 +15,17 @@ package eu.stratosphere.scala.operators
 
 import language.experimental.macros
 import scala.reflect.macros.Context
-import eu.stratosphere.scala.codegen.MacroContextHolder
-import eu.stratosphere.scala.ScalaContract
+
 import eu.stratosphere.pact.common.contract.MapContract
-import eu.stratosphere.scala.analysis.UDT
 import eu.stratosphere.pact.common.`type`.PactRecord
 import eu.stratosphere.pact.common.stubs.{Collector, MapStub => JMapStub}
 import eu.stratosphere.pact.generic.contract.Contract
-import eu.stratosphere.scala.contracts.Annotations
-import eu.stratosphere.scala.OneInputScalaContract
-import eu.stratosphere.scala.analysis.UDF1
-import eu.stratosphere.scala.analysis.UDTSerializer
 import eu.stratosphere.nephele.configuration.Configuration
-import eu.stratosphere.scala.DataSet
-import eu.stratosphere.scala.OneInputHintable
-import eu.stratosphere.scala.codegen.Util
+
+import eu.stratosphere.scala.codegen.{MacroContextHolder, Util}
+import eu.stratosphere.scala._
+import eu.stratosphere.scala.analysis._
+import eu.stratosphere.scala.contracts.Annotations
 import eu.stratosphere.scala.stubs.{MapStub, FlatMapStub, FilterStub, MapStubBase}
 
 object MapMacros {

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
@@ -24,10 +24,9 @@ import eu.stratosphere.pact.generic.contract.Contract
 import eu.stratosphere.pact.common.contract.MapContract
 import eu.stratosphere.pact.common.`type`.PactRecord
 import eu.stratosphere.pact.common.`type`.base.PactInteger
-import eu.stratosphere.pact.common.stubs.MapStub
 import eu.stratosphere.pact.common.stubs.Collector
 import eu.stratosphere.pact.common.contract.ReduceContract
-import eu.stratosphere.pact.common.stubs.ReduceStub
+import eu.stratosphere.pact.common.stubs.{ReduceStub => JReduceStub}
 
 import eu.stratosphere.scala.contracts.Annotations
 import eu.stratosphere.scala.analysis.UDTSerializer
@@ -43,6 +42,7 @@ import eu.stratosphere.scala.DataSet
 import eu.stratosphere.scala.OneInputHintable
 import eu.stratosphere.scala.OneInputScalaContract
 import eu.stratosphere.scala.codegen.Util
+import eu.stratosphere.scala.stubs.{ReduceStub, GroupReduceStub, CombinableGroupReduceStub, ReduceStubBase}
 
 class KeyedDataSet[In](val keySelection: List[Int], val input: DataSet[In]) {
   def reduceGroup[Out](fun: Iterator[In] => Out): DataSet[Out] with OneInputHintable[In, Out] = macro ReduceMacros.reduceGroup[In, Out]
@@ -119,71 +119,15 @@ object ReduceMacros {
 //    val (paramName, udfBody) = slave.extractOneInputUdf(fun.tree)
 
     val (udtIn, createUdtIn) = slave.mkUdtClass[In]
-    
-    val contract = reify {
-      val helper = groupedInput.splice
-      val keySelection = helper.keySelection
 
-      val generatedStub = new ReduceStub with Serializable {
-        val inputUDT = c.Expr[UDT[In]](createUdtIn).splice
-        val outputUDT = inputUDT
-        val keySelector = new FieldSelector(inputUDT, keySelection)
-        val udf: UDF1[In, In] = new UDF1(inputUDT, outputUDT)
-        
-        private val combineRecord = new PactRecord()
-        private val reduceRecord = new PactRecord()
+    val stub: c.Expr[ReduceStubBase[In, In]] = if (fun.actualType <:< weakTypeOf[ReduceStub[In]])
+      reify { fun.splice.asInstanceOf[ReduceStubBase[In, In]] }
+    else reify {
+      implicit val inputUDT: UDT[In] = c.Expr[UDT[In]](createUdtIn).splice
 
-        private var combineIterator: DeserializingIterator[In] = null
-        private var combineSerializer: UDTSerializer[In] = _
-        private var combineForwardFrom: Array[Int] = _
-        private var combineForwardTo: Array[Int] = _
-
-        private var reduceIterator: DeserializingIterator[In] = null
-        private var reduceSerializer: UDTSerializer[In] = _
-        private var reduceForwardFrom: Array[Int] = _
-        private var reduceForwardTo: Array[Int] = _
-
-        private def combinerOutputs: Set[Int] = udf.inputFields.filter(_.isUsed).map(_.globalPos.getValue).toSet
-        private def forwardedKeys: Set[Int] = keySelector.selectedFields.toIndexSet.diff(combinerOutputs)
-
-        def combineForwardSetFrom: Set[Int] = udf.getForwardIndexSetFrom.diff(combinerOutputs).union(forwardedKeys).toSet
-        def combineForwardSetTo: Set[Int] = udf.getForwardIndexSetTo.diff(combinerOutputs).union(forwardedKeys).toSet
-        def combineDiscardSet: Set[Int] = udf.discardSet.map(_.getValue).diff(combinerOutputs).diff(forwardedKeys).toSet
-
-        private def combineOutputLength = {
-          val outMax = if (combinerOutputs.isEmpty) -1 else combinerOutputs.max
-          val forwardMax = if (combineForwardSetTo.isEmpty) -1 else combineForwardSetTo.max
-          math.max(outMax, forwardMax) + 1
-        }
-
-        override def open(config: Configuration) = {
-          super.open(config)
-          this.combineRecord.setNumFields(combineOutputLength)
-          this.reduceRecord.setNumFields(udf.getOutputLength)
-
-          this.combineIterator = new DeserializingIterator(udf.getInputDeserializer)
-          // we are serializing for the input of the reduce...
-          this.combineSerializer = udf.getInputDeserializer
-          this.combineForwardFrom = combineForwardSetFrom.toArray
-          this.combineForwardTo = combineForwardSetTo.toArray
-
-          this.reduceIterator = new DeserializingIterator(udf.getInputDeserializer)
-          this.reduceSerializer = udf.getOutputSerializer
-          this.reduceForwardFrom = udf.getForwardIndexArrayFrom.toArray
-          this.reduceForwardTo = udf.getForwardIndexArrayTo.toArray
-        }
-        
-        val userCode = fun.splice
-
+      new ReduceStubBase[In, In] {
         override def combine(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
-          val firstRecord = combineIterator.initialize(records)
-          combineRecord.copyFrom(firstRecord, combineForwardFrom, combineForwardTo)
-
-          val output = combineIterator.reduce(userCode)
-
-          combineSerializer.serialize(output, combineRecord)
-          out.collect(combineRecord)
+          reduce(records, out)
         }
 
         override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
@@ -191,23 +135,29 @@ object ReduceMacros {
           val firstRecord = reduceIterator.initialize(records)
           reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
 
-          val output = reduceIterator.reduce(userCode)
+          val output = reduceIterator.reduce(fun.splice)
 
           reduceSerializer.serialize(output, reduceRecord)
           out.collect(reduceRecord)
         }
-
       }
-      
+
+    }
+    val contract = reify {
+      val helper = groupedInput.splice
+      val generatedStub = stub.splice
+      val keySelection = helper.keySelection
+      val keySelector = new FieldSelector(generatedStub.inputUDT, keySelection)
+
       val builder = ReduceContract.builder(generatedStub).input(helper.input.contract)
 
-      val keyPositions = generatedStub.keySelector.selectedFields.toIndexArray
+      val keyPositions = keySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.inputUDT.getKeySet(keyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), keyPositions(i)) }
       
       val ret = new ReduceContract(builder) with OneInputKeyedScalaContract[In, In] {
-        override val key: FieldSelector = generatedStub.keySelector
+        override val key: FieldSelector = keySelector
         override def getUDF = generatedStub.udf
         override def annotations = Annotations.getCombinable() +: Seq(
           Annotations.getConstantFields(
@@ -231,35 +181,15 @@ object ReduceMacros {
 
     val (udtIn, createUdtIn) = slave.mkUdtClass[In]
     val (udtOut, createUdtOut) = slave.mkUdtClass[Out]
-    
-    val contract = reify {
-      val helper: KeyedDataSet[In] = groupedInput.splice
-      val keySelection = helper.keySelection
 
-      val generatedStub = new ReduceStub with Serializable {
-        val inputUDT = c.Expr[UDT[In]](createUdtIn).splice
-        val outputUDT = c.Expr[UDT[Out]](createUdtOut).splice
-        val keySelector = new FieldSelector(inputUDT, keySelection)
-        val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
-        
-        private val reduceRecord = new PactRecord()
+    val stub: c.Expr[ReduceStubBase[In, Out]] = if (fun.actualType <:< weakTypeOf[GroupReduceStub[In, Out]])
+      reify { fun.splice.asInstanceOf[ReduceStubBase[In, Out]] }
+    else reify {
+      implicit val inputUDT: UDT[In] = c.Expr[UDT[In]](createUdtIn).splice
+      implicit val outputUDT: UDT[Out] = c.Expr[UDT[Out]](createUdtOut).splice
 
-        private var reduceIterator: DeserializingIterator[In] = null
-        private var reduceSerializer: UDTSerializer[Out] = _
-        private var reduceForwardFrom: Array[Int] = _
-        private var reduceForwardTo: Array[Int] = _
-
-        override def open(config: Configuration) = {
-          super.open(config)
-          this.reduceRecord.setNumFields(udf.getOutputLength)
-          this.reduceIterator = new DeserializingIterator(udf.getInputDeserializer)
-          this.reduceSerializer = udf.getOutputSerializer
-          this.reduceForwardFrom = udf.getForwardIndexArrayFrom
-          this.reduceForwardTo = udf.getForwardIndexArrayTo
-        }
-
+      new ReduceStubBase[In, Out] {
         override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
           val firstRecord = reduceIterator.initialize(records)
           reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
 
@@ -268,18 +198,22 @@ object ReduceMacros {
           reduceSerializer.serialize(output, reduceRecord)
           out.collect(reduceRecord)
         }
-
       }
-      
+    }
+    val contract = reify {
+      val helper = groupedInput.splice
+      val generatedStub = stub.splice
+      val keySelection = helper.keySelection
+      val keySelector = new FieldSelector(generatedStub.inputUDT, keySelection)
       val builder = ReduceContract.builder(generatedStub).input(helper.input.contract)
 
-      val keyPositions = generatedStub.keySelector.selectedFields.toIndexArray
+      val keyPositions = keySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.inputUDT.getKeySet(keyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), keyPositions(i)) }
       
       val ret = new ReduceContract(builder) with OneInputKeyedScalaContract[In, Out] {
-        override val key: FieldSelector = generatedStub.keySelector
+        override val key: FieldSelector = keySelector
         override def getUDF = generatedStub.udf
         override def annotations = Seq(
           Annotations.getConstantFields(
@@ -302,95 +236,42 @@ object ReduceMacros {
 //    val (paramName, udfBody) = slave.extractOneInputUdf(fun.tree)
 
     val (udtIn, createUdtIn) = slave.mkUdtClass[In]
-    
-    val contract = reify {
-      val helper: KeyedDataSet[In] = groupedInput.splice
-      val keySelection = helper.keySelection
 
-      val generatedStub = new ReduceStub with Serializable {
-        val inputUDT = c.Expr[UDT[In]](createUdtIn).splice
-        val outputUDT = inputUDT
-        val keySelector = new FieldSelector(inputUDT, keySelection)
-        val udf: UDF1[In, In] = new UDF1(inputUDT, outputUDT)
-        
-        private val combineRecord = new PactRecord()
-        private val reduceRecord = new PactRecord()
+    val stub: c.Expr[ReduceStubBase[In, In]] = if (fun.actualType <:< weakTypeOf[CombinableGroupReduceStub[In, In]])
+      reify { fun.splice.asInstanceOf[ReduceStubBase[In, In]] }
+    else reify {
+      implicit val inputUDT: UDT[In] = c.Expr[UDT[In]](createUdtIn).splice
 
-        private var combineIterator: DeserializingIterator[In] = null
-        private var combineSerializer: UDTSerializer[In] = _
-        private var combineForwardFrom: Array[Int] = _
-        private var combineForwardTo: Array[Int] = _
-
-        private var reduceIterator: DeserializingIterator[In] = null
-        private var reduceSerializer: UDTSerializer[In] = _
-        private var reduceForwardFrom: Array[Int] = _
-        private var reduceForwardTo: Array[Int] = _
-
-        private def combinerOutputs: Set[Int] = udf.inputFields.filter(_.isUsed).map(_.globalPos.getValue).toSet
-        private def forwardedKeys: Set[Int] = keySelector.selectedFields.toIndexSet.diff(combinerOutputs)
-
-        def combineForwardSetFrom: Set[Int] = udf.getForwardIndexSetFrom.diff(combinerOutputs).union(forwardedKeys).toSet
-        def combineForwardSetTo: Set[Int] = udf.getForwardIndexSetTo.diff(combinerOutputs).union(forwardedKeys).toSet
-        def combineDiscardSet: Set[Int] = udf.discardSet.map(_.getValue).diff(combinerOutputs).diff(forwardedKeys).toSet
-
-        private def combineOutputLength = {
-          val outMax = if (combinerOutputs.isEmpty) -1 else combinerOutputs.max
-          val forwardMax = if (combineForwardSetTo.isEmpty) -1 else combineForwardSetTo.max
-          math.max(outMax, forwardMax) + 1
-        }
-
-        override def open(config: Configuration) = {
-          super.open(config)
-          this.combineRecord.setNumFields(combineOutputLength)
-          this.reduceRecord.setNumFields(udf.getOutputLength)
-
-          this.combineIterator = new DeserializingIterator(udf.getInputDeserializer)
-          // we are serializing for the input of the reduce...
-          this.combineSerializer = udf.getInputDeserializer
-          this.combineForwardFrom = combineForwardSetFrom.toArray
-          this.combineForwardTo = combineForwardSetTo.toArray
-
-          this.reduceIterator = new DeserializingIterator(udf.getInputDeserializer)
-          this.reduceSerializer = udf.getOutputSerializer
-          this.reduceForwardFrom = udf.getForwardIndexArrayFrom
-          this.reduceForwardTo = udf.getForwardIndexArrayTo
-        }
-        
-        val userCode = fun.splice
-
+      new ReduceStubBase[In, In] {
         override def combine(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
-          val firstRecord = combineIterator.initialize(records)
-          combineRecord.copyFrom(firstRecord, combineForwardFrom, combineForwardTo)
-
-          val output = userCode.apply(combineIterator)
-
-          combineSerializer.serialize(output, combineRecord)
-          out.collect(combineRecord)
+          reduce(records, out)
         }
 
         override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
-
           val firstRecord = reduceIterator.initialize(records)
           reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
 
-          val output = userCode.apply(reduceIterator)
+          val output = fun.splice.apply(reduceIterator)
 
           reduceSerializer.serialize(output, reduceRecord)
           out.collect(reduceRecord)
         }
-
       }
-      
+    }
+    val contract = reify {
+      val helper = groupedInput.splice
+      val generatedStub = stub.splice
+      val keySelection = helper.keySelection
+      val keySelector = new FieldSelector(generatedStub.inputUDT, keySelection)
       val builder = ReduceContract.builder(generatedStub).input(helper.input.contract)
 
-      val keyPositions = generatedStub.keySelector.selectedFields.toIndexArray
+      val keyPositions = keySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.inputUDT.getKeySet(keyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), keyPositions(i)) }
       
       val ret = new ReduceContract(builder) with OneInputKeyedScalaContract[In, In] {
-        override val key: FieldSelector = generatedStub.keySelector
+        override val key: FieldSelector = keySelector
         override def getUDF = generatedStub.udf
         override def annotations = Annotations.getCombinable() +: Seq(
           Annotations.getConstantFields(
@@ -416,7 +297,7 @@ object ReduceMacros {
       val helper: KeyedDataSet[In] = c.prefix.splice
       val keySelection = helper.keySelection
 
-      val generatedStub = new ReduceStub with Serializable {
+      val generatedStub = new JReduceStub with Serializable {
         val inputUDT = c.Expr[UDT[In]](createUdtIn).splice
         val outputUDT = c.Expr[UDT[(In, Int)]](createUdtOut).splice
         val keySelector = new FieldSelector(inputUDT, keySelection)

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/operators/ReduceOperator.scala
@@ -29,20 +29,10 @@ import eu.stratosphere.pact.common.contract.ReduceContract
 import eu.stratosphere.pact.common.stubs.{ReduceStub => JReduceStub}
 
 import eu.stratosphere.scala.contracts.Annotations
-import eu.stratosphere.scala.analysis.UDTSerializer
-import eu.stratosphere.scala.analysis.UDF1
-import eu.stratosphere.scala.operators.stubs.DeserializingIterator
-import eu.stratosphere.scala.codegen.MacroContextHolder
-import eu.stratosphere.scala.ScalaContract
-import eu.stratosphere.scala.analysis.UDT
-import eu.stratosphere.scala.analysis.FieldSelector
-import eu.stratosphere.scala.analysis.FieldSelector
-import eu.stratosphere.scala.OneInputKeyedScalaContract
-import eu.stratosphere.scala.DataSet
-import eu.stratosphere.scala.OneInputHintable
-import eu.stratosphere.scala.OneInputScalaContract
-import eu.stratosphere.scala.codegen.Util
-import eu.stratosphere.scala.stubs.{ReduceStub, GroupReduceStub, CombinableGroupReduceStub, ReduceStubBase}
+import eu.stratosphere.scala._
+import eu.stratosphere.scala.analysis._
+import eu.stratosphere.scala.codegen.{MacroContextHolder, Util}
+import eu.stratosphere.scala.stubs.{ReduceStub, ReduceStubBase, CombinableGroupReduceStub, GroupReduceStub}
 
 class KeyedDataSet[In](val keySelection: List[Int], val input: DataSet[In]) {
   def reduceGroup[Out](fun: Iterator[In] => Out): DataSet[Out] with OneInputHintable[In, Out] = macro ReduceMacros.reduceGroup[In, Out]

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/CoGroupStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/CoGroupStub.scala
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.stubs
+
+import eu.stratosphere.scala.analysis.{UDTSerializer, UDF2, UDT}
+import eu.stratosphere.pact.common.stubs.{CoGroupStub => JCoGroupStub, Collector}
+import eu.stratosphere.pact.common.`type`.PactRecord
+import eu.stratosphere.nephele.configuration.Configuration
+import java.util.{Iterator => JIterator}
+
+abstract class CoGroupStubBase[LeftIn: UDT, RightIn: UDT, Out: UDT] extends JCoGroupStub with Serializable {
+  val leftInputUDT = implicitly[UDT[LeftIn]]
+  val rightInputUDT = implicitly[UDT[RightIn]]
+  val outputUDT = implicitly[UDT[Out]]
+  val udf: UDF2[LeftIn, RightIn, Out] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
+
+  protected val outputRecord = new PactRecord()
+
+  protected lazy val leftIterator: DeserializingIterator[LeftIn] = new DeserializingIterator(udf.getLeftInputDeserializer)
+  protected lazy val leftForwardFrom: Array[Int] = udf.getLeftForwardIndexArrayFrom
+  protected lazy val leftForwardTo: Array[Int] = udf.getLeftForwardIndexArrayTo
+  protected lazy val rightIterator: DeserializingIterator[RightIn] = new DeserializingIterator(udf.getRightInputDeserializer)
+  protected lazy val rightForwardFrom: Array[Int] = udf.getRightForwardIndexArrayFrom
+  protected lazy val rightForwardTo: Array[Int] = udf.getRightForwardIndexArrayTo
+  protected lazy val serializer: UDTSerializer[Out] = udf.getOutputSerializer
+
+  override def open(config: Configuration) = {
+    super.open(config)
+
+    this.outputRecord.setNumFields(udf.getOutputLength)
+  }
+}
+
+abstract class CoGroupStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CoGroupStubBase[LeftIn, RightIn, Out] with Function2[Iterator[LeftIn], Iterator[RightIn], Out] {
+  override def coGroup(leftRecords: JIterator[PactRecord], rightRecords: JIterator[PactRecord], out: Collector[PactRecord]) = {
+    val firstLeftRecord = leftIterator.initialize(leftRecords)
+    val firstRightRecord = rightIterator.initialize(rightRecords)
+
+    if (firstRightRecord != null) {
+      outputRecord.copyFrom(firstRightRecord, rightForwardFrom, rightForwardTo)
+    }
+    if (firstLeftRecord != null) {
+      outputRecord.copyFrom(firstLeftRecord, leftForwardFrom, leftForwardTo)
+    }
+
+    val output = apply(leftIterator, rightIterator)
+
+    serializer.serialize(output, outputRecord)
+    out.collect(outputRecord)
+  }
+}
+
+abstract class FlatCoGroupStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CoGroupStubBase[LeftIn, RightIn, Out] with Function2[Iterator[LeftIn], Iterator[RightIn], Iterator[Out]] {
+  override def coGroup(leftRecords: JIterator[PactRecord], rightRecords: JIterator[PactRecord], out: Collector[PactRecord]) = {
+    val firstLeftRecord = leftIterator.initialize(leftRecords)
+    outputRecord.copyFrom(firstLeftRecord, leftForwardFrom, leftForwardTo)
+
+    val firstRightRecord = rightIterator.initialize(rightRecords)
+    outputRecord.copyFrom(firstRightRecord, rightForwardFrom, rightForwardTo)
+
+    val output = apply(leftIterator, rightIterator)
+
+    if (output.nonEmpty) {
+
+      for (item <- output) {
+        serializer.serialize(item, outputRecord)
+        out.collect(outputRecord)
+      }
+    }
+  }
+}

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/CrossStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/CrossStub.scala
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.stubs
+
+import eu.stratosphere.pact.common.stubs.{CrossStub => JCrossStub, Collector}
+import eu.stratosphere.scala.analysis.{UDTSerializer, UDF2, UDT}
+import eu.stratosphere.pact.common.`type`.PactRecord
+
+abstract class CrossStubBase[LeftIn: UDT, RightIn: UDT, Out: UDT] extends JCrossStub with Serializable {
+  val leftInputUDT = implicitly[UDT[LeftIn]]
+  val rightInputUDT = implicitly[UDT[RightIn]]
+  val outputUDT = implicitly[UDT[Out]]
+  val udf: UDF2[LeftIn, RightIn, Out] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
+
+  protected lazy val leftDeserializer: UDTSerializer[LeftIn] = udf.getLeftInputDeserializer
+  protected lazy val leftForwardFrom: Array[Int] = udf.getLeftForwardIndexArrayFrom
+  protected lazy val leftForwardTo: Array[Int] = udf.getLeftForwardIndexArrayTo
+  protected lazy val leftDiscard: Array[Int] = udf.getLeftDiscardIndexArray.filter(_ < udf.getOutputLength)
+  protected lazy val rightDeserializer: UDTSerializer[RightIn] = udf.getRightInputDeserializer
+  protected lazy val rightForwardFrom: Array[Int] = udf.getRightForwardIndexArrayFrom
+  protected lazy val rightForwardTo: Array[Int] = udf.getRightForwardIndexArrayTo
+  protected lazy val serializer: UDTSerializer[Out] = udf.getOutputSerializer
+  protected lazy val outputLength: Int = udf.getOutputLength
+
+}
+
+abstract class CrossStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CrossStubBase[LeftIn, RightIn, Out] with Function2[LeftIn, RightIn, Out] {
+  override def cross(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
+    val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
+    val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
+    val output = cross(left, right)
+
+    leftRecord.setNumFields(outputLength)
+
+    for (field <- leftDiscard)
+      leftRecord.setNull(field)
+
+    leftRecord.copyFrom(rightRecord, rightForwardFrom, rightForwardTo)
+    leftRecord.copyFrom(leftRecord, leftForwardFrom, leftForwardTo)
+
+    serializer.serialize(output, leftRecord)
+    out.collect(leftRecord)
+  }
+
+  def cross(leftIn: LeftIn, rightIn: RightIn): Out
+}
+
+abstract class FlatCrossStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CrossStubBase[LeftIn, RightIn, Out] with Function2[LeftIn, RightIn, Iterator[Out]]  {
+  override def cross(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
+    val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
+    val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
+    val output = flatCross(left, right)
+
+    if (output.nonEmpty) {
+
+      leftRecord.setNumFields(outputLength)
+
+      for (field <- leftDiscard)
+        leftRecord.setNull(field)
+
+      leftRecord.copyFrom(rightRecord, rightForwardFrom, rightForwardTo)
+      leftRecord.copyFrom(leftRecord, leftForwardFrom, leftForwardTo)
+
+      for (item <- output) {
+        serializer.serialize(item, leftRecord)
+        out.collect(leftRecord)
+      }
+    }
+  }
+
+  def flatCross(leftIn: LeftIn, rightIn: RightIn): Iterator[Out]
+}
+
+

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/CrossStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/CrossStub.scala
@@ -39,7 +39,7 @@ abstract class CrossStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CrossStubB
   override def cross(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
     val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
     val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
-    val output = cross(left, right)
+    val output = apply(left, right)
 
     leftRecord.setNumFields(outputLength)
 
@@ -52,15 +52,13 @@ abstract class CrossStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CrossStubB
     serializer.serialize(output, leftRecord)
     out.collect(leftRecord)
   }
-
-  def cross(leftIn: LeftIn, rightIn: RightIn): Out
 }
 
 abstract class FlatCrossStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CrossStubBase[LeftIn, RightIn, Out] with Function2[LeftIn, RightIn, Iterator[Out]]  {
   override def cross(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
     val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
     val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
-    val output = flatCross(left, right)
+    val output = apply(left, right)
 
     if (output.nonEmpty) {
 
@@ -78,8 +76,6 @@ abstract class FlatCrossStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends CrossS
       }
     }
   }
-
-  def flatCross(leftIn: LeftIn, rightIn: RightIn): Iterator[Out]
 }
 
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/DeserializingIterator.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/DeserializingIterator.scala
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package eu.stratosphere.scala.operators.stubs
+package eu.stratosphere.scala.stubs
 
 import java.util.{ Iterator => JIterator }
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/JoinStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/JoinStub.scala
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.stubs
+
+import eu.stratosphere.pact.common.stubs.{MatchStub => JMatchStub, Collector}
+import eu.stratosphere.scala.analysis.{UDTSerializer, UDF2, UDT}
+import eu.stratosphere.pact.common.`type`.PactRecord
+
+abstract class JoinStubBase[LeftIn: UDT, RightIn: UDT, Out: UDT] extends JMatchStub with Serializable {
+  val leftInputUDT = implicitly[UDT[LeftIn]]
+  val rightInputUDT = implicitly[UDT[RightIn]]
+  val outputUDT = implicitly[UDT[Out]]
+  val udf: UDF2[LeftIn, RightIn, Out] = new UDF2(leftInputUDT, rightInputUDT, outputUDT)
+
+  protected lazy val leftDeserializer: UDTSerializer[LeftIn] = udf.getLeftInputDeserializer
+  protected lazy val leftDiscard: Array[Int] = udf.getLeftDiscardIndexArray.filter(_ < udf.getOutputLength)
+  protected lazy val leftForwardFrom: Array[Int] = udf.getLeftForwardIndexArrayFrom
+  protected lazy val leftForwardTo: Array[Int] = udf.getLeftForwardIndexArrayTo
+  protected lazy val rightDeserializer: UDTSerializer[RightIn] = udf.getRightInputDeserializer
+  protected lazy val rightForwardFrom: Array[Int] = udf.getRightForwardIndexArrayFrom
+  protected lazy val rightForwardTo: Array[Int] = udf.getRightForwardIndexArrayTo
+  protected lazy val serializer: UDTSerializer[Out] = udf.getOutputSerializer
+  protected lazy val outputLength: Int = udf.getOutputLength
+}
+
+abstract class JoinStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends JoinStubBase[LeftIn, RightIn, Out] with Function2[LeftIn, RightIn, Out] {
+  override def `match`(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
+    val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
+    val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
+    val output = apply(left, right)
+
+    leftRecord.setNumFields(outputLength)
+    for (field <- leftDiscard)
+      leftRecord.setNull(field)
+
+    leftRecord.copyFrom(rightRecord, rightForwardFrom, rightForwardTo)
+    leftRecord.copyFrom(leftRecord, leftForwardFrom, leftForwardTo)
+
+    serializer.serialize(output, leftRecord)
+    out.collect(leftRecord)
+  }
+}
+
+abstract class FlatJoinStub[LeftIn: UDT, RightIn: UDT, Out: UDT] extends JoinStubBase[LeftIn, RightIn, Out] with Function2[LeftIn, RightIn, Iterator[Out]] {
+  override def `match`(leftRecord: PactRecord, rightRecord: PactRecord, out: Collector[PactRecord]) = {
+    val left = leftDeserializer.deserializeRecyclingOn(leftRecord)
+    val right = rightDeserializer.deserializeRecyclingOn(rightRecord)
+    val output = apply(left, right)
+
+    if (output.nonEmpty) {
+
+      leftRecord.setNumFields(outputLength)
+
+      for (field <- leftDiscard)
+        leftRecord.setNull(field)
+
+      leftRecord.copyFrom(rightRecord, rightForwardFrom, rightForwardTo)
+      leftRecord.copyFrom(leftRecord, leftForwardFrom, leftForwardTo)
+
+      for (item <- output) {
+        serializer.serialize(item, leftRecord)
+        out.collect(leftRecord)
+      }
+    }
+  }
+}

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/MapStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/MapStub.scala
@@ -21,7 +21,7 @@ import eu.stratosphere.pact.common.`type`.PactRecord
 abstract class MapStubBase[In: UDT, Out: UDT] extends JMapStub with Serializable with Function1[In, Out] {
   val inputUDT: UDT[In] = implicitly[UDT[In]]
   val outputUDT: UDT[Out] = implicitly[UDT[Out]]
-  lazy val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
+  val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
 
   protected lazy val deserializer: UDTSerializer[In] = udf.getInputDeserializer
   protected lazy val serializer: UDTSerializer[Out] = udf.getOutputSerializer

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/MapStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/MapStub.scala
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.stubs
+
+import eu.stratosphere.scala.analysis.{UDTSerializer, UDT, UDF1}
+import eu.stratosphere.pact.common.stubs.{Collector, MapStub => JMapStub}
+import eu.stratosphere.nephele.configuration.Configuration
+import eu.stratosphere.pact.common.`type`.PactRecord
+
+abstract class MapStubBase[In: UDT, Out: UDT] extends JMapStub with Serializable with Function1[In, Out] {
+  val inputUDT: UDT[In] = implicitly[UDT[In]]
+  val outputUDT: UDT[Out] = implicitly[UDT[Out]]
+  lazy val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
+
+  protected lazy val deserializer: UDTSerializer[In] = udf.getInputDeserializer
+  protected lazy val serializer: UDTSerializer[Out] = udf.getOutputSerializer
+  protected lazy val discard: Array[Int] = udf.getDiscardIndexArray
+  protected lazy val outputLength: Int = udf.getOutputLength
+
+  // just so we satisfy Function1 requirements
+  def apply(in: In): Out = throw new RuntimeException("Should never be called.")
+}
+
+abstract class MapStub[In: UDT, Out: UDT] extends MapStubBase[In, Out] {
+  override def map(record: PactRecord, out: Collector[PactRecord]) = {
+    val input = deserializer.deserializeRecyclingOn(record)
+    val output = map(input)
+
+    record.setNumFields(outputLength)
+
+    for (field <- discard)
+      record.setNull(field)
+
+    serializer.serialize(output, record)
+    out.collect(record)
+  }
+
+  def map(in: In): Out
+}
+
+abstract class FlatMapStub[In: UDT, Out: UDT] extends MapStubBase[In, Out] {
+  override def map(record: PactRecord, out: Collector[PactRecord]) = {
+    val input = deserializer.deserializeRecyclingOn(record)
+    val output = flatMap(input)
+
+    if (output.nonEmpty) {
+
+      record.setNumFields(outputLength)
+
+      for (field <- discard)
+        record.setNull(field)
+
+      for (item <- output) {
+
+        serializer.serialize(item, record)
+        out.collect(record)
+      }
+    }
+  }
+
+  def flatMap(in: In): Iterator[Out]
+}
+
+abstract class FilterStub[In: UDT, Out: UDT] extends MapStubBase[In, Out] {
+  override def map(record: PactRecord, out: Collector[PactRecord]) = {
+    val input = deserializer.deserializeRecyclingOn(record)
+    if (filter(input)) {
+      out.collect(record)
+    }
+  }
+
+  def filter(in: In): Boolean
+}

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/MapStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/MapStub.scala
@@ -15,7 +15,6 @@ package eu.stratosphere.scala.stubs
 
 import eu.stratosphere.scala.analysis.{UDTSerializer, UDT, UDF1}
 import eu.stratosphere.pact.common.stubs.{Collector, MapStub => JMapStub}
-import eu.stratosphere.nephele.configuration.Configuration
 import eu.stratosphere.pact.common.`type`.PactRecord
 
 abstract class MapStubBase[In: UDT, Out: UDT] extends JMapStub with Serializable with Function1[In, Out] {

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
@@ -17,8 +17,6 @@ import java.util.{ Iterator => JIterator }
 
 import eu.stratosphere.scala.analysis.{UDTSerializer, UDF1, FieldSelector, UDT}
 import eu.stratosphere.pact.common.stubs.{ReduceStub => JReduceStub, Collector}
-import eu.stratosphere.scala.operators.stubs.DeserializingIterator
-import eu.stratosphere.nephele.configuration.Configuration
 import scala.Iterator
 import eu.stratosphere.pact.common.`type`.PactRecord
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
@@ -49,8 +49,6 @@ abstract class ReduceStub[In: UDT] extends ReduceStubBase[In, In] with Function2
     reduceSerializer.serialize(output, reduceRecord)
     out.collect(reduceRecord)
   }
-
-  def apply(in1: In, in2: In): In
 }
 
 abstract class GroupReduceStub[In: UDT, Out: UDT] extends ReduceStubBase[In, Out] with Function1[Iterator[In], Out] {
@@ -58,15 +56,11 @@ abstract class GroupReduceStub[In: UDT, Out: UDT] extends ReduceStubBase[In, Out
     val firstRecord = reduceIterator.initialize(records)
     reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
 
-    val output = reduce(reduceIterator)
+    val output = apply(reduceIterator)
 
     reduceSerializer.serialize(output, reduceRecord)
     out.collect(reduceRecord)
   }
-
-  def reduce(records: Iterator[In]): Out
-
-  def apply(record: Iterator[In]): Out = throw new RuntimeException("This should never be called.")
 }
 
 abstract class CombinableGroupReduceStub[In: UDT, Out: UDT] extends ReduceStubBase[In, Out] with Function1[Iterator[In], Out] {

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
@@ -26,7 +26,7 @@ import eu.stratosphere.pact.common.`type`.PactRecord
 abstract class ReduceStubBase[In: UDT, Out: UDT] extends JReduceStub with Serializable {
   val inputUDT: UDT[In] = implicitly[UDT[In]]
   val outputUDT: UDT[Out] = implicitly[UDT[Out]]
-  lazy val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
+  val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
 
   protected val reduceRecord = new PactRecord()
 

--- a/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
+++ b/pact-scala/pact-scala-core/src/main/scala/eu/stratosphere/scala/stubs/ReduceStub.scala
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package eu.stratosphere.scala.stubs
+
+import java.util.{ Iterator => JIterator }
+
+import eu.stratosphere.scala.analysis.{UDTSerializer, UDF1, FieldSelector, UDT}
+import eu.stratosphere.pact.common.stubs.{ReduceStub => JReduceStub, Collector}
+import eu.stratosphere.scala.operators.stubs.DeserializingIterator
+import eu.stratosphere.nephele.configuration.Configuration
+import scala.Iterator
+import eu.stratosphere.pact.common.`type`.PactRecord
+
+
+abstract class ReduceStubBase[In: UDT, Out: UDT] extends JReduceStub with Serializable {
+  val inputUDT: UDT[In] = implicitly[UDT[In]]
+  val outputUDT: UDT[Out] = implicitly[UDT[Out]]
+  lazy val udf: UDF1[In, Out] = new UDF1(inputUDT, outputUDT)
+
+  protected val reduceRecord = new PactRecord()
+
+  protected lazy val reduceIterator: DeserializingIterator[In] = new DeserializingIterator(udf.getInputDeserializer)
+  protected lazy val reduceSerializer: UDTSerializer[Out] = udf.getOutputSerializer
+  protected lazy val reduceForwardFrom: Array[Int] = udf.getForwardIndexArrayFrom
+  protected lazy val reduceForwardTo: Array[Int] = udf.getForwardIndexArrayTo
+}
+
+abstract class ReduceStub[In: UDT] extends ReduceStubBase[In, In] with Function2[In, In, In] {
+
+  override def combine(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
+    reduce(records, out)
+  }
+
+  override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
+    val firstRecord = reduceIterator.initialize(records)
+    reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
+
+    val output = reduceIterator.reduce(apply)
+
+    reduceSerializer.serialize(output, reduceRecord)
+    out.collect(reduceRecord)
+  }
+
+  def apply(in1: In, in2: In): In
+}
+
+abstract class GroupReduceStub[In: UDT, Out: UDT] extends ReduceStubBase[In, Out] with Function1[Iterator[In], Out] {
+  override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
+    val firstRecord = reduceIterator.initialize(records)
+    reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
+
+    val output = reduce(reduceIterator)
+
+    reduceSerializer.serialize(output, reduceRecord)
+    out.collect(reduceRecord)
+  }
+
+  def reduce(records: Iterator[In]): Out
+
+  def apply(record: Iterator[In]): Out = throw new RuntimeException("This should never be called.")
+}
+
+abstract class CombinableGroupReduceStub[In: UDT, Out: UDT] extends ReduceStubBase[In, Out] with Function1[Iterator[In], Out] {
+  override def combine(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
+    val firstRecord = reduceIterator.initialize(records)
+    reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
+
+    val output = combine(reduceIterator)
+
+    reduceSerializer.serialize(output, reduceRecord)
+    out.collect(reduceRecord)
+  }
+
+  override def reduce(records: JIterator[PactRecord], out: Collector[PactRecord]) = {
+    val firstRecord = reduceIterator.initialize(records)
+    reduceRecord.copyFrom(firstRecord, reduceForwardFrom, reduceForwardTo)
+
+    val output = reduce(reduceIterator)
+
+    reduceSerializer.serialize(output, reduceRecord)
+    out.collect(reduceRecord)
+  }
+
+  def reduce(records: Iterator[In]): Out
+  def combine(records: Iterator[In]): Out
+
+  def apply(record: Iterator[In]): Out = throw new RuntimeException("This should never be called.")
+}

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
@@ -81,7 +81,7 @@ object Main1 extends Serializable {
         override def open(config: Configuration) = {
           println("Opening up this badboy.")
         }
-        override def map(in: (String, Int)) = {
+        override def apply(in: (String, Int)) = {
           println("IN RICH MAPPER: " + in)
           in
         }

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
@@ -9,6 +9,7 @@ import eu.stratosphere.pact.common.`type`.base.PactString
 
 import eu.stratosphere.scala._
 import eu.stratosphere.scala.operators._
+import eu.stratosphere.scala.stubs._
 
 import eu.stratosphere.scala.analysis.GlobalSchemaPrinter
 import eu.stratosphere.pact.example.util.AsciiUtils
@@ -16,6 +17,12 @@ import org.apache.log4j.Logger
 import org.apache.log4j.Level
 import eu.stratosphere.scala.analysis.postPass.GlobalSchemaOptimizer
 import eu.stratosphere.scala.analysis.GlobalSchemaGenerator
+
+import eu.stratosphere.pact.common.`type`.PactRecord
+import eu.stratosphere.pact.common.stubs.Collector
+
+import eu.stratosphere.scala.codegen.Util
+import eu.stratosphere.nephele.configuration.Configuration
 
 
 // Grab bag of random scala examples
@@ -28,7 +35,7 @@ object Main1 extends Serializable {
     lazy val tokenizer = new AsciiUtils.WhitespaceTokenizer()
     val foo = new Foo(3)
     def apply(a: (String, Int)) = {
-      println("I GOT: " + a + " AND: " + foo.a)
+      println("I GOT: " + a + " ANDd: " + foo.a)
       tokenizer.setStringToTokenize(new PactString(a._1))
       a
     }
@@ -52,6 +59,7 @@ object Main1 extends Serializable {
 
 
   def main(args: Array[String]) {
+
 //    var logger = Logger.getLogger(classOf[GlobalSchemaOptimizer])
 //    logger.setLevel(Level.DEBUG)
 //    logger = Logger.getLogger(classOf[GlobalSchemaGenerator])
@@ -62,12 +70,22 @@ object Main1 extends Serializable {
 
     val input = DataSource("file:///home/aljoscha/dummy-input", DelimitedInputFormat(readFun) )
     val inputNumbers = DataSource("file:///home/aljoscha/dummy-input-numbers", CsvInputFormat[(Int, String, String)](Seq(0,2,1), "\n", ','))
-    
+
+
     val counts = input.map { _.split("""\W+""") map { (_, 1) } }
       .flatMap { l => l }
       .groupBy { case (word, _) => word }
       .combinableReduceGroup { _.reduce { (w1, w2) => (w1._1, w1._2 + w2._2) } }
       .map(fun)
+      .map( new MapStub[(String, Int), (String, Int)] {
+        override def open(config: Configuration) = {
+          println("Opening up this badboy.")
+        }
+        override def map(in: (String, Int)) = {
+          println("IN RICH MAPPER: " + in)
+          in
+        }
+      })
 //      .filter { case (w, c) => c == 7 }
 
     val countsCross = counts.cross(counts)

--- a/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
+++ b/pact-scala/pact-scala-examples/src/main/scala/eu/stratosphere/scala/examples/grabbag/Grabbag.scala
@@ -95,7 +95,14 @@ object Main1 extends Serializable {
     val foo = counts.join(inputNumbers) where { case (_, c) => c}
 
     
-    val bar1 = foo.isEqualTo { case (c, _, _) => c } map { (w1, w2) => (w1._1 + " is ONE " + w2._2, w1._2) }
+//    val bar1 = foo.isEqualTo { case (c, _, _) => c } map { (w1, w2) => (w1._1 + " is ONE " + w2._2, w1._2) }
+    val bar1 = foo.isEqualTo { case (c, _, _) => c } map(
+      new JoinStub[(String, Int), (Int, String, String), (String, Int)] {
+        def apply(l: (String, Int), r: (Int, String, String)) = {
+          (l._1 + " is ONE BGG " + r._2, l._2)
+        }
+      }
+    )
     bar1.right neglects { case (a,b,c) => c }
     
     val bar2 = foo.isEqualTo { case (c, _, _) => c } map { (w1, w2) => (w1._1 + " is TWO " + w2._2, w1._2) }


### PR DESCRIPTION
Change Operators to accept stubs with open/close etc. You might call them rich stubs, but in the code it's just MapStub, FlatMapStub, FilterStub, ReduceStub, etc. They derive from MapStub etc. (the java one), so you can do things like getting the iteration context or what you might have...

This allows something like:

``` scala
.map( new MapStub[(String, Int), (String, Int)] {
  override def open(config: Configuration) = {
    println("Opening up this badboy.")
  }
  override def map(in: (String, Int)) = {
    println("IN RICH MAPPER: " + in)
    val (w, c) = in
    (w, c + 1)
  }
})
```

and likewise for flatMap and filter, for example:

``` scala
.map( new FlatMapStub[(String, Int), (String, Int)] {
  override def open(config: Configuration) = {
    println("Opening up this badboy.")
  }
  override def flatMap(in: (String, Int)) = {
    println("IN RICH MAPPER: " + in)
    in
  }
})
```

If people like this I will also make this available for all the other operators.
