### PR TITLE
Speed up travis builds by distributing the deploys among the workers

### DIFF
--- a/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/hash/ReOpenableHashTableITCase.java
+++ b/pact/pact-runtime/src/test/java/eu/stratosphere/pact/runtime/hash/ReOpenableHashTableITCase.java
@@ -60,7 +60,7 @@ public class ReOpenableHashTableITCase {
 	private static final long SEED1 = 561349061987311L;
 	private static final long SEED2 = 231434613412342L;
 	
-	private static final int NUM_PROBES = 5; // number of reopenings of hash join
+	private static final int NUM_PROBES = 3; // number of reopenings of hash join
 	
 	private final AbstractTask parentTask = new DummyInvokable();
 

--- a/tools/deploy_to_maven.sh
+++ b/tools/deploy_to_maven.sh
@@ -2,6 +2,15 @@
 
 #Please ask @rmetzger (on GitHub) before changing anything here. It contains some magic.
 
+# Build Responsibilities
+# 1. Deploy to sonatype (old hadoop)
+# 2. Deploy to dopa (old hadoop)
+# 3. Nothing
+# 4. deploy to sonatype (yarn hadoop)
+# 5. deploy to dopa (yarn hadoop)
+# 6. Nothing
+
+
 echo "install lifecylce mapping fake plugin"
 git clone https://github.com/mfriedenhagen/dummy-lifecycle-mapping-plugin.git
 cd dummy-lifecycle-mapping-plugin
@@ -43,12 +52,16 @@ if [[ $TRAVIS_PULL_REQUEST == "false" ]] ; then
 	if [[ $TRAVIS_JOB_NUMBER == *1 ]] && [[ $TRAVIS_PULL_REQUEST == "false" ]] ; then 
 		# Deploy regular hadoop v1 to maven
 		mvn -DskipTests deploy --settings deploysettings.xml; 
+	fi
 
+	if [[ $TRAVIS_JOB_NUMBER == *4 ]] && [[ $TRAVIS_PULL_REQUEST == "false" ]] ; then 
 		# deploy hadoop v2 (yarn)
 		echo "Generating poms for hadoop-yarn."
 		./tools/generate_specific_pom.sh $CURRENT_STRATOSPHERE_VERSION $CURRENT_STRATOSPHERE_VERSION_YARN
 		mvn -B -f pom.hadoop2.xml -DskipTests clean deploy --settings deploysettings.xml; 
 	fi
+
+	
 
 	#
 	# Deploy binaries to DOPA


### PR DESCRIPTION
The 6 workers now have the following responsibilities:

```
#1. Deploy to sonatype (old hadoop)
#2. Deploy to dopa (old hadoop)
#3. Nothing
#4. deploy to sonatype (yarn hadoop)
#5. deploy to dopa (yarn hadoop)
#6. Nothing
```

Especially worker 1. (which is always running out of time) does not need to download, build and upload the yarn stratosphere version.
This is done by worker 5 which has to download the yarn dependencies anyways.

I also changed the `ReOpenableHashTableITCase` to re-open the HashJoin from 5 to 3 times (the test case takes the most time)
