### PR TITLE
YARN + pact-client enhancements, fix stalling travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 
 install: true
 
-script: "mvn -B $PROFILE clean install verify"
+script: "mvn -B $PROFILE clean verify"
 
 # deploy if the first job is successful; should be replaced by an after_all_success if travis finally supports it
 after_success: 

--- a/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/configuration/ConfigConstants.java
+++ b/nephele/nephele-common/src/main/java/eu/stratosphere/nephele/configuration/ConfigConstants.java
@@ -162,9 +162,14 @@ public final class ConfigConstants {
 	public static final int DEFAULT_WEB_FRONTEND_PORT = 8081;
 
 	/**
+	 * The default directory name of the info server
+	 */
+	public static final String DEFAULT_JOB_MANAGER_WEB_PATH_NAME = "web-docs-infoserver";
+	
+	/**
 	 * The default path of the directory for info server containing the web documents.
 	 */
-	public static final String DEFAULT_JOB_MANAGER_WEB_ROOT_PATH = "./resources/web-docs-infoserver/";
+	public static final String DEFAULT_JOB_MANAGER_WEB_ROOT_PATH = "./resources/"+DEFAULT_JOB_MANAGER_WEB_PATH_NAME+"/";
 	
 	/**
 	 * The default number of archived jobs for the jobmanager

--- a/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
+++ b/nephele/nephele-server/src/main/java/eu/stratosphere/nephele/jobmanager/JobManager.java
@@ -33,6 +33,7 @@
 
 package eu.stratosphere.nephele.jobmanager;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -461,7 +462,7 @@ public class JobManager implements DeploymentManager, ExtendedManagementProtocol
 		
 		// Set base dir for info server
 		Configuration infoserverConfig = GlobalConfiguration.getConfiguration();
-		if (configDir != null) {
+		if (configDir != null && new File(configDir).isDirectory()) {
 			infoserverConfig.setString(ConfigConstants.STRATOSPHERE_BASE_DIR_PATH_KEY, configDir+"/..");
 		}
 		GlobalConfiguration.includeConfiguration(infoserverConfig);

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/RemoteExecutor.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/RemoteExecutor.java
@@ -6,12 +6,10 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 
+import eu.stratosphere.nephele.configuration.Configuration;
 import eu.stratosphere.pact.client.nephele.api.Client;
-import eu.stratosphere.pact.client.nephele.api.ErrorInPlanAssemblerException;
 import eu.stratosphere.pact.client.nephele.api.PlanWithJars;
-import eu.stratosphere.pact.client.nephele.api.ProgramInvocationException;
 import eu.stratosphere.pact.common.plan.Plan;
-import eu.stratosphere.pact.compiler.CompilerException;
 
 public class RemoteExecutor implements PlanExecutor {
 
@@ -20,7 +18,7 @@ public class RemoteExecutor implements PlanExecutor {
 	private List<String> jarFiles;
 
 	public RemoteExecutor(InetSocketAddress inet, List<String> jarFiles) {
-		this.client = new Client(inet);
+		this.client = new Client(inet, new Configuration());
 		this.jarFiles = jarFiles;
 	}
 	
@@ -36,7 +34,7 @@ public class RemoteExecutor implements PlanExecutor {
 		this(getInetFromHostport(hostport), Collections.singletonList(jarFile));
 	}
 	
-	private static InetSocketAddress getInetFromHostport(String hostport) {
+	public static InetSocketAddress getInetFromHostport(String hostport) {
 		// from http://stackoverflow.com/questions/2345063/java-common-way-to-validate-and-convert-hostport-to-inetsocketaddress
 		URI uri;
 		try {

--- a/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/Client.java
+++ b/pact/pact-clients/src/main/java/eu/stratosphere/pact/client/nephele/api/Client.java
@@ -60,8 +60,8 @@ public class Client {
 	 * 
 	 * @param jobManagerAddress Address and port of the job-manager.
 	 */
-	public Client(InetSocketAddress jobManagerAddress) {
-		this.nepheleConfig = new Configuration();
+	public Client(InetSocketAddress jobManagerAddress, Configuration config) {
+		this.nepheleConfig = config;
 		nepheleConfig.setString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, jobManagerAddress.getAddress().getHostAddress());
 		nepheleConfig.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, jobManagerAddress.getPort());
 		

--- a/stratosphere-addons/stratosphere-yarn/src/main/java/eu/stratosphere/yarn/Client.java
+++ b/stratosphere-addons/stratosphere-yarn/src/main/java/eu/stratosphere/yarn/Client.java
@@ -100,7 +100,7 @@ public class Client {
 	/**
 	 * Command Line argument options
 	 */
-	private static final Option QUERY = new Option("q","query",false, "Display avilable YARN resources (memory, cores)");
+	private static final Option QUERY = new Option("q","query",false, "Display available YARN resources (memory, cores)");
 	// --- or ---
 	private static final Option VERBOSE = new Option("v","verbose",false, "Verbose debug mode");
 	private static final Option GEN_CONF = new Option("g","generateConf",false, "Place default configuration file in current directory");

--- a/stratosphere-addons/stratosphere-yarn/src/main/java/eu/stratosphere/yarn/Utils.java
+++ b/stratosphere-addons/stratosphere-yarn/src/main/java/eu/stratosphere/yarn/Utils.java
@@ -192,13 +192,4 @@ public class Utils {
 		appMasterJar.setVisibility(LocalResourceVisibility.APPLICATION);
 	}
 	
-	public static void main(String[] args) {
-		try {
-			Utils.copyJarContents(ConfigConstants.DEFAULT_JOB_MANAGER_WEB_PATH_NAME, 
-					"/home/robert/Projekte/ozone/ozone/stratosphere-dist/target/stratosphere-dist-0.4-SNAPSHOT-yarn-uberjar.jar");
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
-	
 }

--- a/stratosphere-dist/src/main/assemblies/yarn-uberjar.xml
+++ b/stratosphere-dist/src/main/assemblies/yarn-uberjar.xml
@@ -28,4 +28,15 @@
       <fileMode>0644</fileMode>
     </file>
   </files>
+  <fileSets>
+ 	 <fileSet>
+		<!-- copy files for Jobmanager web frontend -->
+		<directory>../nephele/nephele-server/resources</directory>
+		<outputDirectory>resources</outputDirectory>
+		<fileMode>0644</fileMode>
+		<excludes>
+			<exclude>*etc/users</exclude>
+		</excludes>
+	</fileSet>
+</fileSets>
 </assembly>


### PR DESCRIPTION
- YARN now also starts the web interface
- extended pact-client to nicely support remote execution using new option "remote"

```
Action "run" compiles and submits a PACT program.
  "run" action arguments:
     -a,--arguments <programArgs>   Pact program arguments
     -c,--class <classname>         Pact program assembler class
     -j,--jarfile <jarfile>         Pact program JAR file
     -w,--wait                      Wait until program finishes

Action "remote" is similar to "run" but allows to specify the JobManager connection
  "remote" action arguments:
     -a,--arguments <programArgs>   Pact program arguments
     -c,--class <classname>         Pact program assembler class
     -j,--jarfile <jarfile>         Pact program JAR file
     -r,--address <arg>             Hostname:port of JobManager
     -w,--wait                      Wait until program finishes
```

The webinterface starts but is not really usable from the YARN webinterfaces due to https://github.com/stratosphere/stratosphere/issues/325.
