### PR TITLE
Allow empty paths in FileInputFormat to fix a problem with the job-preview

### DIFF
--- a/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FileInputFormat.java
+++ b/pact/pact-common/src/main/java/eu/stratosphere/pact/generic/io/FileInputFormat.java
@@ -31,11 +31,9 @@ import eu.stratosphere.nephele.fs.FileInputSplit;
 import eu.stratosphere.nephele.fs.FileStatus;
 import eu.stratosphere.nephele.fs.FileSystem;
 import eu.stratosphere.nephele.fs.Path;
-import eu.stratosphere.pact.common.contract.FileDataSource;
 import eu.stratosphere.pact.common.contract.GenericDataSource;
 import eu.stratosphere.pact.common.io.statistics.BaseStatistics;
 import eu.stratosphere.pact.common.util.PactConfigConstants;
-import eu.stratosphere.pact.generic.io.InputFormat;
 
 /**
  * Describes the base interface that is used for reading from a file input. For specific input types the 
@@ -158,6 +156,14 @@ public abstract class FileInputFormat<OT> implements InputFormat<OT, FileInputSp
 	public void setFilePath(String filePath) {
 		if (filePath == null)
 			throw new IllegalArgumentException("File path may not be null.");
+		
+		// TODO The job-submission web interface passes empty args (and thus empty
+		// paths) to compute the preview graph. The following is a workaround for
+		// this situation and we should fix this.
+		if (filePath.isEmpty()) {
+			setFilePath(new Path());
+			return;
+		}
 		
 		setFilePath(new Path(filePath));
 	}

--- a/pact/pact-tests/src/test/java/eu/stratosphere/pact/compiler/plandump/PreviewPlanDumpTest.java
+++ b/pact/pact-tests/src/test/java/eu/stratosphere/pact/compiler/plandump/PreviewPlanDumpTest.java
@@ -42,34 +42,45 @@ public class PreviewPlanDumpTest {
 	
 	protected static final String OUT_FILE = FileSystem.isWindows() ?  "file:/c:/test/output" : "file:///test/output";
 	
+	protected static final String[] NO_ARGS = new String[0];
+	
 	@Test
 	public void dumpWordCount() {
 		dump(new WordCount().getPlan("4", IN_FILE, OUT_FILE));
+		
+		// The web interface passes empty string-args to compute the preview of the
+		// job, so we should test this situation too
+		dump(new WordCount().getPlan(NO_ARGS));
 	}
 	
 	@Test
 	public void dumpTPCH3() {
 		dump(new TPCHQuery3().getPlan("4", IN_FILE, IN_FILE, OUT_FILE));
+		dump(new TPCHQuery3().getPlan(NO_ARGS));
 	}
 	
 	@Test
 	public void dumpKMeans() {
 		dump(new KMeansSingleStep().getPlan("4", IN_FILE, IN_FILE, OUT_FILE));
+		dump(new KMeansSingleStep().getPlan(NO_ARGS));
 	}
 	
 	@Test
 	public void dumpWebLogAnalysis() {
 		dump(new WebLogAnalysis().getPlan("4", IN_FILE, IN_FILE, IN_FILE, OUT_FILE));
+		dump(new WebLogAnalysis().getPlan(NO_ARGS));
 	}
 	
 	@Test
 	public void dumpBulkIterationKMeans() {
 		dump(new KMeansIterative().getPlan("4", IN_FILE, OUT_FILE));
+		dump(new KMeansIterative().getPlan(NO_ARGS));
 	}
 	
 	@Test
 	public void dumpWorksetConnectedComponents() {
 		dump(new WorksetConnectedComponents().getPlan("4", IN_FILE, IN_FILE, OUT_FILE));
+		dump(new WorksetConnectedComponents().getPlan(NO_ARGS));
 	}
 	
 	private void dump(Plan p) {


### PR DESCRIPTION
The commit [CsvFormat configurable via regular parameters](https://github.com/stratosphere/stratosphere/commit/9dd4635ad69bf107ab9f81c8e7ffd495475471e0) caused the job-preview of the job-submission web interface to fail. The preview currently creates a plan with empty String args. This is no longer possible due to this commit (see my changes to understand).

I added a quick-fix (see code, very simple), and updated a test case. Please merge for Ufuk.
