### PR TITLE
Rework download page & versions as variables

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,13 @@ paginate_path:      "blog/page-:num"
 
 # see https://github.com/mojombo/jekyll/issues/332
 baseurl:            ""
+
+# Stratosphere related variables
+current_snapshot:		"0.4-SNAPSHOT"
+current_snapshot_yarn:	"0.4-hadoop2-SNAPSHOT"
+current_stable:			"0.4-rc1"
+current_stable_yarn:	"0.4-rc1-hadoop2"
+#used in download and quickstart
+current_stable_dl:		"https://github.com/stratosphere/stratosphere/releases/download/v0.4-rc1/stratosphere-0.4-rc1.tgz"
+current_stable_dl_yarn: "https://github.com/stratosphere/stratosphere/releases/download/v0.4-rc1/stratosphere-0.4-rc1-hadoop2.tgz"
+current_stable_uberjar: "https://github.com/stratosphere/stratosphere/releases/download/v0.4-rc1/stratosphere-dist-0.4-rc1-yarn-uberjar.jar"

--- a/docs/0.4/setup/yarn.markdown
+++ b/docs/0.4/setup/yarn.markdown
@@ -30,20 +30,20 @@ Follow these instructions to learn how to lauch a Stratosphere Session within yo
 You only need one file to run Stratosphere on YARN, the <i>Stratosphere Uber-Jar</i>. Download the Uber-jar on the [download page]({{site.baseurl}}/downloads/#bin).
 
 
-If you want to build the uber-jar from sources, follow the build instructions. Make sure to use the `-Dhadoop.profile=2` profile. You can find the Jar file in `stratosphere-dist/target/stratosphere-dist-0.4-SNAPSHOT-yarn-uberjar.jar` (*Note: The version might be different for you* ).
+If you want to build the uber-jar from sources, follow the build instructions. Make sure to use the `-Dhadoop.profile=2` profile. You can find the Jar file in `stratosphere-dist/target/stratosphere-dist-{{site.current_snapshot}}-yarn-uberjar.jar` (*Note: The version might be different for you* ).
 
 ### Deploy
 
 Invoke the Jar file using the following command:
 
 ```bash
-java -jar stratosphere-dist-0.4-SNAPSHOT-yarn-uberjar.jar
+java -jar stratosphere-dist-{{site.current_stable}}-yarn-uberjar.jar
 ```
 
 This command will show you the following overview:
 
-```
-java -jar stratosphere-dist-0.4-SNAPSHOT-yarn-uberjar.jar 
+```bash
+java -jar stratosphere-dist-{{site.current_stable}}-yarn-uberjar.jar 
 Usage:
    Required
      -n,--container <arg>   Number of Yarn container to allocate (=Number of TaskTrackers)
@@ -64,7 +64,7 @@ Please note that the Client requires the `HADOOP_HOME` (or `YARN_CONF_DIR` or `H
 **Example:** Issue the following command to allocate 10 TaskTrackers, with 8GB of memory each:
 
 ```bash
-java -jar stratosphere-dist-0.4-SNAPSHOT-yarn-uberjar.jar -n 10 -tm 8192
+java -jar stratosphere-dist-{{site.current_stable}}-yarn-uberjar.jar -n 10 -tm 8192
 ```
 
 
@@ -85,7 +85,7 @@ So open `screen`, start Stratosphere on YARN, use `CTRL+a` then press `d` to det
 Use the following command to submit a Stratosphere job to the YARN cluster:
 
 ```
-java -cp stratosphere-dist-0.4-SNAPSHOT-yarn-uberjar.jar eu.stratosphere.client.CliFrontend
+java -cp stratosphere-dist-{{site.current_stable}}-yarn-uberjar.jar eu.stratosphere.client.CliFrontend
 ```
 
 If you have Stratosphere installed from a custom build or a zip file, use the [commandline client]({{site.baseurl}}/docs/0.4/program_execution/cli_client.html):
@@ -117,11 +117,11 @@ Use the *run* action to submit a job to YARN. The uberjar will show you the addr
 wget -O hamlet.txt http://www.gutenberg.org/cache/epub/1787/pg1787.txt
 # Submit Job to Stratosphere
 ./bin/stratosphere run -m localhost:6123 \
-                       -j ./examples/stratosphere-java-examples-0.4-WordCount.jar \
+                       -j ./examples/stratosphere-java-examples-{{site.current_stable}}-WordCount.jar \
                        -a 1 file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt 
 ```
 
-You can use also script without the `-m` (or `--jobmanager`) argument, but you have to configure the `stratosphere-conf.yaml` with the correct hostname and port for the JobManager.
+You can use also script without the `-m` (or `--jobmanager`) argument, but you have to configure the `stratosphere-conf.yaml` with the correct JobManager details.
 </section>
 
 <section id="build">

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -8,6 +8,7 @@ links:
   -       { anchor: vagrant, title: "Vagrant" }
   -       { anchor: debian, title: "Debian Package" }
   -       { anchor: source, title: "Source" }
+  -       { anchor: nightly, title: "Nightly Builds" }
 ---
 
 <p class="lead">There are plenty of ways to get Stratosphere. Pick any of the following to start.</p>
@@ -20,19 +21,19 @@ links:
         <p>
         <ul class="nav nav-tabs">
             <li class="active"><a href="#bin-hadoop2" data-toggle="tab">Hadoop 2 (YARN)</a></li>
-            <li><a href="#bin-hadoop1" data-toggle="tab">Hadoop 1.2</a></li>
+            <li><a href="#bin-hadoop1" data-toggle="tab">Hadoop 1</a></li>
         </ul>
         <div class="tab-content text-center">
             <div class="tab-pane active" id="bin-hadoop2">
-                <a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-hadoop2-SNAPSHOT.tgz"><i class="icon-download"> </i> Download Stratosphere for Hadoop 2</a>
-                <a style="padding-left:5px" class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-dist-0.4-SNAPSHOT-hadoop2-yarn-uberjar.jar"><i class="icon-download"> </i> Stratosphere YARN Uber-jar</a>
+                <a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-hadoop2-SNAPSHOT.tgz"><i class="icon-download"> </i> Stratosphere 0.4 (Hadoop 2)</a>
+                <a style="padding-left:5px" class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-dist-0.4-SNAPSHOT-hadoop2-yarn-uberjar.jar"><i class="icon-download"> </i> Stratosphere 0.4 for YARN</a>
             </div>
             <div class="tab-pane" id="bin-hadoop1">
-                <a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-SNAPSHOT.tgz"><i class="icon-download"> </i> Download Stratosphere for Hadoop 1.2</a>
+                <a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-SNAPSHOT.tgz"><i class="icon-download"> </i> Download Stratosphere 0.4 (Hadoop 1)</a>
             </div>
         </div>
         </p>
-        <p>Make sure to checkout the <a href="{{ site.baseurl }}/docs">Documentation</a> for further help.</p>
+        <p>Read more in the <a href="{{ site.baseurl }}/docs">Documentation</a>.</p>
     </section>
 
     <section id="maven">
@@ -41,21 +42,10 @@ links:
         </div>
         <p class="lead">Use the Maven Dependencies to add Stratosphere to your project.</p>
         <p>These dependencies also include a local execution environment. Therefore they are sufficient for local testing.</p>
-        <p>The current development version is not pushed to Maven central yet (this will change with the release), so please make sure to add the Sonatype snapshot repository to your Maven project between:</p>
-{% highlight xml %}
-<repositories>
-  <repository>
-    <id>snapshots-repo</id>
-    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    <releases><enabled>false</enabled></releases>
-    <snapshots><enabled>true</enabled></snapshots>
-  </repository>
-</repositories>
-{% endhighlight %}
         <p>
-        <p>Maven will now be able to find the Stratosphere dependencies. If you want to interact with Hadoop, make sure to pick the dependency <strong>matching your Hadoop version</strong>. In doubt, use the Stratosphere version for Hadoop 1.2.</p>
+        <p>Maven will now be able to find the Stratosphere dependencies. If you want to interact with Hadoop, pick the dependency <strong>matching your Hadoop version</strong>. In doubt, use the Stratosphere version for Hadoop 1.x.</p>
         <ul class="nav nav-tabs">
-            <li class="active"><a href="#maven-hadoop1" data-toggle="tab">Hadoop 1.2</a></li>
+            <li class="active"><a href="#maven-hadoop1" data-toggle="tab">Hadoop 1</a></li>
             <li><a href="#maven-hadoop2" data-toggle="tab">Hadoop 2 (YARN)</a></li>
         </ul>
         <div class="tab-content">
@@ -63,13 +53,13 @@ links:
 {% highlight xml %}
 <dependency>
   <groupId>eu.stratosphere</groupId>
-  <artifactId>pact-common</artifactId>
-  <version>0.4-SNAPSHOT</version>
+  <artifactId>stratosphere-common</artifactId>
+  <version>0.4-rc1</version>
 </dependency>
 <dependency>
   <groupId>eu.stratosphere</groupId>
-  <artifactId>pact-clients</artifactId>
-  <version>0.4-SNAPSHOT</version>
+  <artifactId>stratosphere-clients</artifactId>
+  <version>0.4-rc1</version>
 </dependency>
 {% endhighlight %}
             </div>
@@ -160,6 +150,40 @@ mvn clean package -DskipTests -Dhadoop.profile=2
         <p>Make sure to checkout the <a href="{{ site.baseurl }}/docs">Documentation</a> for further help.</p>
     </section>
 
+    <section id="nightly">
+        <div class="page-header">
+            <h2>Nightly Builds</h2>
+        </div>
+        <p class="lead">The Nightly Builds contain the most recent development code. Use them for example if you need a feature before its released. Only builds that pass all tests are published here.</p>
+        <h3>Binaries</h3>
+        <p>
+            <a href="https://travis-ci.org/stratosphere/stratosphere">Travis CI</a> builds a new test build each time we push into the repository.
+        Find the <a href="http://stratosphere-bin.s3-website-us-east-1.amazonaws.com/">binaries on Amazon S3</a>.
+        </p>
+        <h3>SNAPSHOT-Versions in Sonatype Maven</h3>
+        Add the Sonatype Snapshots repository to into your Maven pom:
+        {% highlight xml %}
+<repositories>
+  <repository>
+    <id>snapshots-repo</id>
+    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    <releases><enabled>false</enabled></releases>
+    <snapshots><enabled>true</enabled></snapshots>
+  </repository>
+</repositories>
+{% endhighlight %}
+
+Set the version to the next snapshot version, for example: 0.5-SNAPSHOT
+{% highlight xml %}
+<dependency>
+  <groupId>eu.stratosphere</groupId>
+  <artifactId>stratosphere-clients</artifactId>
+  <version>0.5-SNAPSHOT</version>
+</dependency>
+{% endhighlight %}
+    </section>
+
+
     <p class="lead" style="margin-top: 2em">Feel free to <a href="{{ site.baseurl }}/contact">contact us</a> if you have any problems or suggestions.</p>
-    <p class="lead" style="margin-top: 2em">This project uses <a href="http://www.ej-technologies.com/products/jprofiler/overview.html">Java Profiler</a> from from ej-technologies.</p>
+    <p class="lead" style="margin-top: 2em">The Stratosphere developers are using the <a href="http://www.ej-technologies.com/products/jprofiler/overview.html">Java Profiler</a> from ej-technologies.</p>
 </div>

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -25,11 +25,11 @@ links:
         </ul>
         <div class="tab-content text-center">
             <div class="tab-pane active" id="bin-hadoop2">
-                <a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-hadoop2-SNAPSHOT.tgz"><i class="icon-download"> </i> Stratosphere 0.4 (Hadoop 2)</a>
-                <a style="padding-left:5px" class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-dist-0.4-SNAPSHOT-hadoop2-yarn-uberjar.jar"><i class="icon-download"> </i> Stratosphere 0.4 for YARN</a>
+                <a class="btn btn-info btn-lg" href="{{iste.current_stable_dl_yarn}}"><i class="icon-download"> </i> Stratosphere 0.4 (Hadoop 2)</a>
+                <a style="padding-left:5px" class="btn btn-info btn-lg" href="{{site.current_stable_uberjar}}"><i class="icon-download"> </i> Stratosphere 0.4 for YARN</a>
             </div>
             <div class="tab-pane" id="bin-hadoop1">
-                <a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-SNAPSHOT.tgz"><i class="icon-download"> </i> Download Stratosphere 0.4 (Hadoop 1)</a>
+                <a class="btn btn-info btn-lg" href="{{site.current_stable_dl}}"><i class="icon-download"> </i> Download Stratosphere 0.4 (Hadoop 1)</a>
             </div>
         </div>
         </p>
@@ -53,13 +53,13 @@ links:
 {% highlight xml %}
 <dependency>
   <groupId>eu.stratosphere</groupId>
-  <artifactId>stratosphere-common</artifactId>
-  <version>0.4-rc1</version>
+  <artifactId>stratosphere-java</artifactId>
+  <version>{{ site.current_stable }}</version>
 </dependency>
 <dependency>
   <groupId>eu.stratosphere</groupId>
-  <artifactId>stratosphere-clients</artifactId>
-  <version>0.4-rc1</version>
+  <artifactId>stratosphere-core</artifactId>
+  <version>{{ site.current_stable }}</version>
 </dependency>
 {% endhighlight %}
             </div>
@@ -67,13 +67,13 @@ links:
 {% highlight xml %}
 <dependency>
   <groupId>eu.stratosphere</groupId>
-  <artifactId>pact-common</artifactId>
-  <version>0.4-hadoop2-SNAPSHOT</version>
+  <artifactId>stratosphere-java</artifactId>
+  <version>{{ site.current_stable_yarn }}</version>
 </dependency>
 <dependency>
   <groupId>eu.stratosphere</groupId>
-  <artifactId>pact-clients</artifactId>
-  <version>0.4-hadoop2-SNAPSHOT</version>
+  <artifactId>stratosphere-core</artifactId>
+  <version>{{ site.current_stable_yarn }}</version>
 </dependency>
 {% endhighlight %}
             </div>
@@ -154,11 +154,24 @@ mvn clean package -DskipTests -Dhadoop.profile=2
         <div class="page-header">
             <h2>Nightly Builds</h2>
         </div>
-        <p class="lead">The Nightly Builds contain the most recent development code. Use them for example if you need a feature before its released. Only builds that pass all tests are published here.</p>
+        <p class="lead">The Nightly Builds contain the most recent development code. Use them for example if you need a feature before its release. Only builds that pass all tests are published here.</p>
         <h3>Binaries</h3>
         <p>
             <a href="https://travis-ci.org/stratosphere/stratosphere">Travis CI</a> builds a new test build each time we push into the repository.
-        Find the <a href="http://stratosphere-bin.s3-website-us-east-1.amazonaws.com/">binaries on Amazon S3</a>.
+        
+        <p>
+            <a class="btn btn-warning btn-default" href="http://stratosphere-bin.s3-website-us-east-1.amazonaws.com/stratosphere-dist/target/stratosphere-dist-{{ site.current_snapshot_yarn }}-yarn-uberjar.jar"><i class="icon-download"> </i> Download Latest ({{ site.current_snapshot }}) Stratosphere YARN uberjar</a>
+        </p>
+
+         <p>
+            <a class="btn btn-warning btn-default" href="http://stratosphere-bin.s3-website-us-east-1.amazonaws.com/stratosphere-{{site.current_snapshot}}.tgz"><i class="icon-download"> </i> Download Latest ({{ site.current_snapshot }}) Stratosphere for Hadoop 1.x</a>
+        </p>
+         <p>
+            <a class="btn btn-warning btn-default" href="http://stratosphere-bin.s3-website-us-east-1.amazonaws.com/stratosphere-{{site.current_snapshot_yarn}}.tgz"><i class="icon-download"> </i> Download Latest ({{ site.current_snapshot_yarn }}) Stratosphere for Hadoop 2.2.x</a>
+        </p>
+        <p>
+
+        Find all <a href="http://stratosphere-bin.s3-website-us-east-1.amazonaws.com/">binaries on Amazon S3</a>.
         </p>
         <h3>SNAPSHOT-Versions in Sonatype Maven</h3>
         Add the Sonatype Snapshots repository to into your Maven pom:
@@ -178,7 +191,7 @@ Set the version to the next snapshot version, for example: 0.5-SNAPSHOT
 <dependency>
   <groupId>eu.stratosphere</groupId>
   <artifactId>stratosphere-clients</artifactId>
-  <version>0.5-SNAPSHOT</version>
+  <version>{{ site.current_snapshot }}</version>
 </dependency>
 {% endhighlight %}
     </section>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ $( document ).ready(function() {
   <h1>Stratosphere</h1>
   <p style="padding-bottom:2em">Big Data looks tiny from here.</p>
   <p>
-    <a href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-SNAPSHOT.tgz" onclick="_gaq.push(['_trackEvent','Action','download-src',this.href]);" class="btn btn-info btn-lg" style="width:10em">
+    <a href="{{site.current_stable_dl}}" onclick="_gaq.push(['_trackEvent','Action','download-src',this.href]);" class="btn btn-info btn-lg" style="width:10em">
       <i class="icon-download"> </i>Download
     </a>
     <a href="https://github.com/stratosphere/stratosphere" target="_blanc" onclick="_gaq.push(['_trackEvent','Action','github',this.href]);" class="btn btn-primary btn-lg">

--- a/quickstart/build.markdown
+++ b/quickstart/build.markdown
@@ -28,7 +28,7 @@ If you’re a Debian/Ubuntu user, you’ll also find a `.deb` package here.
 Go into the build directory
 
 <pre class="prettyprint" style="padding-left:1em">
-cd stratosphere-dist/target/stratosphere-dist-0.4-SNAPSHOT-bin/stratosphere-0.4-SNAPSHOT/
+cd stratosphere-dist/target/stratosphere-dist-{{site.current_snapshot}}-bin/stratosphere-{{site.current_snapshot}}/
 </pre>
 
 Now, we can start Stratosphere in local mode:
@@ -49,7 +49,7 @@ Start the job:
 
 <pre class="prettyprint" style="padding-left:1em">
 ./bin/pact-client.sh run \
-    --jarfile ./examples/pact/pact-examples-0.4-SNAPSHOT-WordCount.jar \
+    --jarfile ./examples/stratosphere-java-examples-{{site.current_snapshot}}-WordCount.jar \
     --arguments 1 file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
 </pre>
 
@@ -61,11 +61,11 @@ You will find a file called `wordcount-result.txt` in your current directory.
 Start the webinterface, using the following command:
 
 ```
-./bin/start-pact-web.sh
+./bin/start-webclient.sh
 ```
 
 * Access it using the following URL: [http://localhost:8080](http://localhost:8080).
-* Upload the WordCount.jar using the upload form in the lower right box. The jar is located in `./examples/pact/pact-examples-0.4-SNAPSHOT-WordCount.jar`
+* Upload the WordCount.jar using the upload form in the lower right box. The jar is located in `./examples/stratosphere-java-examples-{{site.current_snapshot}}-WordCount.jar`
 * Select the WordCount jar from the list of available jars (upper left).
 * Enter the argument line in the lower-left box: 1 file://<path to>/hamlet.txt file://<wherever you want the>/wordcount-result.txt
 * Hit "Run Job"

--- a/quickstart/java.html
+++ b/quickstart/java.html
@@ -31,8 +31,7 @@ $ curl https://raw.github.com/stratosphere/stratosphere-quickstart/master/quicks
 $ mvn archetype:generate                             \
     -DarchetypeGroupId=eu.stratosphere               \
     -DarchetypeArtifactId=quickstart-java            \
-    -DarchetypeVersion=0.4-SNAPSHOT                  \
-    -DarchetypeCatalog=https://oss.sonatype.org/content/repositories/snapshots/
+    -DarchetypeVersion=0.4-rc1                  
 {% endhighlight %}
       This allows you to <strong>name your newly created project</strong>. It will interactively ask you for the groupId, artifactId, and package name.
     </li>

--- a/quickstart/scala.html
+++ b/quickstart/scala.html
@@ -30,8 +30,7 @@ $ curl https://raw.github.com/stratosphere/stratosphere-quickstart/master/quicks
 $ mvn archetype:generate                             \
     -DarchetypeGroupId=eu.stratosphere               \
     -DarchetypeArtifactId=quickstart-scala           \
-    -DarchetypeVersion=0.4-SNAPSHOT                  \
-    -DarchetypeCatalog=https://oss.sonatype.org/content/repositories/snapshots/
+    -DarchetypeVersion=0.4-rc1                  
 {% endhighlight %}
       This allows you to <strong>name your newly created project</strong>. It will interactively ask you for the groupId, artifactId, and package name.
     </li>

--- a/quickstart/setup.html
+++ b/quickstart/setup.html
@@ -26,10 +26,10 @@ links:
 		</ul>
 		<div class="tab-content text-center">
 			<div class="tab-pane active" id="bin-hadoop1">
-				<a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-SNAPSHOT.tgz"><i class="icon-download"> </i> Download Stratosphere for Hadoop 1.2</a>
+				<a class="btn btn-info btn-lg" href="{{site.current_stable_dl}}"><i class="icon-download"> </i> Download Stratosphere for Hadoop 1.2</a>
 	    </div>
 			<div class="tab-pane" id="bin-hadoop2">
-	      <a class="btn btn-info btn-lg" href="http://dopa.dima.tu-berlin.de/bin/stratosphere-0.4-hadoop2-SNAPSHOT.tgz"><i class="icon-download"> </i> Download Stratosphere for Hadoop 2 (YARN)</a>
+	      <a class="btn btn-info btn-lg" href="{{site.current_stable_dl_yarn}}"><i class="icon-download"> </i> Download Stratosphere for Hadoop 2 (YARN)</a>
 	    </div>
 	  </div>
 	</p>
@@ -67,8 +67,8 @@ $ wget -O hamlet.txt http://www.gutenberg.org/cache/epub/1787/pg1787.txt
 		</li>
   	<li class="lead"><strong>Start the example program</strong>:
 {% highlight bash %}
-$ bin/pact-client.sh run \
-    --jarfile ./examples/pact/pact-examples-0.4-SNAPSHOT-WordCount.jar \
+$ bin/stratosphere run \
+    --jarfile ./examples/stratosphere-java-examples-{{site.current_stable}}-WordCount.jar \
     --arguments 1 file://`pwd`/hamlet.txt file://`pwd`/wordcount-result.txt
 {% endhighlight %}
       You will find a file called <strong>wordcount-result.txt</strong> in your current directory.


### PR DESCRIPTION
We download page now points to the most recent stable release (0.4-rc1)

I also introduced variables for the current stable and snapshot versions.
(I guess we will have some 0.4.1, ... releases soon).

Btw: I promised to work on Christmas!
