### PR TITLE
Bugfix for webinterface: Failed jobs don't disappear

### DIFF
--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/jobmanager/EventCollector.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/jobmanager/EventCollector.java
@@ -528,7 +528,7 @@ public final class EventCollector extends TimerTask implements ProfilingListener
 
 				// Only remove jobs from the list which have stopped running
 				if (jobStatus != JobStatus.FINISHED && jobStatus != JobStatus.CANCELED
-					&& jobStatus != JobStatus.FINISHED) {
+					&& jobStatus != JobStatus.FAILED) {
 					continue;
 				}
 


### PR DESCRIPTION
Because of a small typo inside of the EventCollector failed jobs were not removed from the recentJobs list. See issue #276.
