### PR TITLE
Polling for jobmanager webinterface

### DIFF
--- a/stratosphere-runtime/resources/web-docs-infoserver/css/nephelefrontend.css
+++ b/stratosphere-runtime/resources/web-docs-infoserver/css/nephelefrontend.css
@@ -216,7 +216,8 @@ table{
 td, th {
     color: #000000;
     font-size: 12px;
-    line-height: 24px;
+    line-height: 26px;
+    height: 26px;
 }
 
 th {

--- a/stratosphere-runtime/resources/web-docs-infoserver/js/jobmanagerFrontend.js
+++ b/stratosphere-runtime/resources/web-docs-infoserver/js/jobmanagerFrontend.js
@@ -4,30 +4,68 @@ var widthProgressbar = 120;
 // For coloring the dependency graph
 var colors = [ "#37485D", "#D9AADC", "#4F7C61", "#8F9C6A", "#BC8E88" ];
 
-(function poll() {
-	$.ajax({ url : "jobsInfo", type : "GET", success : function(json) {
+var timestamp = 0;
+
+var recentjobs = new Array();
+
+/*
+ * Initializes global job table
+ */
+function init() {
+	$.ajax({ url : "jobsInfo", type : "GET", cache: false, success : function(json) {
+		
+		// If no job running, poll for new jobs
+		if(json == "")
+			setTimeout(function() {init()}, 2000);
+		
 	    jsonGlobal = json
 	    // Fill Table	
 	    fillTable("#jobs", json)
+	    
 	}, dataType : "json",
-	//complete: setTimeout(function() {poll()}, 5000),
-	//timeout: 2000
 	});
-})();
+}
+	
+// Init once on page load
+$(init());
 
+/*
+ * Pools for updates on currently running jobs
+ */
+function poll(jobId) {
+	$.ajax({ url : "jobsInfo?get=updates&job="+jobId, type : "GET", cache: false, success : function(json) {
+
+		// Call init of no more jobs are running
+		$.each(json.recentjobs, function(j, job) {
+			if(!$.inArray(job.jobid, recentjobs)) {
+				init();
+			}
+		});
+		
+		updateTable(json);
+	}, dataType : "json",
+	});
+};
+
+/*
+ * Polls the job history on page load
+ */
 (function pollArchive() {
-	$.ajax({ url : "jobsInfo?get=archive", type : "GET",
+	$.ajax({ url : "jobsInfo?get=archive", cache: false, type : "GET",
 	    success : function(json) {
+	    	
 		// Fill Table	
 		fillTableArchive("#jobsArchive", json)
+		
 	    }, dataType : "json",
-	//complete: setTimeout(function() {poll()}, 5000),
-	//timeout: 2000
 	});
 })();
 
+/*
+ * Polls the number of taskmanagers on page load
+ */
 (function pollTaskmanagers() {
-	$.ajax({ url : "jobsInfo?get=taskmanagers", type : "GET",
+	$.ajax({ url : "jobsInfo?get=taskmanagers", cache: false, type : "GET",
 	    success : function(json) {
 		$("#stat-taskmanagers").html(json.taskmanagers);
 	    }, dataType : "json",
@@ -45,13 +83,14 @@ $(".opensub").live("click", function() {
 	drawDependencies();
 });
 
+/**
+ * Cancels a job
+ */
 $(".cancel").live("click", function() {
 	var id = $(this).attr("job");
-	$.ajax({ url : "jobsInfo?get=cancel&job=" + id, type : "GET",
+	$.ajax({ url : "jobsInfo?get=cancel&job=" + id, cache: false, type : "GET",
 	    success : function(json) {
 	    }
-	//complete: setTimeout(function() {poll()}, 5000),
-	//timeout: 2000
 	});
 });
 
@@ -62,16 +101,14 @@ function drawDependencies() {
 	$.each(jsonGlobal, function(i, job) {
 		$("#dependencies" + job.jobid).clearCanvas();
 		$("#dependencies" + job.jobid).attr("height", 10);
-		$("#dependencies" + job.jobid).attr("height", ($("#" + job.jobid).height()));
+		$("#dependencies" + job.jobid).attr("height", ($("#" + job.jobid).height()-$("#sum").height()-14));
 
-		//var colors = randomColors(job.groupvertices.length+1)
 		edgeCount = -1;
 		$.each(job.groupvertices, function(j, groupvertex) {
 			$.each(groupvertex.backwardEdges, function(k, edge) {
 				var y1 = ($("#" + edge.groupvertexid).offset().top - $("#dependencies"+ job.jobid).offset().top) + 15;
 				var y2 = ($("#" + groupvertex.groupvertexid).offset().top - $("#dependencies" + job.jobid).offset().top) + 15;
 				var cy1 = y1 + (y2 - y1) / 2;
-				//var cx1 = 70 - (edgeCount / groupvertex.numberofgroupmembers) * 140;
 				var cx1 = 0;
 				edgeCount++;
 
@@ -100,6 +137,9 @@ function drawDependencies() {
 
 }
 
+/*
+ * Creates and fills the global running jobs table
+ */
 function fillTable(table, json) {
 	$(table).html("");
 
@@ -111,13 +151,17 @@ function fillTable(table, json) {
 		var countFinished = 0;
 		var countCanceled = 0;
 		var countFailed = 0;
+		recentjobs.push(job.jobid);
+		poll(job.jobid);
+		if(parseInt(job.time) > timestamp)
+			timestamp = parseInt(job.time);
 		$(table).append(
-						"<h2>"+ job.jobname
-								+ " <span style=\"text-decoration: none\">(time: "+ formattedTimeFromTimestamp(job.time) + ")</span>"
+						"<h2 id=\""+job.jobid+"_title\">"+ job.jobname
+								+ " (time: "+ formattedTimeFromTimestamp(job.time) + ")"
 								+"</h2>"
-								+"<a class=\"cancel btn\" href=\"#\" job=\""+job.jobid+"\">cancel</a><br />");
+								+"<a id=\""+job.jobid+"_cancel\" class=\"cancel btn\" href=\"#\" job=\""+job.jobid+"\">cancel</a><br />");
 		var jobtable;
-		jobtable = "<table id=\""+job.jobid+"\">\
+		jobtable = "<table id=\""+job.jobid+"\" jobname=\""+job.jobname+"\">\
 						<tr>\
 							<th>Name</th>\
 							<th>Tasks</th>\
@@ -131,7 +175,8 @@ function fillTable(table, json) {
 		$.each(job.groupvertices, function(j, groupvertex) {
 			countGroups++;
 			countTasks += groupvertex.numberofgroupmembers;
-			countStarting += (groupvertex.CREATED + groupvertex.SCHEDULED + groupvertex.ASSIGNED + groupvertex.READY + groupvertex.STARTING);
+			starting = (groupvertex.CREATED + groupvertex.SCHEDULED + groupvertex.ASSIGNED + groupvertex.READY + groupvertex.STARTING);
+			countStarting += starting;
 			countRunning += groupvertex.RUNNING;
 			countFinished += groupvertex.FINISHING + groupvertex.FINISHED;
 			countCanceled += groupvertex.CANCELING + groupvertex.CANCELED;
@@ -142,21 +187,21 @@ function fillTable(table, json) {
 									+ groupvertex.groupvertexname
 								+ "</span>\
 							</td>\
-							<td>"+ groupvertex.numberofgroupmembers+ "</td>\
-							<td class=\"starting\"><div class=\"progressBar\"><div style=\"width:"
-							+ ((groupvertex.CREATED + groupvertex.SCHEDULED + groupvertex.ASSIGNED + groupvertex.READY + groupvertex.STARTING) / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
-							+ (groupvertex.CREATED + groupvertex.SCHEDULED + groupvertex.ASSIGNED + groupvertex.READY + groupvertex.STARTING)
+							<td class=\"nummembers\">"+ groupvertex.numberofgroupmembers+ "</td>\
+							<td class=\"starting\" val=\""+starting+"\"><div class=\"progressBar\"><div class=\"progressBarInner\" style=\"width:"
+							+ (starting / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
+							+ starting
 							+ "</div></div></td>\
-							<td class=\"running\"><div class=\"progressBar\"><div style=\"width:"+ (groupvertex.RUNNING / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
+							<td class=\"running\" val=\""+groupvertex.RUNNING+"\"><div class=\"progressBar\"><div class=\"progressBarInner\" style=\"width:"+ (groupvertex.RUNNING / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
 							+ groupvertex.RUNNING
 							+ "</div></div></td>\
-							<td class=\"finished\"><div class=\"progressBar\"><div style=\"width:" + ((groupvertex.FINISHING + groupvertex.FINISHED) / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
+							<td class=\"finished\" val=\""+(groupvertex.FINISHING + groupvertex.FINISHED)+"\"><div class=\"progressBar\"><div class=\"progressBarInner\" style=\"width:" + ((groupvertex.FINISHING + groupvertex.FINISHED) / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
 							+ (groupvertex.FINISHING + groupvertex.FINISHED)
 							+ "</div></div></td>\
-							<td class=\"canceled\"><div class=\"progressBar\"><div style=\"width:" + ((groupvertex.CANCELING + groupvertex.CANCELED) / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
+							<td class=\"canceled\" val=\""+(groupvertex.CANCELING + groupvertex.CANCELED)+"\"><div class=\"progressBar\"><div class=\"progressBarInner\" style=\"width:" + ((groupvertex.CANCELING + groupvertex.CANCELED) / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
 							+ (groupvertex.CANCELING + groupvertex.CANCELED)
 							+ "</div></div></td>\
-							<td class=\"failed\"><div class=\"progressBar\"><div style=\"width:"
+							<td class=\"failed\" val=\""+groupvertex.FAILED+"\"><div class=\"progressBar\"><div class=\"progressBarInner\" style=\"width:"
 							+ (groupvertex.FAILED / groupvertex.numberofgroupmembers) * widthProgressbar + "px\">"
 							+ groupvertex.FAILED
 							+ "</div></div></td>\
@@ -170,9 +215,9 @@ function fillTable(table, json) {
 							  		<th>instancetype</th>\
 							  	</tr>";
 							$.each(groupvertex.groupmembers, function(k, vertex) {
-								jobtable += "<tr>\
+								jobtable += "<tr id="+vertex.vertexid+" lastupdate=\""+job.time+"\">\
        								<td>"+ vertex.vertexname + "</td>\
-       								<td>"+ vertex.vertexstatus + "</td>\
+       								<td class=\"status\">"+ vertex.vertexstatus + "</td>\
        								<td>"+ vertex.vertexinstancename + "</td>\
        								<td>"+ vertex.vertexinstancetype + "</td>\
        							</tr>";
@@ -181,22 +226,22 @@ function fillTable(table, json) {
 						</td></tr>";
 						});
 
-		jobtable += "<tr>\
+		jobtable += "<tr id=\"sum\">\
 						<td colspan=\"2\" align=\"center\">Sum</td>\
-						<td>"+ countTasks + "</td>\
-						<td class=\"starting\"><div class=\"progressBar\"><div style=\"width:" + (countStarting / countTasks) * widthProgressbar + "px\">" 
+						<td class=\"nummebembers\">"+ countTasks + "</td>\
+						<td class=\"starting\" val=\""+countStarting+"\"><div class=\"progressBar\"><div style=\"width:" + (countStarting / countTasks) * widthProgressbar + "px\">" 
 							+ countStarting
 						+ "</div></div></td>\
-						<td class=\"running\"><div class=\"progressBar\"><div style=\"width:" + (countRunning / countTasks) * widthProgressbar + "px\">"
+						<td class=\"running\"  val=\""+countRunning+"\"><div class=\"progressBar\"><div style=\"width:" + (countRunning / countTasks) * widthProgressbar + "px\">"
 							+ countRunning
 						+ "</div></div></td>\
-						<td class=\"finished\"><div class=\"progressBar\"><div style=\"width:"+ (countFinished / countTasks) * widthProgressbar + "px\">"
+						<td class=\"finished\"  val=\""+countFinished+"\"><div class=\"progressBar\"><div style=\"width:"+ (countFinished / countTasks) * widthProgressbar + "px\">"
 							+ countFinished
 						+ "</div></div></td>\
-						<td class=\"canceled\"><div class=\"progressBar\"><div style=\"width:"+ (countCanceled / countTasks) * widthProgressbar + "px\">"
+						<td class=\"canceled\"  val=\""+countCanceled+"\"><div class=\"progressBar\"><div style=\"width:"+ (countCanceled / countTasks) * widthProgressbar + "px\">"
 							+ countCanceled
 						+ "</div></div></td>\
-						<td class=\"failed\"><div class=\"progressBar\"><div style=\"width:" + (countFailed / countTasks) * widthProgressbar + "px\">"
+						<td class=\"failed\"  val=\""+countFailed+"\"><div class=\"progressBar\"><div style=\"width:" + (countFailed / countTasks) * widthProgressbar + "px\">"
 							+ countFailed
 						+ "</div></div></td>\
 					</tr>";
@@ -204,33 +249,162 @@ function fillTable(table, json) {
 		jobtable += "</table>"
 		$(table).append(jobtable);
 		$("#" + job.jobid).prepend(
-						"<tr><td width=\"100\" rowspan=" + (countGroups * 2 + 2)+ ">\
-							<canvas id=\"dependencies" + job.jobid+ "\" height=\""+ ($("#" + job.jobid).height())+ "\" width=\"100\"></canvas>\
+						"<tr><td width=\"100\" rowspan=" + (countGroups * 2 + 2)+ " style=\"overflow:hidden\">\
+							<canvas id=\"dependencies" + job.jobid+ "\" height=\"10\" width=\"100\"></canvas>\
 						</td></tr>");
 	});
 	drawDependencies(json);
 
 }
 
+/*
+ * Updates the global running job table with newest events
+ */
+function updateTable(json) {
+	var pollfinished = false;
+	$.each(json.vertexevents , function(i, event) {
+
+		if(parseInt($("#"+event.vertexid).attr("lastupdate")) < event.timestamp)
+		{
+			// not very nice
+			var oldstatus = ""+$("#"+event.vertexid).children(".status").html();
+			if(oldstatus == "CREATED" ||  oldstatus == "SCHEDULED" ||oldstatus == "ASSIGNED" ||oldstatus == "READY" ||oldstatus == "STARTING")
+				oldstatus = "starting";
+			else if(oldstatus == "FINISHING")
+				oldstatus = "finished";
+			else if(oldstatus == "CANCELING")
+				oldstatus = "canceled";
+			
+			var newstate = event.newstate;
+			if(newstate == "CREATED" ||  newstate == "SCHEDULED" ||newstate == "ASSIGNED" ||newstate == "READY" ||newstate == "STARTING")
+				newstate = "starting";
+			else if(newstate == "FINISHING")
+				newstate = "finished";
+			else if(newstate == "CANCELING")
+				newstate = "canceled";
+			
+			// update detailed state
+			$("#"+event.vertexid).children(".status").html(event.newstate);
+			// update timestamp
+			$("#"+event.vertexid).attr("lastupdate", event.timestamp);
+			
+			var nummembers = parseInt($("#"+event.vertexid).parent().parent().parent().parent().prev().children(".nummembers").html());
+			var summembers = parseInt($("#sum").children(".nummebembers").html());
+			
+
+			if(oldstatus.toLowerCase() != newstate.toLowerCase()) {
+			
+				// adjust groupvertex
+				var oldcount = parseInt($("#"+event.vertexid).parent().parent().parent().parent().prev().children("."+oldstatus.toLowerCase()).attr("val"));
+				var oldcount2 = parseInt($("#"+event.vertexid).parent().parent().parent().parent().prev().children("."+newstate.toLowerCase()).attr("val"));
+				$("#"+event.vertexid).parent().parent().parent().parent().prev().children("."+oldstatus.toLowerCase()).attr("val", oldcount-1);
+				$("#"+event.vertexid).parent().parent().parent().parent().prev().children("."+newstate.toLowerCase()).attr("val", oldcount2+1);
+				
+				// adjust progressbars
+				$("#"+event.vertexid).parent().parent().parent().parent().prev().children("."+oldstatus.toLowerCase()).first().children().first().children().first().css("width", ((oldcount-1) / nummembers * widthProgressbar)+"px").html(oldcount-1);
+				$("#"+event.vertexid).parent().parent().parent().parent().prev().children("."+newstate.toLowerCase()).first().children().first().children().first().css("width", ((oldcount2+1) / nummembers * widthProgressbar)+"px").html(oldcount2+1);
+				
+				
+				// adjust sum
+				oldcount = parseInt($("#sum").children("."+oldstatus.toLowerCase()).attr("val"));
+				oldcount2 = parseInt($("#sum").children("."+newstate.toLowerCase()).attr("val"));
+				$("#sum").children("."+oldstatus.toLowerCase()).attr("val", oldcount-1);
+				$("#sum").children("."+newstate.toLowerCase()).attr("val", oldcount2+1);
+
+				// adjust progressbars
+				$("#sum").children("."+oldstatus.toLowerCase()).first().children().first().children().first().css("width", ((oldcount-1) / summembers * widthProgressbar)+"px").html(oldcount-1);
+				$("#sum").children("."+newstate.toLowerCase()).first().children().first().children().first().css("width", ((oldcount2+1) / summembers * widthProgressbar)+"px").html(oldcount2+1);
+				
+		}
+		}
+	});
+	
+	// handle jobevents
+	$.each(json.jobevents , function(i, event) {
+		if(event.newstate == "FINISHED" || event.newstate == "FAILED" || event.newstate == "CANCELED") {
+			// stop polling
+			pollfinished = true;
+			
+			// add to history
+			var jobjson = {};
+			jobjson.jobid = json.jobid;
+			jobjson.jobname = $("#"+json.jobid).attr("jobname");
+			jobjson.time = event.timestamp;
+			jobjson.status = event.newstate;
+			_fillTableArchive("#jobsArchive", jobjson, true);
+			
+			// delete table
+			$("#"+json.jobid).remove();
+			$("#"+json.jobid+"_title").remove();
+			$("#"+json.jobid+"_cancel").remove();
+			
+			// remove from internal list
+			for(var i in recentjobs){
+			    if(recentjobs[i]==json.jobid){
+			    	recentjobs.splice(i,1);
+			        break;
+			    }
+			}
+		}
+	});
+
+	if(!pollfinished)
+		 setTimeout(function() {poll(json.jobid)}, 2000);
+	else if(recentjobs.length == 0) {
+		// wait long enough for job to be completely removed on server side before new init
+		setTimeout(init, 5000);
+	}
+}
+
+var archive_finished = 0;
+var archive_failed = 0;
+var archive_canceled = 0;
+
+/*
+ * Creates job history table
+ */
 function fillTableArchive(table, json) {
 	$(table).html("");
-	var finished = 0;
-	var failed = 0;
-	var canceled = 0;
+	
+	$("#jobs-finished").html(archive_finished);
+	$("#jobs-failed").html(archive_failed);
+	$("#jobs-canceled").html(archive_canceled);
+	
 	$.each(json, function(i, job) {
-		$(table).append(
-				"<li><a href=\"analyze.html?job=" + job.jobid + "\">"
-						+ job.jobname + " (time: "
-						+ formattedTimeFromTimestamp(job.time)
-						+ ")</a></li>");
-		if (job.status == "FINISHED")
-			finished++;
-		if (job.status == "FAILED")
-			failed++;
-		if (job.status == "CANCELED")
-			canceled++;
+		_fillTableArchive(table, job, false)
 	});
-	$("#jobs-finished").html(finished);
-	$("#jobs-failed").html(failed);
-	$("#jobs-canceled").html(canceled);
+}
+
+/*
+ * Adds one row to job history table
+ */
+function _fillTableArchive(table, job, prepend) {
+	
+	// no duplicates
+	if($("#"+job.jobid+"_archive").length > 0) {
+		return false;
+	}
+	
+	if(prepend)
+		$(table).prepend(
+				"<li id=\""+job.jobid+"_archive\"><a href=\"/analyze.html?job=" + job.jobid + "\">"
+						+ job.jobname + " (time: "
+						+ formattedTimeFromTimestamp(parseInt(job.time))
+						+ ")</a></li>");
+	else
+		$(table).append(
+				"<li><a href=\"/analyze.html?job=" + job.jobid + "\">"
+						+ job.jobname + " (time: "
+						+ formattedTimeFromTimestamp(parseInt(job.time))
+						+ ")</a></li>");
+	if (job.status == "FINISHED")
+		archive_finished++;
+	if (job.status == "FAILED")
+		archive_failed++;
+	if (job.status == "CANCELED")
+		archive_canceled++;
+	
+	$("#jobs-finished").html(archive_finished);
+	$("#jobs-failed").html(archive_failed);
+	$("#jobs-canceled").html(archive_canceled);
 }


### PR DESCRIPTION
I added polling functionality to the webinterface of the jobmanager, so no more pressing of F5 is neccessary and bandwidth is saved. The script is polling for changes every 2secs.
I tested it on FF26, Chrome 31 and IE 11 (on windows).
