### PR TITLE
Fix bug in scala cogroup.flatMap

### DIFF
--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/CoGroupOperator.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/CoGroupOperator.scala
@@ -172,10 +172,14 @@ object CoGroupMacros {
       new CoGroupFunctionBase[LeftIn, RightIn, Out] {
         override def coGroup(leftRecords: JIterator[Record], rightRecords: JIterator[Record], out: Collector[Record]) = {
           val firstLeftRecord = leftIterator.initialize(leftRecords)
-          outputRecord.copyFrom(firstLeftRecord, leftForwardFrom, leftForwardTo)
-
           val firstRightRecord = rightIterator.initialize(rightRecords)
-          outputRecord.copyFrom(firstRightRecord, rightForwardFrom, rightForwardTo)
+
+          if (firstRightRecord != null) {
+            outputRecord.copyFrom(firstRightRecord, rightForwardFrom, rightForwardTo)
+          }
+          if (firstLeftRecord != null) {
+            outputRecord.copyFrom(firstLeftRecord, leftForwardFrom, leftForwardTo)
+          }
 
           val output = fun.splice.apply(leftIterator, rightIterator)
 


### PR DESCRIPTION
Did fail with null pointer exception when one of the inputs is empty.
