### PR TITLE
Set individual descriptions and keywords for the most important pages.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,8 +4,8 @@
 
 <meta charset="utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-<meta name="description" content="Stratosphere is a Open Source platform for next-generation Big Data Analytics. It combines the strengths of MapReduce/Hadoop with powerful programming abstractions in Java and Scala and a high performance runtime. Stratosphere has native support for iterations, incremental iterations, and programs consisting of large DAGs of operations." />
-<meta name="keywords" content="stratosphere, big data, data analytics, scalable information management, massively-parallel data procesing" />
+<meta name="description" content="{{ page.description }}" />
+<meta name="keywords" content="{{ page.keywords }}" />
 <title>Stratosphere &raquo; {{ page.title }}</title>
 <meta name="viewport" content="width=device-width" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,8 @@
 ---
 layout: blog_layout
 title: Blog 
+description: Blog posts and news around the Stratosphere Big Data Analytics platform.
+keywords: stratosphere, news, blog, big data, data analytics
 ---
 
 {% for post in paginator.posts %}

--- a/docs/0.4/index.markdown
+++ b/docs/0.4/index.markdown
@@ -1,6 +1,8 @@
 --- 
 layout: inner_docs_v04
 title: "Documentation (0.4)"
+description: Documentation for the Stratosphere Big Data Analytics platform.
+keywords: stratosphere, documentation, usage, help, setup, java, scala, program, howto, configuration, api, big data, data analytics
 ---
 
 ## Documentation (0.4)

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -1,6 +1,8 @@
 --- 
 layout: inner_with_sidebar
 title: Downloads
+description: Download the next-generation Big Data Analytics platform.
+keywords: stratosphere, download, source code, maven, vagrant, virtual machine, vm image, debian, install, setup, big data, data analytics
 links: 
   -       { anchor: bin, title: "Ready to Run Package" }
   -       { anchor: maven, title: "Maven Dependencies" }

--- a/faq/index.markdown
+++ b/faq/index.markdown
@@ -1,6 +1,8 @@
 --- 
 layout: inner_faq
 title: Frequently Asked Questions (FAQ)
+description: Frequently Asked Questions for the Stratosphere system.
+keywords: stratosphere, faq, question, problem, help, answers, howto, support, big data, data analytics
 questions: 
   - {section: "true", anchor: "usage", title: "Usage"}
   - {anchor: "usage_progress", title: "How do I assess the progress of a Stratosphere program?"}

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 --- 
 layout: default 
 title:  Next Generation Big Data Analytics Platform
+description: Stratosphere is an Open Source platform for massively parallel big data analytics. It features a rich set of operators, advanced, iterative data flows, an efficient runtime, and automatic program optimization.
+keywords: stratosphere, big data, data analytics, open source, hadoop, apache, massively-parallel data processing, map reduce
 ---
 
 <script src="{{ site.baseurl }}/js/jquery.scrollTo.min.js"></script>

--- a/project/funding/index.html
+++ b/project/funding/index.html
@@ -1,6 +1,8 @@
 --- 
 layout: inner_text
 title: Funding 
+description: Funding of the Stratosphere research project.
+keywords: stratosphere, research, funding, dfg, eit, ibm, hp, eu, big data, data analytics
 ---
 
 <p>Research and development in the context of Stratosphere is funded

--- a/project/people/index.html
+++ b/project/people/index.html
@@ -1,6 +1,8 @@
 ---
 layout: inner_with_sidebar
 title: People 
+description: People working on the Stratosphere research project.
+keywords: stratosphere, people, researcher, principal investigator, research project, lead, contributor, big data, data analytics
 links: 
   -       { anchor: speaker, title: "Speaker" }
   -       { anchor: pi, title: "Principal Investigators" }

--- a/project/publications/index.html
+++ b/project/publications/index.html
@@ -1,6 +1,8 @@
 ---
 layout: inner_with_sidebar
 title: Publications 
+description: Publications of the Stratosphere research project.
+keywords: stratosphere, research project, publication, conference, paper, research, impact, big data, data analytics
 links: 
   -       { anchor: 2013, title: 2013 }
   -       { anchor: 2012, title: 2012 }

--- a/quickstart/build.markdown
+++ b/quickstart/build.markdown
@@ -1,6 +1,8 @@
 --- 
 layout: inner_simple
 title: Quick Start - Build
+description: Learn to build Stratosphere.
+keywords: stratosphere, build, setup, howto, quickstart, big data, data analytics
 ---
 
 # Quickstart: Build Stratosphere

--- a/quickstart/index.markdown
+++ b/quickstart/index.markdown
@@ -1,6 +1,8 @@
 --- 
 layout: inner_simple
 title: Quick Start - Overview
+description: Getting started with a Stratosphere in just a few minutes.
+keywords: stratosphere, setup, java, scala, learn, howto, quickstart, big data, data analytics
 ---
 
 <div class="page-header text-center">

--- a/quickstart/java.html
+++ b/quickstart/java.html
@@ -1,6 +1,8 @@
 --- 
 layout: inner_with_sidebar
 title: "Quickstart: Java"
+description: Getting started with a Java Stratosphere program.
+keywords: stratosphere, java, program, howto, quickstart, big data, data analytics
 links:
   - {anchor: "requirements", title: "Requirements"}
   - {anchor: "create_project", title: "Create Project"}

--- a/quickstart/scala.html
+++ b/quickstart/scala.html
@@ -1,6 +1,8 @@
 --- 
 layout: inner_with_sidebar
 title: "Quick Start: Scala"
+description: Getting started with a Scala Stratosphere program.
+keywords: stratosphere, scala, program, howto, quickstart, big data, data analytics
 links:
   - {anchor: "requirements", title: "Requirements"}
   - {anchor: "create_project", title: "Create Project"}

--- a/quickstart/setup.html
+++ b/quickstart/setup.html
@@ -1,6 +1,8 @@
 ---
 layout: inner_with_sidebar
 title: "Quickstart: Setup"
+description: Setup Stratosphere in a few steps.
+keywords: stratosphere, setup, install, run, big data, data analytics
 links:
   - {anchor: "requirements", title: "Requirements"}
   - {anchor: "download", title: "Download"}


### PR DESCRIPTION
Extracted static meta description and keywords from layout.
Set individual descriptions and keywords for the most important pages.

Search engines (at least Google) penalize identical description and keyword meta data on multiple pages.
This should give us a better search result entries (title + description) and hopefully also better keyword coverage.

This PR updates PR #412 addresses issue #411
