### PR TITLE
Added broadcast variables support to the runtime.

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/RuntimeContext.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/RuntimeContext.java
@@ -12,6 +12,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.common.functions;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 import eu.stratosphere.api.common.accumulators.Accumulator;
@@ -19,6 +20,7 @@ import eu.stratosphere.api.common.accumulators.DoubleCounter;
 import eu.stratosphere.api.common.accumulators.Histogram;
 import eu.stratosphere.api.common.accumulators.IntCounter;
 import eu.stratosphere.api.common.accumulators.LongCounter;
+import eu.stratosphere.types.Record;
 
 /**
  *
@@ -30,6 +32,8 @@ public interface RuntimeContext {
 	int getNumberOfParallelSubtasks();
 
 	int getIndexOfThisSubtask();
+	
+	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Add this accumulator. Throws an exception if the counter is already
@@ -56,18 +60,23 @@ public interface RuntimeContext {
 	HashMap<String, Accumulator<?, ?>> getAllAccumulators();
 
 	/**
-	 * Convenience function to create a counter object for integers. This
-	 * creates an accumulator object for double values internally.
-	 * 
-	 * @param name
-	 * @return
+	 * Convenience function to create a counter object for integers.
 	 */
 	IntCounter getIntCounter(String name);
 
+	/**
+	 * Convenience function to create a counter object for longs.
+	 */
 	LongCounter getLongCounter(String name);
 
+	/**
+	 * Convenience function to create a counter object for doubles.
+	 */
 	DoubleCounter getDoubleCounter(String name);
 
+	/**
+	 * Convenience function to create a counter object for histograms.
+	 */
 	Histogram getHistogram(String name);
 
 //	/**
@@ -97,5 +106,18 @@ public interface RuntimeContext {
 //	 */
 //	<T> SimpleAccumulator<T> getSimpleAccumulator(String name,
 //			Class<? extends SimpleAccumulator<T>> accumulatorClass);
+	
+	// --------------------------------------------------------------------------------------------
 
+	/**
+	 * Sets the value of the broadcast variable identified by the given 
+	 * {@code name}.
+	 */
+	void setBroadcastVariable(String name, Collection<?> value);
+
+	/**
+	 * Returns the result bound to the broadcast variable identified by the 
+	 * given {@code name}.
+	 */
+	<RT> Collection<RT> getBroadcastVariable(String name);
 }

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
@@ -261,6 +261,9 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 			for (Operator c : this.input2) {
 				c.accept(visitor);
 			}
+			for (Operator c : this.broadcastInputs.values()) {
+				c.accept(visitor);
+			}
 			visitor.postVisit(this);
 		}
 	}

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/SingleInputOperator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/SingleInputOperator.java
@@ -163,6 +163,9 @@ public abstract class SingleInputOperator<T extends Function> extends AbstractUd
 			for (Operator c : this.input) {
 				c.accept(visitor);
 			}
+			for (Operator c : this.broadcastInputs.values()) {
+				c.accept(visitor);
+			}
 			visitor.postVisit(this);
 		}
 	}

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
@@ -93,7 +93,7 @@ public final class Record implements Value {
 	}
 	
 	/**
-	 * Creates a new record containing exactly to fields, which are the given values.
+	 * Creates a new record containing exactly two fields, which are the given values.
 	 * 
 	 * @param val1 The value for the first field.
 	 * @param val2 The value for the second field.

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeBroadcast.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeBroadcast.java
@@ -1,0 +1,80 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.example.java.record.kmeans;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.ProgramDescription;
+import eu.stratosphere.api.common.operators.BulkIteration;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.record.operators.MapOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.example.java.record.kmeans.udfs.FindNearestCenterBroadcast;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointInFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointOutFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.RecomputeClusterCenter;
+import eu.stratosphere.types.IntValue;
+
+
+public class KMeansIterativeBroadcast implements Program, ProgramDescription {
+	
+	@Override
+	public Plan getPlan(String... args) {
+		// parse job parameters
+		final int numSubTasks = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
+		final String dataPointInput = (args.length > 1 ? args[1] : "");
+		final String clusterInput = (args.length > 2 ? args[2] : "");
+		final String output = (args.length > 3 ? args[3] : "");
+		final int numIterations = (args.length > 4 ? Integer.parseInt(args[4]) : 1);
+
+		// create DataSourceContract for cluster center input
+		FileDataSource initialClusterPoints = new FileDataSource(new PointInFormat(), clusterInput, "Centers");
+		initialClusterPoints.setDegreeOfParallelism(1);
+		
+		BulkIteration iteration = new BulkIteration("K-Means Loop");
+		iteration.setInput(initialClusterPoints);
+		iteration.setMaximumNumberOfIterations(numIterations);
+		
+		// create DataSourceContract for data point input
+		FileDataSource dataPoints = new FileDataSource(new PointInFormat(), dataPointInput, "Data Points");
+
+		// create MapOperator for finding the nearest cluster centers
+		MapOperator findNearestClusterCenters = MapOperator.builder(new FindNearestCenterBroadcast())
+				.setBroadcastVariable("centers", iteration.getPartialSolution())
+				.input(dataPoints)
+				.name("Find Nearest Centers")
+				.build();
+
+		// create ReduceOperator for computing new cluster positions
+		ReduceOperator recomputeClusterCenter = ReduceOperator.builder(new RecomputeClusterCenter(), IntValue.class, 0)
+				.input(findNearestClusterCenters)
+				.name("Recompute Center Positions")
+				.build();
+		iteration.setNextPartialSolution(recomputeClusterCenter);
+
+		// create DataSinkContract for writing the new cluster positions
+		FileDataSink finalResult = new FileDataSink(new PointOutFormat(), output, iteration, "New Center Positions");
+
+		// return the PACT plan
+		Plan plan = new Plan(finalResult, "Iterative KMeans");
+		plan.setDefaultParallelism(numSubTasks);
+		return plan;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Parameters: <numSubStasks> <dataPoints> <clusterCenters> <output> <numIterations>";
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeWithParameterInputs.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeWithParameterInputs.java
@@ -1,0 +1,87 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.example.java.record.kmeans;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.ProgramDescription;
+import eu.stratosphere.api.common.operators.BulkIteration;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.record.operators.MapOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.example.java.record.kmeans.udfs.ComputeDistanceParameterized;
+import eu.stratosphere.example.java.record.kmeans.udfs.FindNearestCenter;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointInFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointOutFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.RecomputeClusterCenter;
+import eu.stratosphere.types.IntValue;
+
+
+public class KMeansIterativeWithParameterInputs implements Program, ProgramDescription {
+	
+	@Override
+	public Plan getPlan(String... args) {
+		// parse job parameters
+		final int numSubTasks = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
+		final String dataPointInput = (args.length > 1 ? args[1] : "");
+		final String clusterInput = (args.length > 2 ? args[2] : "");
+		final String output = (args.length > 3 ? args[3] : "");
+		final int numIterations = (args.length > 4 ? Integer.parseInt(args[4]) : 1);
+
+		// create DataSourceContract for cluster center input
+		FileDataSource initialClusterPoints = new FileDataSource(new PointInFormat(), clusterInput, "Centers");
+		initialClusterPoints.setDegreeOfParallelism(1);
+		
+		BulkIteration iteration = new BulkIteration("K-Means Loop");
+		iteration.setInput(initialClusterPoints);
+		iteration.setMaximumNumberOfIterations(numIterations);
+		
+		// create DataSourceContract for data point input
+		FileDataSource dataPoints = new FileDataSource(new PointInFormat(), dataPointInput, "Data Points");
+
+		// create CrossOperator for distance computation
+		MapOperator computeDistance = MapOperator.builder(new ComputeDistanceParameterized())
+				.setBroadcastVariable("centers", iteration.getPartialSolution())
+				.input(dataPoints)
+				.name("Compute Distances")
+				.build();
+
+		// create ReduceOperator for finding the nearest cluster centers
+		ReduceOperator findNearestClusterCenters = ReduceOperator.builder(new FindNearestCenter(), IntValue.class, 0)
+				.input(computeDistance)
+				.name("Find Nearest Centers")
+				.build();
+
+		// create ReduceOperator for computing new cluster positions
+		ReduceOperator recomputeClusterCenter = ReduceOperator.builder(new RecomputeClusterCenter(), IntValue.class, 0)
+				.input(findNearestClusterCenters)
+				.name("Recompute Center Positions")
+				.build();
+		iteration.setNextPartialSolution(recomputeClusterCenter);
+
+		// create DataSinkContract for writing the new cluster positions
+		FileDataSink finalResult = new FileDataSink(new PointOutFormat(), output, iteration, "New Center Positions");
+
+		// return the PACT plan
+		Plan plan = new Plan(finalResult, "Iterative KMeans");
+		plan.setDefaultParallelism(numSubTasks);
+		return plan;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Parameters: <numSubStasks> <dataPoints> <clusterCenters> <output> <numIterations>";
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansSingleStepBroadcast.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansSingleStepBroadcast.java
@@ -1,0 +1,86 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.example.java.record.kmeans;
+
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.ProgramDescription;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.record.operators.MapOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.example.java.record.kmeans.udfs.FindNearestCenterBroadcast;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointInFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointOutFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.RecomputeClusterCenter;
+import eu.stratosphere.types.IntValue;
+
+/**
+ * The K-Means cluster algorithm is well-known (see
+ * http://en.wikipedia.org/wiki/K-means_clustering). KMeansIteration is a PACT
+ * program that computes a single iteration of the k-means algorithm. The job
+ * has two inputs, a set of data points and a set of cluster centers. A Cross
+ * PACT is used to compute all distances from all centers to all points. A
+ * following Reduce PACT assigns each data point to the cluster center that is
+ * next to it. Finally, a second Reduce PACT compute the new locations of all
+ * cluster centers.
+ */
+public class KMeansSingleStepBroadcast implements Program, ProgramDescription {
+	
+
+	@Override
+	public Plan getPlan(String... args) {
+		// parse job parameters
+		int numSubTasks = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
+		String dataPointInput = (args.length > 1 ? args[1] : "");
+		String clusterInput = (args.length > 2 ? args[2] : "");
+		String output = (args.length > 3 ? args[3] : "");
+
+		// create DataSourceContract for data point input
+		FileDataSource dataPoints = new FileDataSource(new PointInFormat(), dataPointInput, "Data Points");
+		dataPoints.getCompilerHints().addUniqueField(0);
+
+		// create DataSourceContract for cluster center input
+		FileDataSource clusterPoints = new FileDataSource(new PointInFormat(), clusterInput, "Centers");
+		clusterPoints.setDegreeOfParallelism(1);
+		clusterPoints.getCompilerHints().addUniqueField(0);
+
+		// create CrossOperator for distance computation
+		MapOperator findNearestClusterCenters = MapOperator.builder(new FindNearestCenterBroadcast())
+			.setBroadcastVariable("centers", clusterPoints)
+			.input(dataPoints)
+			.name("Find Nearest Centers")
+			.build();
+
+		// create ReduceOperator for computing new cluster positions
+		ReduceOperator recomputeClusterCenter = ReduceOperator.builder(new RecomputeClusterCenter(), IntValue.class, 0)
+			.input(findNearestClusterCenters)
+			.name("Recompute Center Positions")
+			.build();
+
+		// create DataSinkContract for writing the new cluster positions
+		FileDataSink newClusterPoints = new FileDataSink(new PointOutFormat(), output, recomputeClusterCenter, "New Center Positions");
+
+		// return the PACT plan
+		Plan plan = new Plan(newClusterPoints, "KMeans Iteration");
+		plan.setDefaultParallelism(numSubTasks);
+		return plan;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Parameters: [numSubStasks] [dataPoints] [clusterCenters] [output]";
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/ComputeDistanceParameterized.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/ComputeDistanceParameterized.java
@@ -1,0 +1,70 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.record.kmeans.udfs;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation.ConstantFieldsFirst;
+import eu.stratosphere.api.java.record.functions.MapFunction;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.types.DoubleValue;
+import eu.stratosphere.types.IntValue;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.util.Collector;
+
+/**
+ * Cross PACT computes the distance of all data points to all cluster
+ * centers.
+ */
+@ConstantFieldsFirst({0,1})
+public class ComputeDistanceParameterized extends MapFunction implements Serializable {
+	private static final long serialVersionUID = 1L;
+	
+	private final DoubleValue distance = new DoubleValue();
+	
+	private Collection<Record> clusterCenters;
+	
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		this.clusterCenters = this.getRuntimeContext().getBroadcastVariable("centers");
+	}
+	
+	/**
+	 * Computes the distance of one data point to one cluster center.
+	 * 
+	 * Output Format:
+	 * 0: pointID
+	 * 1: pointVector
+	 * 2: clusterID
+	 * 3: distance
+	 */
+	@Override
+	public void map(Record dataPointRecord, Collector<Record> out) {
+		
+		CoordVector dataPoint = dataPointRecord.getField(1, CoordVector.class);
+		
+		for (Record clusterCenterRecord : this.clusterCenters) {
+			IntValue clusterCenterId = clusterCenterRecord.getField(0, IntValue.class);
+			CoordVector clusterPoint = clusterCenterRecord.getField(1, CoordVector.class);
+		
+			this.distance.setValue(dataPoint.computeEuclidianDistance(clusterPoint));
+			
+			// add cluster center id and distance to the data point record 
+			dataPointRecord.setField(2, clusterCenterId);
+			dataPointRecord.setField(3, this.distance);
+			
+			out.collect(dataPointRecord);
+		}
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/FindNearestCenterBroadcast.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/FindNearestCenterBroadcast.java
@@ -1,0 +1,81 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.record.kmeans.udfs;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation.ConstantFieldsFirst;
+import eu.stratosphere.api.java.record.functions.MapFunction;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.types.IntValue;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.util.Collector;
+
+/**
+ * Determines the closest cluster center for a data point.
+ */
+@ConstantFieldsFirst({0,1})
+public class FindNearestCenterBroadcast extends MapFunction implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	private final IntValue centerId = new IntValue();
+	private final CoordVector dataPoint = new CoordVector();
+	private final CoordVector centerPoint = new CoordVector();
+	private final IntValue one = new IntValue(1);
+
+	private final Record result = new Record(3);
+
+	private Collection<Record> clusterCenters;
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		this.clusterCenters = this.getRuntimeContext().getBroadcastVariable("centers");
+	}
+
+	/**
+	 * Computes a minimum aggregation on the distance of a data point to cluster centers.
+	 * 
+	 * Output Format:
+	 * 0: centerID
+	 * 1: pointVector
+	 * 2: constant(1) (to enable combinable average computation in the following reducer)
+	 */
+	@Override
+	public void map(Record dataPointRecord, Collector<Record> out) {
+		dataPointRecord.getFieldInto(1, this.dataPoint);
+		
+		double nearestDistance = Double.MAX_VALUE;
+
+		// check all cluster centers
+		for (Record clusterCenterRecord : this.clusterCenters) {
+			clusterCenterRecord.getFieldInto(1, this.centerPoint);
+
+			// compute distance
+			double distance = this.dataPoint.computeEuclidianDistance(this.centerPoint);
+			// update nearest cluster if necessary 
+			if (distance < nearestDistance) {
+				nearestDistance = distance;
+				clusterCenterRecord.getFieldInto(0, this.centerId);
+			}
+		}
+
+		// emit a new record with the center id and the data point. add a one to ease the
+		// implementation of the average function with a combiner
+		this.result.setField(0, this.centerId);
+		this.result.setField(1, this.dataPoint);
+		this.result.setField(2, this.one);
+
+		out.collect(this.result);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossOperator.java
@@ -14,7 +14,9 @@
 package eu.stratosphere.api.java.record.operators;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
@@ -62,6 +64,7 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 		super(builder.udf, builder.name);
 		setFirstInputs(builder.inputs1);
 		setSecondInputs(builder.inputs2);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 
@@ -83,6 +86,7 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 		/* The optional parameters */
 		private List<Operator> inputs1;
 		private List<Operator> inputs2;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		/**
@@ -94,6 +98,7 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 			this.udf = udf;
 			this.inputs1 = new ArrayList<Operator>();
 			this.inputs2 = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -139,6 +144,24 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 		 */
 		public Builder inputs2(List<Operator> inputs) {
 			this.inputs2 = inputs;
+			return this;
+		}
+		
+		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
 			return this;
 		}
 		

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithLargeOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithLargeOperator.java
@@ -76,6 +76,7 @@ public class CrossWithLargeOperator extends CrossOperator implements CrossWithLa
 		 * 
 		 * @return The created contract
 		 */
+		@Override
 		public CrossWithLargeOperator build() {
 			return new CrossWithLargeOperator(this);
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithSmallOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithSmallOperator.java
@@ -76,6 +76,7 @@ public class CrossWithSmallOperator extends CrossOperator implements CrossWithSm
 		 * 
 		 * @return The created contract
 		 */
+		@Override
 		public CrossWithSmallOperator build() {
 			return new CrossWithSmallOperator(this);
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/JoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/JoinOperator.java
@@ -14,7 +14,9 @@
 package eu.stratosphere.api.java.record.operators;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
@@ -76,6 +78,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 		this.keyTypes = builder.getKeyClassesArray();
 		setFirstInputs(builder.inputs1);
 		setSecondInputs(builder.inputs2);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 	@Override
@@ -99,6 +102,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 		/* The optional parameters */
 		private List<Operator> inputs1;
 		private List<Operator> inputs2;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		
@@ -120,6 +124,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 			this.keyColumns2.add(keyColumn2);
 			this.inputs1 = new ArrayList<Operator>();
 			this.inputs2 = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -135,6 +140,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 			this.keyColumns2 = new ArrayList<Integer>();
 			this.inputs1 = new ArrayList<Operator>();
 			this.inputs2 = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		private int[] getKeyColumnsArray1() {
@@ -219,9 +225,25 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 		}
 		
 		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
+			return this;
+		}
+		
+		/**
 		 * Sets the name of this contract.
-		 * 
-		 * @param name
 		 */
 		public Builder name(String name) {
 			this.name = name;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/MapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/MapOperator.java
@@ -14,7 +14,9 @@
 package eu.stratosphere.api.java.record.operators;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.base.MapOperatorBase;
@@ -60,6 +62,7 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 	protected MapOperator(Builder builder) {
 		super(builder.udf, builder.name);
 		setInputs(builder.inputs);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 
@@ -80,6 +83,7 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 		
 		/* The optional parameters */
 		private List<Operator> inputs;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		/**
@@ -90,6 +94,7 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 		private Builder(UserCodeWrapper<MapFunction> udf) {
 			this.udf = udf;
 			this.inputs = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -112,6 +117,24 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 		 */
 		public Builder inputs(List<Operator> inputs) {
 			this.inputs = inputs;
+			return this;
+		}
+		
+		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
 			return this;
 		}
 		

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/RecordOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/RecordOperator.java
@@ -14,7 +14,6 @@
 package eu.stratosphere.api.java.record.operators;
 
 import eu.stratosphere.types.Key;
-import eu.stratosphere.types.Record;
 
 /**
  * Interface marking contract classes to be referring to the {@link Record} data model.

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/ReduceOperator.java
@@ -18,7 +18,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.Ordering;
@@ -99,6 +101,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 		this.keyTypes = builder.getKeyClassesArray();
 		setInputs(builder.inputs);
 		setGroupOrder(builder.secondaryOrder);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -191,6 +194,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 		/* The optional parameters */
 		private Ordering secondaryOrder = null;
 		private List<Operator> inputs;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		/**
@@ -203,6 +207,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 			this.keyClasses = new ArrayList<Class<? extends Key>>();
 			this.keyColumns = new ArrayList<Integer>();
 			this.inputs = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -219,6 +224,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 			this.keyColumns = new ArrayList<Integer>();
 			this.keyColumns.add(keyColumn);
 			this.inputs = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		private int[] getKeyColumnsArray() {
@@ -276,6 +282,24 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 		 */
 		public Builder inputs(List<Operator> inputs) {
 			this.inputs = inputs;
+			return this;
+		}
+		
+		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
 			return this;
 		}
 		

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/util/TaskConfig.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/util/TaskConfig.java
@@ -73,6 +73,8 @@ public class TaskConfig {
 
 	private static final String NUM_INPUTS = "pact.in.num";
 	
+	private static final String NUM_BROADCAST_INPUTS = "pact.in.broadcast.num";
+	
 	/*
 	 * If one input has multiple predecessors (bag union), multiple
 	 * inputs must be grouped together. For a map or reduce there is
@@ -86,9 +88,15 @@ public class TaskConfig {
 	 */
 	private static final String INPUT_GROUP_SIZE_PREFIX = "pact.in.groupsize.";
 	
+	private static final String BROADCAST_INPUT_GROUP_SIZE_PREFIX = "pact.in.broadcast.groupsize.";
+	
 	private static final String INPUT_TYPE_SERIALIZER_FACTORY_PREFIX = "pact.in.serializer.";
 	
+	private static final String BROADCAST_INPUT_TYPE_SERIALIZER_FACTORY_PREFIX = "pact.in.broadcast.serializer.";
+	
 	private static final String INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX = "pact.in.serializer.param.";
+	
+	private static final String BROADCAST_INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX = "pact.in.broadcast.serializer.param.";
 	
 	private static final String INPUT_LOCAL_STRATEGY_PREFIX = "pact.in.strategy.";
 	
@@ -101,6 +109,8 @@ public class TaskConfig {
 	private static final String INPUT_REPLAYABLE_PREFIX = "pact.in.dam.replay.";
 	
 	private static final String INPUT_DAM_MEMORY_PREFIX = "pact.in.dam.mem.";
+	
+	private static final String BROADCAST_INPUT_NAME_PREFIX = "pact.in.broadcast.name.";
 	
 	
 	// -------------------------------------- Outputs ---------------------------------------------
@@ -384,9 +394,19 @@ public class TaskConfig {
 			INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR);
 	}
 	
+	public void setBroadcastInputSerializer(TypeSerializerFactory<?> factory, int inputNum) {
+		setTypeSerializerFactory(factory, BROADCAST_INPUT_TYPE_SERIALIZER_FACTORY_PREFIX + inputNum,
+			BROADCAST_INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR);
+	}
+	
 	public <T> TypeSerializerFactory<T> getInputSerializer(int inputNum, ClassLoader cl) {
 		return getTypeSerializerFactory(INPUT_TYPE_SERIALIZER_FACTORY_PREFIX + inputNum,
 			INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR, cl);
+	}
+	
+	public <T> TypeSerializerFactory<T> getBroadcastInputSerializer(int inputNum, ClassLoader cl) {
+		return getTypeSerializerFactory(BROADCAST_INPUT_TYPE_SERIALIZER_FACTORY_PREFIX + inputNum,
+			BROADCAST_INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR, cl);
 	}
 	
 	public void setInputComparator(TypeComparatorFactory<?> factory, int inputNum) {
@@ -403,14 +423,28 @@ public class TaskConfig {
 		return this.config.getInteger(NUM_INPUTS, 0);
 	}
 	
+	public int getNumBroadcastInputs() {
+		return this.config.getInteger(NUM_BROADCAST_INPUTS, 0);
+	}
+	
 	public int getGroupSize(int groupIndex) {
 		return this.config.getInteger(INPUT_GROUP_SIZE_PREFIX + groupIndex, -1);
+	}
+	
+	public int getBroadcastGroupSize(int groupIndex) {
+		return this.config.getInteger(BROADCAST_INPUT_GROUP_SIZE_PREFIX + groupIndex, -1);
 	}
 	
 	public void addInputToGroup(int groupIndex) {
 		final String grp = INPUT_GROUP_SIZE_PREFIX + groupIndex;
 		this.config.setInteger(grp, this.config.getInteger(grp, 0) + 1);
 		this.config.setInteger(NUM_INPUTS, this.config.getInteger(NUM_INPUTS, 0) + 1);
+	}
+	
+	public void addBroadcastInputToGroup(int groupIndex) {
+		final String grp = BROADCAST_INPUT_GROUP_SIZE_PREFIX + groupIndex;
+		this.config.setInteger(grp, this.config.getInteger(grp, 0) + 1);
+		this.config.setInteger(NUM_BROADCAST_INPUTS, this.config.getInteger(NUM_BROADCAST_INPUTS, 0) + 1);
 	}
 	
 	public void setInputAsynchronouslyMaterialized(int inputNum, boolean temp) {
@@ -435,6 +469,14 @@ public class TaskConfig {
 	
 	public long getInputMaterializationMemory(int inputNum) {
 		return this.config.getLong(INPUT_DAM_MEMORY_PREFIX + inputNum, -1);
+	}
+	
+	public void setBroadcastInputName(String name, int groupIndex) {
+		this.config.setString(BROADCAST_INPUT_NAME_PREFIX + groupIndex, name);
+	}
+	
+	public String getBroadcastInputName(int groupIndex) {
+		return this.config.getString(BROADCAST_INPUT_NAME_PREFIX + groupIndex, String.format("broadcastVar%04d", groupIndex));
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/udf/RuntimeUDFContext.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/udf/RuntimeUDFContext.java
@@ -12,6 +12,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.pact.runtime.udf;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 import eu.stratosphere.api.common.accumulators.Accumulator;
@@ -21,6 +22,7 @@ import eu.stratosphere.api.common.accumulators.Histogram;
 import eu.stratosphere.api.common.accumulators.IntCounter;
 import eu.stratosphere.api.common.accumulators.LongCounter;
 import eu.stratosphere.api.common.functions.RuntimeContext;
+import eu.stratosphere.types.Record;
 
 /**
  *
@@ -34,6 +36,8 @@ public class RuntimeUDFContext implements RuntimeContext {
 	private final int subtaskIndex;
 
 	private HashMap<String, Accumulator<?, ?>> accumulators = new HashMap<String, Accumulator<?, ?>>();
+
+	private HashMap<String, Collection<?>> broadcastVars = new HashMap<String, Collection<?>>();
 
 	public RuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex) {
 		this.name = name;
@@ -118,4 +122,23 @@ public class RuntimeUDFContext implements RuntimeContext {
 		return this.accumulators;
 	}
 
+	@Override
+	public void setBroadcastVariable(String name, Collection<?> value) {
+		if (this.broadcastVars.containsKey(name)) {
+			throw new UnsupportedOperationException("The broadcast variable '" + name
+					+ "' already exists and cannot be added.");
+		}
+		this.broadcastVars.put(name, value);
+	}
+
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <RT> Collection<RT> getBroadcastVariable(String name) {
+		if (!this.broadcastVars.containsKey(name)) {
+			throw new UnsupportedOperationException("Trying to access an unbound broadcast variable '" 
+					+ name + "'.");
+		}
+		return (Collection<RT>) this.broadcastVars.get(name);
+	}
 }

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/BroadcastVarsNepheleITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/BroadcastVarsNepheleITCase.java
@@ -1,0 +1,327 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.test.broadcastvars;
+
+import java.io.BufferedReader;
+import java.util.Collection;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+
+import eu.stratosphere.api.common.io.FileOutputFormat;
+import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
+import eu.stratosphere.api.common.typeutils.TypeSerializerFactory;
+import eu.stratosphere.api.java.record.functions.MapFunction;
+import eu.stratosphere.api.java.record.io.CsvInputFormat;
+import eu.stratosphere.api.java.record.io.CsvOutputFormat;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.nephele.io.DistributionPattern;
+import eu.stratosphere.nephele.io.channels.ChannelType;
+import eu.stratosphere.nephele.jobgraph.JobGraph;
+import eu.stratosphere.nephele.jobgraph.JobGraphDefinitionException;
+import eu.stratosphere.nephele.jobgraph.JobInputVertex;
+import eu.stratosphere.nephele.jobgraph.JobOutputVertex;
+import eu.stratosphere.nephele.jobgraph.JobTaskVertex;
+import eu.stratosphere.pact.runtime.plugable.pactrecord.RecordSerializerFactory;
+import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
+import eu.stratosphere.pact.runtime.task.DriverStrategy;
+import eu.stratosphere.pact.runtime.task.MapDriver;
+import eu.stratosphere.pact.runtime.task.RegularPactTask;
+import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
+import eu.stratosphere.pact.runtime.task.util.TaskConfig;
+import eu.stratosphere.test.iterative.nephele.JobGraphUtils;
+import eu.stratosphere.test.util.TestBase2;
+import eu.stratosphere.types.LongValue;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.util.Collector;
+
+public class BroadcastVarsNepheleITCase extends TestBase2 {
+
+	private static final long SEED_POINTS = 0xBADC0FFEEBEEFL;
+
+	private static final long SEED_MODELS = 0x39134230AFF32L;
+
+	private static final int NUM_POINTS = 10000;
+
+	private static final int NUM_MODELS = 42;
+
+	private static final int NUM_FEATURES = 3;
+
+	protected String pointsPath;
+
+	protected String modelsPath;
+
+	protected String resultPath;
+
+	public BroadcastVarsNepheleITCase() {
+		super(new Configuration());
+	}
+
+	public static final String getInputPoints(int numPoints, int numDimensions, long seed) {
+		if (numPoints < 1 || numPoints > 1000000)
+			throw new IllegalArgumentException();
+
+		Random r = new Random();
+
+		StringBuilder bld = new StringBuilder(3 * (1 + numDimensions) * numPoints);
+		for (int i = 1; i <= numPoints; i++) {
+			bld.append(i);
+			bld.append(' ');
+
+			r.setSeed(seed + 1000 * i);
+			for (int j = 1; j <= numDimensions; j++) {
+				bld.append(r.nextInt(1000));
+				bld.append(' ');
+			}
+			bld.append('\n');
+		}
+		return bld.toString();
+	}
+
+	public static final String getInputModels(int numModels, int numDimensions, long seed) {
+		if (numModels < 1 || numModels > 100)
+			throw new IllegalArgumentException();
+
+		Random r = new Random();
+
+		StringBuilder bld = new StringBuilder(3 * (1 + numDimensions) * numModels);
+		for (int i = 1; i <= numModels; i++) {
+			bld.append(i);
+			bld.append(' ');
+
+			r.setSeed(seed + 1000 * i);
+			for (int j = 1; j <= numDimensions; j++) {
+				bld.append(r.nextInt(100));
+				bld.append(' ');
+			}
+			bld.append('\n');
+		}
+		return bld.toString();
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		this.pointsPath = createTempFile("points.txt", getInputPoints(NUM_POINTS, NUM_FEATURES, SEED_POINTS));
+		this.modelsPath = createTempFile("models.txt", getInputModels(NUM_MODELS, NUM_FEATURES, SEED_MODELS));
+		this.resultPath = getTempFilePath("results");
+	}
+
+	@Override
+	protected JobGraph getJobGraph() throws Exception {
+		return createJobGraphV1(this.pointsPath, this.modelsPath, this.resultPath, 4);
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		final Random randPoints = new Random();
+		final Random randModels = new Random();
+		final Pattern p = Pattern.compile("(\\d+) (\\d+) (\\d+)");
+		
+		long [][] results = new long[NUM_POINTS][NUM_MODELS];
+		boolean [][] occurs = new boolean[NUM_POINTS][NUM_MODELS];
+		for (int i = 0; i < NUM_POINTS; i++) {
+			for (int j = 0; j < NUM_MODELS; j++) {
+				long actDotProd = 0;
+				randPoints.setSeed(SEED_POINTS + 1000 * (i+1));
+				randModels.setSeed(SEED_MODELS + 1000 * (j+1));
+				for (int z = 1; z <= NUM_FEATURES; z++) {
+					actDotProd += randPoints.nextInt(1000) * randModels.nextInt(100);
+				}
+				results[i][j] = actDotProd;
+				occurs[i][j] = false;
+			}
+		}
+
+		for (BufferedReader reader : getResultReader(this.resultPath)) {
+			String line = null;
+			while (null != (line = reader.readLine())) {
+				final Matcher m = p.matcher(line);
+				Assert.assertTrue(m.matches());
+
+				int modelId = Integer.parseInt(m.group(1));
+				int pointId = Integer.parseInt(m.group(2));
+				long expDotProd = Long.parseLong(m.group(3));
+
+				Assert.assertFalse("Dot product for record (" + pointId + ", " + modelId + ") occurs more than once", occurs[pointId-1][modelId-1]);
+				Assert.assertEquals(String.format("Bad product for (%04d, %04d)", pointId, modelId), expDotProd, results[pointId-1][modelId-1]);
+
+				occurs[pointId-1][modelId-1] = true;
+			}
+		}
+
+		for (int i = 0; i < NUM_POINTS; i++) {
+			for (int j = 0; j < NUM_MODELS; j++) {
+				Assert.assertTrue("Dot product for record (" + (i+1) + ", " + (j+1) + ") does not occur", occurs[i][j]);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// UDFs
+	// -------------------------------------------------------------------------------------------------------------
+
+	public static final class DotProducts extends MapFunction {
+
+		private final Record result = new Record(3);
+
+		private final LongValue lft = new LongValue();
+
+		private final LongValue rgt = new LongValue();
+
+		private final LongValue prd = new LongValue();
+
+		private Collection<Record> models;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			this.models = this.getRuntimeContext().getBroadcastVariable("models");
+		}
+
+		@Override
+		public void map(Record record, Collector<Record> out) throws Exception {
+
+			for (Record model : this.models) {
+				// compute dot product between model and pair
+				long product = 0;
+				for (int i = 1; i <= NUM_FEATURES; i++) {
+					product += model.getField(i, this.lft).getValue() * record.getField(i, this.rgt).getValue();
+				}
+				this.prd.setValue(product);
+
+				// construct result
+				this.result.copyFrom(model, new int[] { 0 }, new int[] { 0 });
+				this.result.copyFrom(record, new int[] { 0 }, new int[] { 1 });
+				this.result.setField(2, this.prd);
+
+				// emit result
+				out.collect(this.result);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Job vertex builder methods
+	// -------------------------------------------------------------------------------------------------------------
+
+	@SuppressWarnings("unchecked")
+	private static JobInputVertex createPointsInput(JobGraph jobGraph, String pointsPath, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		CsvInputFormat pointsInFormat = new CsvInputFormat(' ', LongValue.class, LongValue.class, LongValue.class, LongValue.class);
+		JobInputVertex pointsInput = JobGraphUtils.createInput(pointsInFormat, pointsPath, "Input[Points]", jobGraph, numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(pointsInput.getConfiguration());
+			taskConfig.addOutputShipStrategy(ShipStrategyType.FORWARD);
+			taskConfig.setOutputSerializer(serializer);
+		}
+
+		return pointsInput;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static JobInputVertex createModelsInput(JobGraph jobGraph, String pointsPath, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		CsvInputFormat modelsInFormat = new CsvInputFormat(' ', LongValue.class, LongValue.class, LongValue.class, LongValue.class);
+		JobInputVertex modelsInput = JobGraphUtils.createInput(modelsInFormat, pointsPath, "Input[Models]", jobGraph, numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(modelsInput.getConfiguration());
+			taskConfig.addOutputShipStrategy(ShipStrategyType.BROADCAST);
+			taskConfig.setOutputSerializer(serializer);
+		}
+
+		return modelsInput;
+	}
+
+	private static JobTaskVertex createMapper(JobGraph jobGraph, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		JobTaskVertex pointsInput = JobGraphUtils.createTask(RegularPactTask.class, "Map[DotProducts]", jobGraph, numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(pointsInput.getConfiguration());
+
+			taskConfig.setStubWrapper(new UserCodeClassWrapper<DotProducts>(DotProducts.class));
+			taskConfig.addOutputShipStrategy(ShipStrategyType.FORWARD);
+			taskConfig.setOutputSerializer(serializer);
+			taskConfig.setDriver(MapDriver.class);
+			taskConfig.setDriverStrategy(DriverStrategy.MAP);
+
+			taskConfig.addInputToGroup(0);
+			taskConfig.setInputLocalStrategy(0, LocalStrategy.NONE);
+			taskConfig.setInputSerializer(serializer, 0);
+
+			taskConfig.setBroadcastInputName("models", 0);
+			taskConfig.addBroadcastInputToGroup(0);
+			taskConfig.setBroadcastInputSerializer(serializer, 0);
+		}
+
+		return pointsInput;
+	}
+
+	private static JobOutputVertex createOutput(JobGraph jobGraph, String resultPath, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		JobOutputVertex output = JobGraphUtils.createFileOutput(jobGraph, "Output", numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(output.getConfiguration());
+			taskConfig.addInputToGroup(0);
+			taskConfig.setInputSerializer(serializer, 0);
+
+			taskConfig.setStubWrapper(new UserCodeClassWrapper<CsvOutputFormat>(CsvOutputFormat.class));
+			taskConfig.setStubParameter(FileOutputFormat.FILE_PARAMETER_KEY, resultPath);
+
+			Configuration stubConfig = taskConfig.getStubParameters();
+			stubConfig.setString(CsvOutputFormat.RECORD_DELIMITER_PARAMETER, "\n");
+			stubConfig.setString(CsvOutputFormat.FIELD_DELIMITER_PARAMETER, " ");
+			stubConfig.setClass(CsvOutputFormat.FIELD_TYPE_PARAMETER_PREFIX + 0, LongValue.class);
+			stubConfig.setInteger(CsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + 0, 0);
+			stubConfig.setClass(CsvOutputFormat.FIELD_TYPE_PARAMETER_PREFIX + 1, LongValue.class);
+			stubConfig.setInteger(CsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + 1, 1);
+			stubConfig.setClass(CsvOutputFormat.FIELD_TYPE_PARAMETER_PREFIX + 2, LongValue.class);
+			stubConfig.setInteger(CsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + 2, 2);
+			stubConfig.setInteger(CsvOutputFormat.NUM_FIELDS_PARAMETER, 3);
+		}
+
+		return output;
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Unified solution set and workset tail update
+	// -------------------------------------------------------------------------------------------------------------
+
+	private JobGraph createJobGraphV1(String pointsPath, String centersPath, String resultPath, int numSubTasks) throws JobGraphDefinitionException {
+
+		// -- init -------------------------------------------------------------------------------------------------
+		final TypeSerializerFactory<?> serializer = RecordSerializerFactory.get();
+
+		JobGraph jobGraph = new JobGraph("Distance Builder");
+
+		// -- vertices ---------------------------------------------------------------------------------------------
+		JobInputVertex points = createPointsInput(jobGraph, pointsPath, numSubTasks, serializer);
+		JobInputVertex models = createModelsInput(jobGraph, centersPath, numSubTasks, serializer);
+		JobTaskVertex mapper = createMapper(jobGraph, numSubTasks, serializer);
+		JobOutputVertex output = createOutput(jobGraph, resultPath, numSubTasks, serializer);
+
+		// -- edges ------------------------------------------------------------------------------------------------
+		JobGraphUtils.connect(points, mapper, ChannelType.NETWORK, DistributionPattern.POINTWISE);
+		JobGraphUtils.connect(models, mapper, ChannelType.NETWORK, DistributionPattern.BIPARTITE);
+		JobGraphUtils.connect(mapper, output, ChannelType.NETWORK, DistributionPattern.POINTWISE);
+
+		// -- instance sharing -------------------------------------------------------------------------------------
+		points.setVertexToShareInstancesWith(output);
+		models.setVertexToShareInstancesWith(output);
+		mapper.setVertexToShareInstancesWith(output);
+
+		return jobGraph;
+	}
+}


### PR DESCRIPTION
This is a first step towards realizing the functionality requested in issue #66 in the runtime, building upon the API proposed in PR #383.

Broadcast variables are realized as additional outputs attached to a `RegularPactTask`. Convenience methods for accessing the configuration information for broadcast input setup was added to the `TaskConfig`.

An integrated test case for with a simple hardwired JobGraph can be found in `BoradcastVarsNepheleITCase`.
