### PR TITLE
removeField method in Record class

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
@@ -426,28 +426,31 @@ public final class Record implements Value {
 	}
 	
 	/**
-	 * Removes the field at the given position.
+	 * Removes the field at the given position. 
+	 * <p>
+	 * This method should be used carefully. Be aware that as the field is actually removed from the record, the
+	 * total number of fields is modified, and all fields to the right of the field removed shift one position to
+	 * the left.
 	 * 
-	 * @param field The index number of the field to be removed.
+	 * @param fieldNum The position of the field to be removed, starting at zero.
 	 * @throws IndexOutOfBoundsException Thrown, when the position is not between 0 (inclusive) and the
 	 *                                   number of fields (exclusive).
 	 */
-	public void removeField(int field)
+	public void removeField(int fieldNum)
 	{
 		// range check
-		if (field < 0 || field >= this.numFields) {
+		if (fieldNum < 0 || fieldNum >= this.numFields) {
 			throw new IndexOutOfBoundsException();
 		}
 		int lastIndex = this.numFields - 1;		
 
-		if (field < lastIndex) {
-			int len = lastIndex - field;
-			System.arraycopy(this.offsets, field + 1, this.offsets, field, len);
-			System.arraycopy(this.lengths, field + 1, this.lengths, field, len);
-			System.arraycopy(this.readFields, field + 1, this.readFields, field, len);
-			System.arraycopy(this.writeFields, field + 1, this.writeFields, field, len);
-			//System.arraycopy(this.fields, field + 1, this.fields, field, len);
-			markModified(field);
+		if (fieldNum < lastIndex) {
+			int len = lastIndex - fieldNum;
+			System.arraycopy(this.offsets, fieldNum + 1, this.offsets, fieldNum, len);
+			System.arraycopy(this.lengths, fieldNum + 1, this.lengths, fieldNum, len);
+			System.arraycopy(this.readFields, fieldNum + 1, this.readFields, fieldNum, len);
+			System.arraycopy(this.writeFields, fieldNum + 1, this.writeFields, fieldNum, len);
+			markModified(fieldNum);
 		}
 		this.offsets[lastIndex] = NULL_INDICATOR_OFFSET;
 		this.lengths[lastIndex] = 0;

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
@@ -425,6 +425,37 @@ public final class Record implements Value {
 		return this.firstModifiedPos != Integer.MAX_VALUE;
 	}
 	
+	/**
+	 * Removes the field at the given position.
+	 * 
+	 * @param field The index number of the field to be removed.
+	 * @throws IndexOutOfBoundsException Thrown, when the position is not between 0 (inclusive) and the
+	 *                                   number of fields (exclusive).
+	 */
+	public void removeField(int field)
+	{
+		// range check
+		if (field < 0 || field >= this.numFields) {
+			throw new IndexOutOfBoundsException();
+		}
+		int lastIndex = this.numFields - 1;		
+
+		if (field < lastIndex) {
+			int len = lastIndex - field;
+			System.arraycopy(this.offsets, field + 1, this.offsets, field, len);
+			System.arraycopy(this.lengths, field + 1, this.lengths, field, len);
+			System.arraycopy(this.readFields, field + 1, this.readFields, field, len);
+			System.arraycopy(this.writeFields, field + 1, this.writeFields, field, len);
+			//System.arraycopy(this.fields, field + 1, this.fields, field, len);
+			markModified(field);
+		}
+		this.offsets[lastIndex] = NULL_INDICATOR_OFFSET;
+		this.lengths[lastIndex] = 0;
+		this.writeFields[lastIndex] = null;
+
+		setNumFields(lastIndex);
+	}
+	
 	public final boolean isNull(int fieldNum) {
 		// range check
 		if (fieldNum < 0 || fieldNum >= this.numFields) {

--- a/stratosphere-core/src/test/java/eu/stratosphere/types/RecordTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/types/RecordTest.java
@@ -163,46 +163,46 @@ public class RecordTest {
 //		}
 //	}
 
-//	@Test
-//	public void testRemoveField() {		
-//		Record record = null;
-//		int oldLen = 0;
-//
-//		// Create filled record and remove field from the middle
-//		record = new Record(this.origVal1, this.origVal2);
-//		record.addField(this.origVal3);
-//		record.removeField(1);
-//
-//		assertTrue(record.getNumFields() == 2);
-//
-//		StringValue recVal1 = record.getField(0, StringValue.class);
-//		IntValue recVal2 = record.getField(1, IntValue.class);
-//
-//		assertTrue(recVal1.getValue().equals(this.origVal1.getValue()));
-//		assertTrue(recVal2.getValue() == this.origVal3.getValue());
-//
-//		record = this.generateFilledDenseRecord(100);
-//
-//		// Remove field from the first position of the record
-//		oldLen = record.getNumFields();
-//		record.removeField(0);
-//		assertTrue(record.getNumFields() == oldLen - 1);
-//
-//		// Remove field from the end of the record
-//		oldLen = record.getNumFields();
-//		record.removeField(oldLen - 1);
-//		assertTrue(record.getNumFields() == oldLen - 1);
-//
-//		// Insert several random fields into the record
-//		record = this.generateFilledDenseRecord(100);
-//
-//		for (int i = 0; i < 100; i++) {
-//			oldLen = record.getNumFields();
-//			int pos = rand.nextInt(record.getNumFields());
-//			record.removeField(pos);
-//			assertTrue(record.getNumFields() == oldLen - 1);
-//		}
-//	}
+	@Test
+	public void testRemoveField() {		
+		Record record = null;
+		int oldLen = 0;
+
+		// Create filled record and remove field from the middle
+		record = new Record(this.origVal1, this.origVal2);
+		record.addField(this.origVal3);
+		record.removeField(1);
+
+		assertTrue(record.getNumFields() == 2);
+
+		StringValue recVal1 = record.getField(0, StringValue.class);
+		IntValue recVal2 = record.getField(1, IntValue.class);
+
+		assertTrue(recVal1.getValue().equals(this.origVal1.getValue()));
+		assertTrue(recVal2.getValue() == this.origVal3.getValue());
+
+		record = this.generateFilledDenseRecord(100);
+
+		// Remove field from the first position of the record
+		oldLen = record.getNumFields();
+		record.removeField(0);
+		assertTrue(record.getNumFields() == oldLen - 1);
+
+		// Remove field from the end of the record
+		oldLen = record.getNumFields();
+		record.removeField(oldLen - 1);
+		assertTrue(record.getNumFields() == oldLen - 1);
+
+		// Insert several random fields into the record
+		record = this.generateFilledDenseRecord(100);
+
+		for (int i = 0; i < 100; i++) {
+			oldLen = record.getNumFields();
+			int pos = this.rand.nextInt(record.getNumFields());
+			record.removeField(pos);
+			assertTrue(record.getNumFields() == oldLen - 1);
+		}
+	}
 
 //	@Test
 //	public void testProjectLong() {		


### PR DESCRIPTION
Is there a reason to not have a method that deletes (projects) a field from a Record?

The code of the method has been taken from an older version of Stratosphere, where it was commented out. I just needed to update it, and now it works with the current version.
