### PR TITLE
Provide Iterable instead of Iterator to updateVertex method of Spargel API 

### DIFF
--- a/stratosphere-addons/spargel/pom.xml
+++ b/stratosphere-addons/spargel/pom.xml
@@ -17,7 +17,6 @@
 	<packaging>jar</packaging>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-core</artifactId>
@@ -28,10 +27,23 @@
 			<artifactId>stratosphere-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-				<dependency>
+		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-clients</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>stratosphere-tests</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>stratosphere-tests</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
 		</dependency>
 	</dependencies>
 </project>

--- a/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/SpargelIteration.java
+++ b/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/SpargelIteration.java
@@ -29,7 +29,6 @@ import eu.stratosphere.util.Collector;
 import eu.stratosphere.util.InstantiationUtil;
 import eu.stratosphere.util.ReflectionUtil;
 
-
 public class SpargelIteration {
 	
 	private static final String DEFAULT_NAME = "<unnamed vertex-centric iteration>";

--- a/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/VertexUpdateFunction.java
+++ b/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/VertexUpdateFunction.java
@@ -35,7 +35,7 @@ public abstract class VertexUpdateFunction<VertexKey extends Key, VertexValue ex
 	//  Public API Methods
 	// --------------------------------------------------------------------------------------------
 	
-	public abstract void updateVertex(VertexKey vertexKey, VertexValue vertexValue, Iterator<Message> inMessages) throws Exception;
+	public abstract void updateVertex(VertexKey vertexKey, VertexValue vertexValue, Iterable<Message> inMessages) throws Exception;
 	
 	public void setup(Configuration config) throws Exception {}
 	

--- a/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/examples/connectedcomponents/SpargelConnectedComponents.java
+++ b/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/examples/connectedcomponents/SpargelConnectedComponents.java
@@ -72,10 +72,10 @@ public class SpargelConnectedComponents implements Program, ProgramDescription {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public void updateVertex(LongValue vertexKey, LongValue vertexValue, Iterator<LongValue> inMessages) {
+		public void updateVertex(LongValue vertexKey, LongValue vertexValue, Iterable<LongValue> inMessages) {
 			long min = Long.MAX_VALUE;
-			while (inMessages.hasNext()) {
-				long next = inMessages.next().getValue();
+			for (LongValue msg : inMessages) {
+				long next = msg.getValue();
 				min = Math.min(min, next);
 			}
 			if (min < vertexValue.getValue()) {

--- a/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/examples/connectedcomponents/SpargelConnectedComponents.java
+++ b/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/examples/connectedcomponents/SpargelConnectedComponents.java
@@ -46,7 +46,6 @@ public class SpargelConnectedComponents implements Program, ProgramDescription {
 		FileDataSource initialVertices = new FileDataSource(DuplicateLongInputFormat.class, verticesPath, "Vertices");
 		FileDataSource edges = new FileDataSource(new CsvInputFormat(' ', LongValue.class, LongValue.class), edgesPath, "Edges");
 		
-		// create DataSinkContract for writing the new cluster positions
 		FileDataSink result = new FileDataSink(CsvOutputFormat.class, resultPath, "Result");
 		CsvOutputFormat.configureRecordFormat(result)
 			.recordDelimiter('\n')

--- a/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/util/MessageIterator.java
+++ b/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/util/MessageIterator.java
@@ -17,8 +17,7 @@ import java.util.Iterator;
 import eu.stratosphere.types.Record;
 import eu.stratosphere.types.Value;
 
-
-public final class MessageIterator<Message extends Value> implements Iterator<Message> {
+public final class MessageIterator<Message extends Value> implements Iterator<Message>, Iterable<Message> {
 
 	private final Message instance;
 	private Iterator<Record> source;
@@ -45,5 +44,10 @@ public final class MessageIterator<Message extends Value> implements Iterator<Me
 	@Override
 	public final void remove() {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterator<Message> iterator() {
+		return this;
 	}
 }

--- a/stratosphere-addons/spargel/src/test/java/eu/stratosphere/test/spargel/SpargelConnectedComponentsITCase.java
+++ b/stratosphere-addons/spargel/src/test/java/eu/stratosphere/test/spargel/SpargelConnectedComponentsITCase.java
@@ -3,38 +3,12 @@ package eu.stratosphere.test.spargel;
 import eu.stratosphere.api.common.Plan;
 import eu.stratosphere.configuration.Configuration;
 import eu.stratosphere.spargel.java.examples.connectedcomponents.SpargelConnectedComponents;
-import eu.stratosphere.test.iterative.nephele.ConnectedComponentsNepheleITCase;
-import eu.stratosphere.test.util.TestBase2;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import eu.stratosphere.test.iterative.ConnectedComponentsITCase;
 
-import java.io.BufferedReader;
-import java.util.Collection;
-
-@RunWith(Parameterized.class)
-public class SpargelConnectedComponentsITCase extends TestBase2 {
-
-	private static final long SEED = 0xBADC0FFEEBEEFL;
-
-	private static final int NUM_VERTICES = 1000;
-
-	private static final int NUM_EDGES = 10000;
-
-	protected String verticesPath;
-
-	protected String edgesPath;
-
-	protected String resultPath;
+public class SpargelConnectedComponentsITCase extends ConnectedComponentsITCase {
 
 	public SpargelConnectedComponentsITCase(Configuration config) {
 		super(config);
-	}
-
-	@Override
-	protected void preSubmit() throws Exception {
-		verticesPath = createTempFile("vertices.txt", ConnectedComponentsNepheleITCase.getEnumeratingVertices(NUM_VERTICES));
-		edgesPath = createTempFile("edges.txt", ConnectedComponentsNepheleITCase.getRandomOddEvenEdges(NUM_EDGES, NUM_VERTICES, SEED));
-		resultPath = getTempFilePath("results");
 	}
 
 	@Override
@@ -45,20 +19,5 @@ public class SpargelConnectedComponentsITCase extends TestBase2 {
 
 		SpargelConnectedComponents cc = new SpargelConnectedComponents();
 		return cc.getPlan(params);
-	}
-
-	@Override
-	protected void postSubmit() throws Exception {
-		for (BufferedReader reader : getResultReader(resultPath)) {
-			ConnectedComponentsNepheleITCase.checkOddEvenResult(reader);
-		}
-	}
-
-	@Parameterized.Parameters
-	public static Collection<Object[]> getConfigurations() {
-		Configuration config1 = new Configuration();
-		config1.setInteger("ConnectedComponents#NumSubtasks", 4);
-		config1.setInteger("ConnectedComponents#NumIterations", 100);
-		return toParameterList(config1);
 	}
 }

--- a/stratosphere-addons/spargel/src/test/java/eu/stratosphere/test/spargel/SpargelConnectedComponentsITCase.java
+++ b/stratosphere-addons/spargel/src/test/java/eu/stratosphere/test/spargel/SpargelConnectedComponentsITCase.java
@@ -1,0 +1,64 @@
+package eu.stratosphere.test.spargel;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.spargel.java.examples.connectedcomponents.SpargelConnectedComponents;
+import eu.stratosphere.test.iterative.nephele.ConnectedComponentsNepheleITCase;
+import eu.stratosphere.test.util.TestBase2;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.BufferedReader;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class SpargelConnectedComponentsITCase extends TestBase2 {
+
+	private static final long SEED = 0xBADC0FFEEBEEFL;
+
+	private static final int NUM_VERTICES = 1000;
+
+	private static final int NUM_EDGES = 10000;
+
+	protected String verticesPath;
+
+	protected String edgesPath;
+
+	protected String resultPath;
+
+	public SpargelConnectedComponentsITCase(Configuration config) {
+		super(config);
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		verticesPath = createTempFile("vertices.txt", ConnectedComponentsNepheleITCase.getEnumeratingVertices(NUM_VERTICES));
+		edgesPath = createTempFile("edges.txt", ConnectedComponentsNepheleITCase.getRandomOddEvenEdges(NUM_EDGES, NUM_VERTICES, SEED));
+		resultPath = getTempFilePath("results");
+	}
+
+	@Override
+	protected Plan getTestJob() {
+		int dop = config.getInteger("ConnectedComponents#NumSubtasks", 1);
+		int maxIterations = config.getInteger("ConnectedComponents#NumIterations", 1);
+		String[] params = { String.valueOf(dop) , verticesPath, edgesPath, resultPath, String.valueOf(maxIterations) };
+
+		SpargelConnectedComponents cc = new SpargelConnectedComponents();
+		return cc.getPlan(params);
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		for (BufferedReader reader : getResultReader(resultPath)) {
+			ConnectedComponentsNepheleITCase.checkOddEvenResult(reader);
+		}
+	}
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> getConfigurations() {
+		Configuration config1 = new Configuration();
+		config1.setInteger("ConnectedComponents#NumSubtasks", 4);
+		config1.setInteger("ConnectedComponents#NumIterations", 100);
+		return toParameterList(config1);
+	}
+}

--- a/stratosphere-tests/pom.xml
+++ b/stratosphere-tests/pom.xml
@@ -17,69 +17,71 @@
 	<packaging>jar</packaging>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-compiler</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-runtime</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-clients</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.7</version>
 		</dependency>
-
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-java</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-scala</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-java-examples</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-scala-examples</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
 	</dependencies>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -95,7 +97,6 @@
 					<argLine>-Xmx1024m</argLine>
 				</configuration>
 			</plugin>
-
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>2.7</version>


### PR DESCRIPTION
This is issue #425.

I did this, before @StephanEwen and @sscdotopen discussed the `IterableIterator` in #425. Why do we want to expose the Iterator?
