### PR TITLE
Discussion: Allow Anonymous Classes for Functions in Plan

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/Program.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/Program.java
@@ -13,11 +13,13 @@
 
 package eu.stratosphere.api.common;
 
+import java.io.Serializable;
+
 /**
  * Interface for classes that represent Stratosphere programs. The program creates the {@link Plan}, which is the
  * instance of the program that will be executed.l
  */
-public interface Program {
+public interface Program extends Serializable {
 	
 	/**
 	 * The method which is invoked by the compiler to get the job that is then compiled into an

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/AbstractFunction.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/AbstractFunction.java
@@ -15,10 +15,12 @@ package eu.stratosphere.api.common.functions;
 
 import eu.stratosphere.configuration.Configuration;
 
+import java.io.Serializable;
+
 /**
  * An abstract stub implementation that does nothing when opened or closed.
  */
-public abstract class AbstractFunction implements Function {
+public abstract class AbstractFunction implements Function, Serializable {
 	
 	// --------------------------------------------------------------------------------------------
 	//  Runtime context access

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/AnonymousWordCount.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/AnonymousWordCount.java
@@ -1,0 +1,99 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.example.java.record.wordcount;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.ProgramDescription;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation.ConstantFields;
+import eu.stratosphere.api.java.record.functions.MapFunction;
+import eu.stratosphere.api.java.record.functions.ReduceFunction;
+import eu.stratosphere.api.java.record.io.CsvOutputFormat;
+import eu.stratosphere.api.java.record.io.TextInputFormat;
+import eu.stratosphere.api.java.record.operators.MapOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator.Combinable;
+import eu.stratosphere.client.LocalExecutor;
+import eu.stratosphere.nephele.client.JobExecutionResult;
+import eu.stratosphere.types.IntValue;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.types.StringValue;
+import eu.stratosphere.util.Collector;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.StringTokenizer;
+
+/**
+ * Implements a word count which takes the input file and counts the number of
+ * the occurrences of each word in the file.
+ */
+public class AnonymousWordCount implements Program {
+
+	@Override
+	public Plan getPlan(String... args) {
+		// parse job parameters
+		int defaultParallelism = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
+		String inputPath = (args.length > 1 ? args[1] : "");
+		String outputPath = (args.length > 2 ? args[2] : "");
+
+		FileDataSource source = new FileDataSource(new TextInputFormat(), inputPath);
+
+		MapOperator mapper = MapOperator.builder(new MapFunction() {
+			public void map(Record record, Collector<Record> collector) throws Exception {
+				String line = record.getField(0, StringValue.class).getValue();
+
+				// normalize the line
+				line = line.replaceAll("\\W+", " ").toLowerCase();
+
+				// tokenize the line
+				StringTokenizer tokenizer = new StringTokenizer(line);
+				while (tokenizer.hasMoreTokens()) {
+					String word = tokenizer.nextToken();
+
+					// we emit a (word, 1) pair
+					collector.collect(new Record(new StringValue(word), new IntValue(1)));
+				}
+			}
+		}).input(source).build();
+
+		ReduceOperator reducer = ReduceOperator.builder(new ReduceFunction() {
+			public void reduce(Iterator<Record> records, Collector<Record> collector) {
+				Record element = null;
+				int sum = 0;
+
+				while (records.hasNext()) {
+					element = records.next();
+					int cnt = element.getField(1, IntValue.class).getValue();
+					sum += cnt;
+				}
+
+				element.setField(1, new IntValue(sum));
+				collector.collect(element);
+			}
+		}).keyField(StringValue.class, 0).input(mapper).build();
+
+		FileDataSink out = new FileDataSink(new CsvOutputFormat(), outputPath, reducer, "Word Counts");
+		CsvOutputFormat.configureRecordFormat(out)
+			.recordDelimiter('\n')
+			.fieldDelimiter(' ')
+			.field(StringValue.class, 0)
+			.field(IntValue.class, 1);
+		
+		Plan plan = new Plan(out, "WordCount Example", defaultParallelism);
+		return plan;
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/WordCount.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/WordCount.java
@@ -55,7 +55,7 @@ public class WordCount implements Program, ProgramDescription {
 	 */
 	public static class TokenizeLine extends MapFunction implements Serializable {
 		private static final long serialVersionUID = 1L;
-		
+
 		@Override
 		public void map(Record record, Collector<Record> collector) {
 			// get the first field (as type StringValue) from the record
@@ -155,7 +155,7 @@ public class WordCount implements Program, ProgramDescription {
 		// This will execute the word-count embedded in a local context. replace this line by the commented
 		// succeeding line to send the job to a local installation or to a cluster for execution
 		JobExecutionResult result = LocalExecutor.execute(plan);
-		System.err.println("Total runtime: "+result.getNetRuntime());
+		System.err.println("Total runtime: " + result.getNetRuntime());
 //		PlanExecutor ex = new RemoteExecutor("localhost", 6123, "target/pact-examples-0.4-SNAPSHOT-WordCount.jar");
 //		ex.executePlan(plan);
 	}

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleRecordPrograms/WordCountITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleRecordPrograms/WordCountITCase.java
@@ -15,6 +15,7 @@ package eu.stratosphere.test.exampleRecordPrograms;
 
 import java.util.Collection;
 
+import eu.stratosphere.example.java.record.wordcount.AnonymousWordCount;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -180,7 +181,7 @@ public class WordCountITCase extends TestBase2 {
 
 	@Override
 	protected Plan getTestJob() {
-		WordCount wc = new WordCount();
+		AnonymousWordCount wc = new AnonymousWordCount();
 		return wc.getPlan(config.getString("WordCountTest#NumSubtasks", "1"),
 				textPath, resultPath);
 	}


### PR DESCRIPTION
**This PR is just for discussion.**

I've been thinking about our Java API and @StephanEwen is also prototyping a new API, which will bring the Java and Scala APIs closer together (among other things) by moving the Java API to the distributed DataSet abstraction instead of operator wiring (which is imho super important and will be a big plus).

With the upcoming support for Lambda expressions in Java 8, the upcoming API will be very concise. Since this will only be supported in Java 8, I assume that we will provide separate Java 6/7 and Java 8 APIs. For the Java 6/7 API, I thought that it might be worthwhile to support anonymous classes as function implementations.

`AnonymousWordCount` of this PR shows the default `WordCount` implementation with anonymous classes instead of static nested classes, which makes it imho more readable.

But there is a problem with serializability. With anonymous classes you can only implement a single interface (e.g. `MapFunction`), but we also need to implement `Serializable` (and make sure that everything is indeed serializable). For this discussion I've declared `AbstractFunction` as `Serializable` as a work around, but it has problems (see #147). One way around this would be to provide something like `SerializableMapFunction`. But I find it somehow ugly and inconvenient in terms of usability for newcomers.

So the questions for discussions are:
- What do you think about supporting this?
- What is the best solution if we want it?
