### PR TITLE
deploy spargel with dist

### DIFF
--- a/stratosphere-dist/pom.xml
+++ b/stratosphere-dist/pom.xml
@@ -55,6 +55,12 @@
 
 		<dependency>
 			<groupId>eu.stratosphere</groupId>
+			<artifactId>spargel</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
 			<artifactId>stratosphere-java-examples</artifactId>
 			<version>${project.version}</version>
 		</dependency>


### PR DESCRIPTION
We currently do not ship `spargel` with the stratosphere downloadable binary.
The spargel out-of-the-box experience is bad since the quickstart does not use `jar-with-dependencies` as the default packaging method (for some good reasons). But, users can not simply add `spargel` as a dependency to their project and run it on a cluster.

I suggest to include this PR to the 0.4.1 release https://github.com/stratosphere/stratosphere/issues/395
