### PR TITLE
Added broadcast variables support to the optimizer.

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
@@ -952,6 +952,7 @@ public class PactCompiler {
 
 			// first connect to the predecessors
 			n.setInputs(this.con2node);
+			n.setBroadcastInputs(this.con2node);
 
 			// read id again as it might have been incremented for newly created union nodes
 			this.id = n.getId() + 1;

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
@@ -14,6 +14,7 @@
 package eu.stratosphere.compiler.dag;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +33,7 @@ import eu.stratosphere.compiler.dataproperties.RequestedLocalProperties;
 import eu.stratosphere.compiler.operators.BinaryUnionOpDescriptor;
 import eu.stratosphere.compiler.operators.OperatorDescriptorDual;
 import eu.stratosphere.compiler.plan.Channel;
+import eu.stratosphere.compiler.plan.NamedChannel;
 import eu.stratosphere.compiler.plan.PlanNode;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 
@@ -110,6 +112,24 @@ public class BinaryUnionNode extends TwoInputNode {
 		// step down to all producer nodes and calculate alternative plans
 		final List<? extends PlanNode> subPlans1 = getFirstPredecessorNode().getAlternativePlans(estimator);
 		final List<? extends PlanNode> subPlans2 = getSecondPredecessorNode().getAlternativePlans(estimator);
+		
+		// calculate alternative sub-plans for broadcast inputs
+		final List<Set<? extends NamedChannel>> broadcastPlanChannels = new ArrayList<Set<? extends NamedChannel>>();
+		List<PactConnection> broadcastConnections = getBroadcastConnections();
+		List<String> broadcastConnectionNames = getBroadcastConnectionNames();
+		for (int i = 0; i < broadcastConnections.size(); i++ ) {
+			PactConnection broadcastConnection = broadcastConnections.get(i);
+			String broadcastConnectionName = broadcastConnectionNames.get(i);
+			List<PlanNode> broadcastPlanCandidates = broadcastConnection.getSource().getAlternativePlans(estimator);
+			// wrap the plan candidates in named channels 
+			HashSet<NamedChannel> broadcastChannels = new HashSet<NamedChannel>(broadcastPlanCandidates.size());
+			for (PlanNode plan: broadcastPlanCandidates) {
+				final NamedChannel c = new NamedChannel(broadcastConnectionName, plan);
+				c.setShipStrategy(ShipStrategyType.BROADCAST);
+				broadcastChannels.add(c);
+			}
+			broadcastPlanChannels.add(broadcastChannels);
+		}
 		
 		final ArrayList<PlanNode> outputPlans = new ArrayList<PlanNode>();
 		
@@ -241,7 +261,7 @@ public class BinaryUnionNode extends TwoInputNode {
 						}
 					}
 					
-					instantiate(operator, c1, c2, outputPlans, estimator, igps, igps, noLocalProps, noLocalProps);
+					instantiate(operator, c1, c2, broadcastPlanChannels, outputPlans, estimator, igps, igps, noLocalProps, noLocalProps);
 				}
 			}
 		}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
@@ -16,6 +16,7 @@ package eu.stratosphere.compiler.dag;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import eu.stratosphere.api.common.operators.BulkIteration;
 import eu.stratosphere.compiler.CompilerException;
@@ -32,6 +33,7 @@ import eu.stratosphere.compiler.operators.OperatorDescriptorSingle;
 import eu.stratosphere.compiler.plan.BulkIterationPlanNode;
 import eu.stratosphere.compiler.plan.BulkPartialSolutionPlanNode;
 import eu.stratosphere.compiler.plan.Channel;
+import eu.stratosphere.compiler.plan.NamedChannel;
 import eu.stratosphere.compiler.plan.PlanNode;
 import eu.stratosphere.util.Visitor;
 
@@ -186,8 +188,8 @@ public class BulkIterationNode extends SingleInputNode implements IterationNode 
 	}
 	
 	@Override
-	protected void instantiateCandidate(OperatorDescriptorSingle dps, Channel in, List<PlanNode> target,
-			CostEstimator estimator, RequestedGlobalProperties globPropsReq, RequestedLocalProperties locPropsReq)
+	protected void instantiateCandidate(OperatorDescriptorSingle dps, Channel in, List<Set<? extends NamedChannel>> broadcastPlanChannels, 
+			List<PlanNode> target, CostEstimator estimator, RequestedGlobalProperties globPropsReq, RequestedLocalProperties locPropsReq)
 	{
 		// NOTES ON THE ENUMERATION OF THE STEP FUNCTION PLANS:
 		// Whenever we instantiate the iteration, we enumerate new candidates for the step function.

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/OptimizerNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/OptimizerNode.java
@@ -55,6 +55,8 @@ public abstract class OptimizerNode implements Visitable<OptimizerNode>, Estimat
 
 	private final Operator pactContract; // The contract (Reduce / Match / DataSource / ...)
 	
+	private List<String> broadcastConnectionNames = new ArrayList<String>(); // the broadcast inputs names of this node
+	
 	private List<PactConnection> broadcastConnections = new ArrayList<PactConnection>(); // the broadcast inputs of this node
 	
 	private List<PactConnection> outgoingConnections; // The links to succeeding nodes
@@ -195,7 +197,7 @@ public abstract class OptimizerNode implements Visitable<OptimizerNode>, Estimat
 		for (Map.Entry<String, Operator> input: operator.getBroadcastInputs().entrySet()) {
 			OptimizerNode predecessor = operatorToNode.get(input.getValue());
 			PactConnection connection = new PactConnection(predecessor, this, ShipStrategyType.BROADCAST, predecessor.getMaxDepth() + 1);
-			addBroadcastConnection(connection);
+			addBroadcastConnection(input.getKey(), connection);
 			predecessor.addOutgoingConnection(connection);
 		}
 	}
@@ -316,18 +318,25 @@ public abstract class OptimizerNode implements Visitable<OptimizerNode>, Estimat
 	}
 
 	/**
-	 * Adds a new broadcast connection to this node.
+	 * Adds the broadcast connection identified by the given {@code name} to this node.
 	 * 
 	 * @param broadcastConnection
 	 *        The connection to add.
 	 */
-	public void addBroadcastConnection(PactConnection broadcastConnection) {
+	public void addBroadcastConnection(String name, PactConnection broadcastConnection) {
+		this.broadcastConnectionNames.add(name);
 		this.broadcastConnections.add(broadcastConnection);
 	}
 
 	/**
+	 * Return the list of names associated with broadcast inputs for this node.
+	 */
+	public List<String> getBroadcastConnectionNames() {
+		return this.broadcastConnectionNames;
+	}
+
+	/**
 	 * Return the list of inputs associated with broadcast variables for this node.
-	 * @return
 	 */
 	public List<PactConnection> getBroadcastConnections() {
 		return this.broadcastConnections;

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/SingleInputNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/SingleInputNode.java
@@ -230,6 +230,10 @@ public abstract class SingleInputNode extends OptimizerNode {
 			}
 		}
 		this.inConn.setInterestingProperties(props);
+		
+		for (PactConnection conn : getBroadcastConnections()) {
+			conn.setInterestingProperties(new InterestingProperties());
+		}
 	}
 	
 
@@ -243,7 +247,12 @@ public abstract class SingleInputNode extends OptimizerNode {
 		// calculate alternative sub-plans for predecessor
 		final List<? extends PlanNode> subPlans = getPredecessorNode().getAlternativePlans(estimator);
 		final Set<RequestedGlobalProperties> intGlobal = this.inConn.getInterestingProperties().getGlobalProperties();
-		
+		// calculate alternative sub-plans for broadcast inputs
+		final List<List<? extends PlanNode>> broadcastPlans = new ArrayList<List<? extends PlanNode>>();
+		for (PactConnection broadcastConnection: getBroadcastConnections()) {
+			broadcastPlans.add(broadcastConnection.getSource().getAlternativePlans(estimator));
+		}
+
 		final RequestedGlobalProperties[] allValidGlobals;
 		{
 			Set<RequestedGlobalProperties> pairs = new HashSet<RequestedGlobalProperties>();
@@ -470,6 +479,9 @@ public abstract class SingleInputNode extends OptimizerNode {
 				getPredecessorNode().accept(visitor);
 			} else {
 				throw new CompilerException();
+			}
+			for (PactConnection connection : getBroadcastConnections()) {
+				connection.getSource().accept(visitor);
 			}
 			visitor.postVisit(this);
 		}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/SingleInputNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/SingleInputNode.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
+
 import eu.stratosphere.api.common.operators.CompilerHints;
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.SingleInputOperator;
@@ -36,6 +38,7 @@ import eu.stratosphere.compiler.dataproperties.RequestedGlobalProperties;
 import eu.stratosphere.compiler.dataproperties.RequestedLocalProperties;
 import eu.stratosphere.compiler.operators.OperatorDescriptorSingle;
 import eu.stratosphere.compiler.plan.Channel;
+import eu.stratosphere.compiler.plan.NamedChannel;
 import eu.stratosphere.compiler.plan.PlanNode;
 import eu.stratosphere.compiler.plan.SingleInputPlanNode;
 import eu.stratosphere.compiler.util.NoOpUnaryUdfOp;
@@ -247,10 +250,23 @@ public abstract class SingleInputNode extends OptimizerNode {
 		// calculate alternative sub-plans for predecessor
 		final List<? extends PlanNode> subPlans = getPredecessorNode().getAlternativePlans(estimator);
 		final Set<RequestedGlobalProperties> intGlobal = this.inConn.getInterestingProperties().getGlobalProperties();
+		
 		// calculate alternative sub-plans for broadcast inputs
-		final List<List<? extends PlanNode>> broadcastPlans = new ArrayList<List<? extends PlanNode>>();
-		for (PactConnection broadcastConnection: getBroadcastConnections()) {
-			broadcastPlans.add(broadcastConnection.getSource().getAlternativePlans(estimator));
+		final List<Set<? extends NamedChannel>> broadcastPlanChannels = new ArrayList<Set<? extends NamedChannel>>();
+		List<PactConnection> broadcastConnections = getBroadcastConnections();
+		List<String> broadcastConnectionNames = getBroadcastConnectionNames();
+		for (int i = 0; i < broadcastConnections.size(); i++ ) {
+			PactConnection broadcastConnection = broadcastConnections.get(i);
+			String broadcastConnectionName = broadcastConnectionNames.get(i);
+			List<PlanNode> broadcastPlanCandidates = broadcastConnection.getSource().getAlternativePlans(estimator);
+			// wrap the plan candidates in named channels 
+			HashSet<NamedChannel> broadcastChannels = new HashSet<NamedChannel>(broadcastPlanCandidates.size());
+			for (PlanNode plan: broadcastPlanCandidates) {
+				final NamedChannel c = new NamedChannel(broadcastConnectionName, plan);
+				c.setShipStrategy(ShipStrategyType.BROADCAST);
+				broadcastChannels.add(c);
+			}
+			broadcastPlanChannels.add(broadcastChannels);
 		}
 
 		final RequestedGlobalProperties[] allValidGlobals;
@@ -297,7 +313,7 @@ public abstract class SingleInputNode extends OptimizerNode {
 					// requested properties
 					for (RequestedGlobalProperties rgps: allValidGlobals) {
 						if (rgps.isMetBy(c.getGlobalProperties())) {
-							addLocalCandidates(c, igps, outputPlans, estimator);
+							addLocalCandidates(c, broadcastPlanChannels, igps, outputPlans, estimator);
 							break;
 						}
 					}
@@ -320,7 +336,7 @@ public abstract class SingleInputNode extends OptimizerNode {
 				// check whether we meet any of the accepted properties
 				for (RequestedGlobalProperties rgps: allValidGlobals) {
 					if (rgps.isMetBy(c.getGlobalProperties())) {
-						addLocalCandidates(c, rgps, outputPlans, estimator);
+						addLocalCandidates(c, broadcastPlanChannels, rgps, outputPlans, estimator);
 						break;
 					}
 				}
@@ -338,7 +354,7 @@ public abstract class SingleInputNode extends OptimizerNode {
 		return outputPlans;
 	}
 	
-	protected void addLocalCandidates(Channel template, RequestedGlobalProperties rgps,
+	protected void addLocalCandidates(Channel template, List<Set<? extends NamedChannel>> broadcastPlanChannels, RequestedGlobalProperties rgps,
 			List<PlanNode> target, CostEstimator estimator)
 	{
 		final LocalProperties lp = template.getLocalPropertiesAfterShippingOnly();
@@ -354,33 +370,36 @@ public abstract class SingleInputNode extends OptimizerNode {
 			for (OperatorDescriptorSingle dps: getPossibleProperties()) {
 				for (RequestedLocalProperties ilps : dps.getPossibleLocalProperties()) {
 					if (ilps.isMetBy(in.getLocalProperties())) {
-						instantiateCandidate(dps, in, target, estimator, rgps, ilp);
+						instantiateCandidate(dps, in, broadcastPlanChannels, target, estimator, rgps, ilp);
 						break;
 					}
 				}
 			}
 		}
 	}
-	
-	protected void instantiateCandidate(OperatorDescriptorSingle dps, Channel in, List<PlanNode> target,
-			CostEstimator estimator, RequestedGlobalProperties globPropsReq, RequestedLocalProperties locPropsReq)
+
+	protected void instantiateCandidate(OperatorDescriptorSingle dps, Channel in, List<Set<? extends NamedChannel>> broadcastPlanChannels,
+			List<PlanNode> target, CostEstimator estimator, RequestedGlobalProperties globPropsReq, RequestedLocalProperties locPropsReq)
 	{
-		final SingleInputPlanNode node = dps.instantiate(in, this);
-		
-		// compute how the strategy affects the properties
-		GlobalProperties gProps = in.getGlobalProperties().clone();
-		LocalProperties lProps = in.getLocalProperties().clone();
-		gProps = dps.computeGlobalProperties(gProps);
-		lProps = dps.computeLocalProperties(lProps);
-		
-		// filter by the user code field copies
-		gProps = gProps.filterByNodesConstantSet(this, 0);
-		lProps = lProps.filterByNodesConstantSet(this, 0);
-		
-		// apply
-		node.initProperties(gProps, lProps);
-		node.updatePropertiesWithUniqueSets(getUniqueFields());
-		target.add(node);
+		for (List<NamedChannel> broadcastChannelsCombination: Sets.cartesianProduct(broadcastPlanChannels)) {
+			final SingleInputPlanNode node = dps.instantiate(in, this);
+			node.setBroadcastInputs(broadcastChannelsCombination);
+			
+			// compute how the strategy affects the properties
+			GlobalProperties gProps = in.getGlobalProperties().clone();
+			LocalProperties lProps = in.getLocalProperties().clone();
+			gProps = dps.computeGlobalProperties(gProps);
+			lProps = dps.computeLocalProperties(lProps);
+			
+			// filter by the user code field copies
+			gProps = gProps.filterByNodesConstantSet(this, 0);
+			lProps = lProps.filterByNodesConstantSet(this, 0);
+			
+			// apply
+			node.initProperties(gProps, lProps);
+			node.updatePropertiesWithUniqueSets(getUniqueFields());
+			target.add(node);
+		}
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/WorksetIterationNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/WorksetIterationNode.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import eu.stratosphere.api.common.operators.DeltaIteration;
 import eu.stratosphere.api.common.operators.util.FieldList;
@@ -34,6 +35,7 @@ import eu.stratosphere.compiler.operators.OperatorDescriptorDual;
 import eu.stratosphere.compiler.operators.SolutionSetDeltaOperator;
 import eu.stratosphere.compiler.plan.Channel;
 import eu.stratosphere.compiler.plan.DualInputPlanNode;
+import eu.stratosphere.compiler.plan.NamedChannel;
 import eu.stratosphere.compiler.plan.PlanNode;
 import eu.stratosphere.compiler.plan.SingleInputPlanNode;
 import eu.stratosphere.compiler.plan.SolutionSetPlanNode;
@@ -271,7 +273,7 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 	
 	@Override
 	protected void instantiate(OperatorDescriptorDual operator, Channel solutionSetIn, Channel worksetIn,
-			List<PlanNode> target, CostEstimator estimator,
+			List<Set<? extends NamedChannel>> broadcastPlanChannels, List<PlanNode> target, CostEstimator estimator,
 			RequestedGlobalProperties globPropsReqSolutionSet,RequestedGlobalProperties globPropsReqWorkset,
 			RequestedLocalProperties locPropsReqSolutionSet, RequestedLocalProperties locPropsReqWorkset)
 	{

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/DualInputPlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/DualInputPlanNode.java
@@ -215,6 +215,9 @@ public class DualInputPlanNode extends PlanNode {
 		if (visitor.preVisit(this)) {
 			this.input1.getSource().accept(visitor);
 			this.input2.getSource().accept(visitor);
+			for (Channel broadcastInput : this.broadcastInputs) {
+				broadcastInput.getSource().accept(visitor);
+			}
 			visitor.postVisit(this);
 		}
 	}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/NamedChannel.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/NamedChannel.java
@@ -1,0 +1,27 @@
+package eu.stratosphere.compiler.plan;
+
+import eu.stratosphere.compiler.dag.TempMode;
+
+public class NamedChannel extends Channel {
+
+	private final String name;
+
+	/**
+	 * Initializes NamedChannel.
+	 * 
+	 * @param sourceNode
+	 */
+	public NamedChannel(String name, PlanNode sourceNode) {
+		super(sourceNode);
+		this.name = name;
+	}
+
+	public NamedChannel(String name, PlanNode sourceNode, TempMode tempMode) {
+		super(sourceNode, tempMode);
+		this.name = name;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
@@ -47,6 +47,8 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	
 	protected final List<Channel> outChannels;
 	
+	protected List<Channel> broadcastInputs;
+	
 	private final String nodeName; 
 	
 	private final DriverStrategy driverStrategy;	// The local strategy (sorting / hashing, ...)
@@ -69,6 +71,7 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	
 	public PlanNode(OptimizerNode template, String nodeName, DriverStrategy strategy) {
 		this.outChannels = new ArrayList<Channel>(2);
+		this.broadcastInputs = new ArrayList<Channel>();
 		this.template = template;
 		this.nodeName = nodeName;
 		this.driverStrategy = strategy;
@@ -228,7 +231,25 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	
 	public abstract Iterator<Channel> getInputs();
 	
+	@Override
 	public abstract Iterator<PlanNode> getPredecessors();
+	
+	/**
+	 * Sets a list of all broadcast inputs attached to this node.
+	 */
+	public void setBroadcastInputs(List<Channel> broadcastInputs) {
+		if (broadcastInputs == null) {
+			return;
+		}
+		this.broadcastInputs = broadcastInputs;
+	}
+	
+	/**
+	 * Gets a list of all broadcast inputs attached to this node.
+	 */
+	public List<Channel> getBroadcastInputs() {
+		return this.broadcastInputs;
+	}
 	
 	/**
 	 * Adds a channel to a successor node to this node.

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
@@ -47,7 +47,7 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	
 	protected final List<Channel> outChannels;
 	
-	protected List<Channel> broadcastInputs;
+	protected List<NamedChannel> broadcastInputs;
 	
 	private final String nodeName; 
 	
@@ -71,7 +71,7 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	
 	public PlanNode(OptimizerNode template, String nodeName, DriverStrategy strategy) {
 		this.outChannels = new ArrayList<Channel>(2);
-		this.broadcastInputs = new ArrayList<Channel>();
+		this.broadcastInputs = new ArrayList<NamedChannel>();
 		this.template = template;
 		this.nodeName = nodeName;
 		this.driverStrategy = strategy;
@@ -237,7 +237,7 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	/**
 	 * Sets a list of all broadcast inputs attached to this node.
 	 */
-	public void setBroadcastInputs(List<Channel> broadcastInputs) {
+	public void setBroadcastInputs(List<NamedChannel> broadcastInputs) {
 		if (broadcastInputs == null) {
 			return;
 		}
@@ -247,7 +247,7 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	/**
 	 * Gets a list of all broadcast inputs attached to this node.
 	 */
-	public List<Channel> getBroadcastInputs() {
+	public List<NamedChannel> getBroadcastInputs() {
 		return this.broadcastInputs;
 	}
 	

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/SingleInputPlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/SingleInputPlanNode.java
@@ -13,6 +13,7 @@
 
 package eu.stratosphere.compiler.plan;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -135,6 +136,9 @@ public class SingleInputPlanNode extends PlanNode {
 	public void accept(Visitor<PlanNode> visitor) {
 		if (visitor.preVisit(this)) {
 			this.input.getSource().accept(visitor);
+			for (Channel broadcastInput : this.broadcastInputs) {
+				broadcastInput.getSource().accept(visitor);
+			}
 			visitor.postVisit(this);
 		}
 	}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plantranslate/NepheleJobGraphGenerator.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plantranslate/NepheleJobGraphGenerator.java
@@ -39,6 +39,7 @@ import eu.stratosphere.compiler.plan.Channel;
 import eu.stratosphere.compiler.plan.DualInputPlanNode;
 import eu.stratosphere.compiler.plan.IterationPlanNode;
 import eu.stratosphere.compiler.plan.NAryUnionPlanNode;
+import eu.stratosphere.compiler.plan.NamedChannel;
 import eu.stratosphere.compiler.plan.OptimizedPlan;
 import eu.stratosphere.compiler.plan.PlanNode;
 import eu.stratosphere.compiler.plan.SingleInputPlanNode;
@@ -397,7 +398,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 					TaskConfig headConfig = new TaskConfig(headVertex.getConfiguration());
 					int inputIndex = headConfig.getDriverStrategy().getNumInputs();
 					headConfig.setIterationHeadSolutionSetInputIndex(inputIndex);
-					translateChannel(wsNode.getInitialSolutionSetInput(), inputIndex, headVertex, headConfig);
+					translateChannel(wsNode.getInitialSolutionSetInput(), inputIndex, headVertex, headConfig, false);
 				}
 				
 				return;
@@ -557,7 +558,15 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 			int inputIndex = 0;
 			while (inConns.hasNext()) {
 				Channel input = inConns.next();
-				inputIndex += translateChannel(input, inputIndex, targetVertex,targetVertexConfig);
+				inputIndex += translateChannel(input, inputIndex, targetVertex, targetVertexConfig, false);
+			}
+			// broadcast variables
+			int broadcastInputIndex = 0;
+			for (NamedChannel broadcastInput: node.getBroadcastInputs()) {
+				int broadcastInputIndexDelta = translateChannel(broadcastInput, broadcastInputIndex, targetVertex, targetVertexConfig, true);
+				targetVertexConfig.setBroadcastInputName(broadcastInput.getName(), broadcastInputIndex);
+				targetVertexConfig.setBroadcastInputSerializer(broadcastInput.getSerializer(), broadcastInputIndex);
+				broadcastInputIndex += broadcastInputIndexDelta;
 			}
 		} catch (Exception e) {
 			throw new CompilerException(
@@ -566,7 +575,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 	}
 	
 	private int translateChannel(Channel input, int inputIndex, AbstractJobVertex targetVertex,
-			TaskConfig targetVertexConfig) throws Exception
+			TaskConfig targetVertexConfig, boolean isBroadcast) throws Exception
 	{
 		final PlanNode inputPlanNode = input.getSource();
 		final Iterator<Channel> allInChannels;
@@ -666,7 +675,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 				sourceVertexConfig = new TaskConfig(sourceVertex.getConfiguration());
 			}
 			DistributionPattern pattern = connectJobVertices(
-				inConn, inputIndex, sourceVertex, sourceVertexConfig, targetVertex, targetVertexConfig);
+				inConn, inputIndex, sourceVertex, sourceVertexConfig, targetVertex, targetVertexConfig, isBroadcast);
 			
 			// accounting on channels and senders
 			numChannelsTotal++;
@@ -729,7 +738,8 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 					inConn.getLocalStrategy() == LocalStrategy.NONE &&
 					pred.getOutgoingChannels().size() == 1 &&
 					node.getDegreeOfParallelism() == pred.getDegreeOfParallelism() && 
-					node.getSubtasksPerInstance() == pred.getSubtasksPerInstance();
+					node.getSubtasksPerInstance() == pred.getSubtasksPerInstance() &&
+					node.getBroadcastInputs().isEmpty();
 			
 			// cannot chain the nodes that produce the next workset or the next solution set, if they are not the
 			// in a tail 
@@ -1010,7 +1020,7 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 	 */
 	private DistributionPattern connectJobVertices(Channel channel, int inputNumber,
 			final AbstractJobVertex sourceVertex, final TaskConfig sourceConfig,
-			final AbstractJobVertex targetVertex, final TaskConfig targetConfig)
+			final AbstractJobVertex targetVertex, final TaskConfig targetConfig, boolean isBroadcast)
 	throws JobGraphDefinitionException, CompilerException
 	{
 		// ------------ connect the vertices to the job graph --------------
@@ -1064,7 +1074,11 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 //		}
 		
 		// ---------------- configure the receiver -------------------
-		targetConfig.addInputToGroup(inputNumber);
+		if (isBroadcast) {
+			targetConfig.addBroadcastInputToGroup(inputNumber);
+		} else {
+			targetConfig.addInputToGroup(inputNumber);
+		}
 		return distributionPattern;
 	}
 	

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/postpass/GenericFlatTypePostPass.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/postpass/GenericFlatTypePostPass.java
@@ -294,6 +294,16 @@ public abstract class GenericFlatTypePostPass<X, T extends AbstractSchema<X>> im
 				throw new CompilerPostPassException("Could not set up runtime strategy for input channel to node '" +
 					optNode.getPactContract().getName() + "'. Missing type information for field " + e.getFieldNumber());
 			}
+			
+			// don't forget the broadcast inputs
+			for (Channel c: sn.getBroadcastInputs()) {
+				try {
+					propagateToChannel(createEmptySchema(), c, createUtilities);
+				} catch (MissingFieldTypeInfoException e) {
+					throw new CompilerPostPassException("Could not set up runtime strategy for broadcast channel in node '" +
+						optNode.getPactContract().getName() + "'. Missing type information for field " + e.getFieldNumber());
+				}
+			}
 		}
 		else if (node instanceof DualInputPlanNode) {
 			DualInputPlanNode dn = (DualInputPlanNode) node;
@@ -369,6 +379,16 @@ public abstract class GenericFlatTypePostPass<X, T extends AbstractSchema<X>> im
 			} catch (MissingFieldTypeInfoException e) {
 				throw new CompilerPostPassException("Could not set up runtime strategy for the second input channel to node '"
 					+ optNode.getPactContract().getName() + "'. Missing type information for field " + e.getFieldNumber());
+			}
+			
+			// don't forget the broadcast inputs
+			for (Channel c: dn.getBroadcastInputs()) {
+				try {
+					propagateToChannel(createEmptySchema(), c, createUtilities);
+				} catch (MissingFieldTypeInfoException e) {
+					throw new CompilerPostPassException("Could not set up runtime strategy for broadcast channel in node '" +
+						optNode.getPactContract().getName() + "'. Missing type information for field " + e.getFieldNumber());
+				}
 			}
 		}
 		else if (node instanceof NAryUnionPlanNode) {

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/RuntimeContext.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/RuntimeContext.java
@@ -12,6 +12,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.common.functions;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 import eu.stratosphere.api.common.accumulators.Accumulator;
@@ -19,6 +20,7 @@ import eu.stratosphere.api.common.accumulators.DoubleCounter;
 import eu.stratosphere.api.common.accumulators.Histogram;
 import eu.stratosphere.api.common.accumulators.IntCounter;
 import eu.stratosphere.api.common.accumulators.LongCounter;
+import eu.stratosphere.types.Record;
 
 /**
  *
@@ -30,6 +32,8 @@ public interface RuntimeContext {
 	int getNumberOfParallelSubtasks();
 
 	int getIndexOfThisSubtask();
+	
+	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Add this accumulator. Throws an exception if the counter is already
@@ -56,18 +60,23 @@ public interface RuntimeContext {
 	HashMap<String, Accumulator<?, ?>> getAllAccumulators();
 
 	/**
-	 * Convenience function to create a counter object for integers. This
-	 * creates an accumulator object for double values internally.
-	 * 
-	 * @param name
-	 * @return
+	 * Convenience function to create a counter object for integers.
 	 */
 	IntCounter getIntCounter(String name);
 
+	/**
+	 * Convenience function to create a counter object for longs.
+	 */
 	LongCounter getLongCounter(String name);
 
+	/**
+	 * Convenience function to create a counter object for doubles.
+	 */
 	DoubleCounter getDoubleCounter(String name);
 
+	/**
+	 * Convenience function to create a counter object for histograms.
+	 */
 	Histogram getHistogram(String name);
 
 //	/**
@@ -97,5 +106,18 @@ public interface RuntimeContext {
 //	 */
 //	<T> SimpleAccumulator<T> getSimpleAccumulator(String name,
 //			Class<? extends SimpleAccumulator<T>> accumulatorClass);
+	
+	// --------------------------------------------------------------------------------------------
 
+	/**
+	 * Sets the value of the broadcast variable identified by the given 
+	 * {@code name}.
+	 */
+	void setBroadcastVariable(String name, Collection<?> value);
+
+	/**
+	 * Returns the result bound to the broadcast variable identified by the 
+	 * given {@code name}.
+	 */
+	<RT> Collection<RT> getBroadcastVariable(String name);
 }

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
@@ -261,6 +261,9 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 			for (Operator c : this.input2) {
 				c.accept(visitor);
 			}
+			for (Operator c : this.broadcastInputs.values()) {
+				c.accept(visitor);
+			}
 			visitor.postVisit(this);
 		}
 	}

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/SingleInputOperator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/SingleInputOperator.java
@@ -163,6 +163,9 @@ public abstract class SingleInputOperator<T extends Function> extends AbstractUd
 			for (Operator c : this.input) {
 				c.accept(visitor);
 			}
+			for (Operator c : this.broadcastInputs.values()) {
+				c.accept(visitor);
+			}
 			visitor.postVisit(this);
 		}
 	}

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/Record.java
@@ -93,7 +93,7 @@ public final class Record implements Value {
 	}
 	
 	/**
-	 * Creates a new record containing exactly to fields, which are the given values.
+	 * Creates a new record containing exactly two fields, which are the given values.
 	 * 
 	 * @param val1 The value for the first field.
 	 * @param val2 The value for the second field.

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeBroadcast.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeBroadcast.java
@@ -1,0 +1,80 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.example.java.record.kmeans;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.ProgramDescription;
+import eu.stratosphere.api.common.operators.BulkIteration;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.record.operators.MapOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.example.java.record.kmeans.udfs.FindNearestCenterBroadcast;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointInFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointOutFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.RecomputeClusterCenter;
+import eu.stratosphere.types.IntValue;
+
+
+public class KMeansIterativeBroadcast implements Program, ProgramDescription {
+	
+	@Override
+	public Plan getPlan(String... args) {
+		// parse job parameters
+		final int numSubTasks = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
+		final String dataPointInput = (args.length > 1 ? args[1] : "");
+		final String clusterInput = (args.length > 2 ? args[2] : "");
+		final String output = (args.length > 3 ? args[3] : "");
+		final int numIterations = (args.length > 4 ? Integer.parseInt(args[4]) : 1);
+
+		// create DataSourceContract for cluster center input
+		FileDataSource initialClusterPoints = new FileDataSource(new PointInFormat(), clusterInput, "Centers");
+		initialClusterPoints.setDegreeOfParallelism(1);
+		
+		BulkIteration iteration = new BulkIteration("K-Means Loop");
+		iteration.setInput(initialClusterPoints);
+		iteration.setMaximumNumberOfIterations(numIterations);
+		
+		// create DataSourceContract for data point input
+		FileDataSource dataPoints = new FileDataSource(new PointInFormat(), dataPointInput, "Data Points");
+
+		// create MapOperator for finding the nearest cluster centers
+		MapOperator findNearestClusterCenters = MapOperator.builder(new FindNearestCenterBroadcast())
+				.setBroadcastVariable("centers", iteration.getPartialSolution())
+				.input(dataPoints)
+				.name("Find Nearest Centers")
+				.build();
+
+		// create ReduceOperator for computing new cluster positions
+		ReduceOperator recomputeClusterCenter = ReduceOperator.builder(new RecomputeClusterCenter(), IntValue.class, 0)
+				.input(findNearestClusterCenters)
+				.name("Recompute Center Positions")
+				.build();
+		iteration.setNextPartialSolution(recomputeClusterCenter);
+
+		// create DataSinkContract for writing the new cluster positions
+		FileDataSink finalResult = new FileDataSink(new PointOutFormat(), output, iteration, "New Center Positions");
+
+		// return the PACT plan
+		Plan plan = new Plan(finalResult, "Iterative KMeans");
+		plan.setDefaultParallelism(numSubTasks);
+		return plan;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Parameters: <numSubStasks> <dataPoints> <clusterCenters> <output> <numIterations>";
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeWithParameterInputs.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansIterativeWithParameterInputs.java
@@ -1,0 +1,87 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.example.java.record.kmeans;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.ProgramDescription;
+import eu.stratosphere.api.common.operators.BulkIteration;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.record.operators.MapOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.example.java.record.kmeans.udfs.ComputeDistanceParameterized;
+import eu.stratosphere.example.java.record.kmeans.udfs.FindNearestCenter;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointInFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointOutFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.RecomputeClusterCenter;
+import eu.stratosphere.types.IntValue;
+
+
+public class KMeansIterativeWithParameterInputs implements Program, ProgramDescription {
+	
+	@Override
+	public Plan getPlan(String... args) {
+		// parse job parameters
+		final int numSubTasks = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
+		final String dataPointInput = (args.length > 1 ? args[1] : "");
+		final String clusterInput = (args.length > 2 ? args[2] : "");
+		final String output = (args.length > 3 ? args[3] : "");
+		final int numIterations = (args.length > 4 ? Integer.parseInt(args[4]) : 1);
+
+		// create DataSourceContract for cluster center input
+		FileDataSource initialClusterPoints = new FileDataSource(new PointInFormat(), clusterInput, "Centers");
+		initialClusterPoints.setDegreeOfParallelism(1);
+		
+		BulkIteration iteration = new BulkIteration("K-Means Loop");
+		iteration.setInput(initialClusterPoints);
+		iteration.setMaximumNumberOfIterations(numIterations);
+		
+		// create DataSourceContract for data point input
+		FileDataSource dataPoints = new FileDataSource(new PointInFormat(), dataPointInput, "Data Points");
+
+		// create CrossOperator for distance computation
+		MapOperator computeDistance = MapOperator.builder(new ComputeDistanceParameterized())
+				.setBroadcastVariable("centers", iteration.getPartialSolution())
+				.input(dataPoints)
+				.name("Compute Distances")
+				.build();
+
+		// create ReduceOperator for finding the nearest cluster centers
+		ReduceOperator findNearestClusterCenters = ReduceOperator.builder(new FindNearestCenter(), IntValue.class, 0)
+				.input(computeDistance)
+				.name("Find Nearest Centers")
+				.build();
+
+		// create ReduceOperator for computing new cluster positions
+		ReduceOperator recomputeClusterCenter = ReduceOperator.builder(new RecomputeClusterCenter(), IntValue.class, 0)
+				.input(findNearestClusterCenters)
+				.name("Recompute Center Positions")
+				.build();
+		iteration.setNextPartialSolution(recomputeClusterCenter);
+
+		// create DataSinkContract for writing the new cluster positions
+		FileDataSink finalResult = new FileDataSink(new PointOutFormat(), output, iteration, "New Center Positions");
+
+		// return the PACT plan
+		Plan plan = new Plan(finalResult, "Iterative KMeans");
+		plan.setDefaultParallelism(numSubTasks);
+		return plan;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Parameters: <numSubStasks> <dataPoints> <clusterCenters> <output> <numIterations>";
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansSingleStepBroadcast.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/KMeansSingleStepBroadcast.java
@@ -1,0 +1,86 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.example.java.record.kmeans;
+
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.ProgramDescription;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.record.operators.MapOperator;
+import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.example.java.record.kmeans.udfs.FindNearestCenterBroadcast;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointInFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.PointOutFormat;
+import eu.stratosphere.example.java.record.kmeans.udfs.RecomputeClusterCenter;
+import eu.stratosphere.types.IntValue;
+
+/**
+ * The K-Means cluster algorithm is well-known (see
+ * http://en.wikipedia.org/wiki/K-means_clustering). KMeansIteration is a PACT
+ * program that computes a single iteration of the k-means algorithm. The job
+ * has two inputs, a set of data points and a set of cluster centers. A Cross
+ * PACT is used to compute all distances from all centers to all points. A
+ * following Reduce PACT assigns each data point to the cluster center that is
+ * next to it. Finally, a second Reduce PACT compute the new locations of all
+ * cluster centers.
+ */
+public class KMeansSingleStepBroadcast implements Program, ProgramDescription {
+	
+
+	@Override
+	public Plan getPlan(String... args) {
+		// parse job parameters
+		int numSubTasks = (args.length > 0 ? Integer.parseInt(args[0]) : 1);
+		String dataPointInput = (args.length > 1 ? args[1] : "");
+		String clusterInput = (args.length > 2 ? args[2] : "");
+		String output = (args.length > 3 ? args[3] : "");
+
+		// create DataSourceContract for data point input
+		FileDataSource dataPoints = new FileDataSource(new PointInFormat(), dataPointInput, "Data Points");
+		dataPoints.getCompilerHints().addUniqueField(0);
+
+		// create DataSourceContract for cluster center input
+		FileDataSource clusterPoints = new FileDataSource(new PointInFormat(), clusterInput, "Centers");
+		clusterPoints.setDegreeOfParallelism(1);
+		clusterPoints.getCompilerHints().addUniqueField(0);
+
+		// create CrossOperator for distance computation
+		MapOperator findNearestClusterCenters = MapOperator.builder(new FindNearestCenterBroadcast())
+			.setBroadcastVariable("centers", clusterPoints)
+			.input(dataPoints)
+			.name("Find Nearest Centers")
+			.build();
+
+		// create ReduceOperator for computing new cluster positions
+		ReduceOperator recomputeClusterCenter = ReduceOperator.builder(new RecomputeClusterCenter(), IntValue.class, 0)
+			.input(findNearestClusterCenters)
+			.name("Recompute Center Positions")
+			.build();
+
+		// create DataSinkContract for writing the new cluster positions
+		FileDataSink newClusterPoints = new FileDataSink(new PointOutFormat(), output, recomputeClusterCenter, "New Center Positions");
+
+		// return the PACT plan
+		Plan plan = new Plan(newClusterPoints, "KMeans Iteration");
+		plan.setDefaultParallelism(numSubTasks);
+		return plan;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Parameters: [numSubStasks] [dataPoints] [clusterCenters] [output]";
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/ComputeDistanceParameterized.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/ComputeDistanceParameterized.java
@@ -1,0 +1,70 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.record.kmeans.udfs;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation.ConstantFieldsFirst;
+import eu.stratosphere.api.java.record.functions.MapFunction;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.types.DoubleValue;
+import eu.stratosphere.types.IntValue;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.util.Collector;
+
+/**
+ * Cross PACT computes the distance of all data points to all cluster
+ * centers.
+ */
+@ConstantFieldsFirst({0,1})
+public class ComputeDistanceParameterized extends MapFunction implements Serializable {
+	private static final long serialVersionUID = 1L;
+	
+	private final DoubleValue distance = new DoubleValue();
+	
+	private Collection<Record> clusterCenters;
+	
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		this.clusterCenters = this.getRuntimeContext().getBroadcastVariable("centers");
+	}
+	
+	/**
+	 * Computes the distance of one data point to one cluster center.
+	 * 
+	 * Output Format:
+	 * 0: pointID
+	 * 1: pointVector
+	 * 2: clusterID
+	 * 3: distance
+	 */
+	@Override
+	public void map(Record dataPointRecord, Collector<Record> out) {
+		
+		CoordVector dataPoint = dataPointRecord.getField(1, CoordVector.class);
+		
+		for (Record clusterCenterRecord : this.clusterCenters) {
+			IntValue clusterCenterId = clusterCenterRecord.getField(0, IntValue.class);
+			CoordVector clusterPoint = clusterCenterRecord.getField(1, CoordVector.class);
+		
+			this.distance.setValue(dataPoint.computeEuclidianDistance(clusterPoint));
+			
+			// add cluster center id and distance to the data point record 
+			dataPointRecord.setField(2, clusterCenterId);
+			dataPointRecord.setField(3, this.distance);
+			
+			out.collect(dataPointRecord);
+		}
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/FindNearestCenterBroadcast.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/kmeans/udfs/FindNearestCenterBroadcast.java
@@ -1,0 +1,81 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.record.kmeans.udfs;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation.ConstantFieldsFirst;
+import eu.stratosphere.api.java.record.functions.MapFunction;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.types.IntValue;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.util.Collector;
+
+/**
+ * Determines the closest cluster center for a data point.
+ */
+@ConstantFieldsFirst({0,1})
+public class FindNearestCenterBroadcast extends MapFunction implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	private final IntValue centerId = new IntValue();
+	private final CoordVector dataPoint = new CoordVector();
+	private final CoordVector centerPoint = new CoordVector();
+	private final IntValue one = new IntValue(1);
+
+	private final Record result = new Record(3);
+
+	private Collection<Record> clusterCenters;
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		this.clusterCenters = this.getRuntimeContext().getBroadcastVariable("centers");
+	}
+
+	/**
+	 * Computes a minimum aggregation on the distance of a data point to cluster centers.
+	 * 
+	 * Output Format:
+	 * 0: centerID
+	 * 1: pointVector
+	 * 2: constant(1) (to enable combinable average computation in the following reducer)
+	 */
+	@Override
+	public void map(Record dataPointRecord, Collector<Record> out) {
+		dataPointRecord.getFieldInto(1, this.dataPoint);
+		
+		double nearestDistance = Double.MAX_VALUE;
+
+		// check all cluster centers
+		for (Record clusterCenterRecord : this.clusterCenters) {
+			clusterCenterRecord.getFieldInto(1, this.centerPoint);
+
+			// compute distance
+			double distance = this.dataPoint.computeEuclidianDistance(this.centerPoint);
+			// update nearest cluster if necessary 
+			if (distance < nearestDistance) {
+				nearestDistance = distance;
+				clusterCenterRecord.getFieldInto(0, this.centerId);
+			}
+		}
+
+		// emit a new record with the center id and the data point. add a one to ease the
+		// implementation of the average function with a combiner
+		this.result.setField(0, this.centerId);
+		this.result.setField(1, this.dataPoint);
+		this.result.setField(2, this.one);
+
+		out.collect(this.result);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossOperator.java
@@ -14,7 +14,9 @@
 package eu.stratosphere.api.java.record.operators;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
@@ -62,6 +64,7 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 		super(builder.udf, builder.name);
 		setFirstInputs(builder.inputs1);
 		setSecondInputs(builder.inputs2);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 
@@ -83,6 +86,7 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 		/* The optional parameters */
 		private List<Operator> inputs1;
 		private List<Operator> inputs2;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		/**
@@ -94,6 +98,7 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 			this.udf = udf;
 			this.inputs1 = new ArrayList<Operator>();
 			this.inputs2 = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -139,6 +144,24 @@ public class CrossOperator extends CrossOperatorBase<CrossFunction> implements R
 		 */
 		public Builder inputs2(List<Operator> inputs) {
 			this.inputs2 = inputs;
+			return this;
+		}
+		
+		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
 			return this;
 		}
 		

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithLargeOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithLargeOperator.java
@@ -76,6 +76,7 @@ public class CrossWithLargeOperator extends CrossOperator implements CrossWithLa
 		 * 
 		 * @return The created contract
 		 */
+		@Override
 		public CrossWithLargeOperator build() {
 			return new CrossWithLargeOperator(this);
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithSmallOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/CrossWithSmallOperator.java
@@ -76,6 +76,7 @@ public class CrossWithSmallOperator extends CrossOperator implements CrossWithSm
 		 * 
 		 * @return The created contract
 		 */
+		@Override
 		public CrossWithSmallOperator build() {
 			return new CrossWithSmallOperator(this);
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/JoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/JoinOperator.java
@@ -14,7 +14,9 @@
 package eu.stratosphere.api.java.record.operators;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
@@ -76,6 +78,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 		this.keyTypes = builder.getKeyClassesArray();
 		setFirstInputs(builder.inputs1);
 		setSecondInputs(builder.inputs2);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 	@Override
@@ -99,6 +102,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 		/* The optional parameters */
 		private List<Operator> inputs1;
 		private List<Operator> inputs2;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		
@@ -120,6 +124,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 			this.keyColumns2.add(keyColumn2);
 			this.inputs1 = new ArrayList<Operator>();
 			this.inputs2 = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -135,6 +140,7 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 			this.keyColumns2 = new ArrayList<Integer>();
 			this.inputs1 = new ArrayList<Operator>();
 			this.inputs2 = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		private int[] getKeyColumnsArray1() {
@@ -219,9 +225,25 @@ public class JoinOperator extends JoinOperatorBase<JoinFunction> implements Reco
 		}
 		
 		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
+			return this;
+		}
+		
+		/**
 		 * Sets the name of this contract.
-		 * 
-		 * @param name
 		 */
 		public Builder name(String name) {
 			this.name = name;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/MapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/MapOperator.java
@@ -14,7 +14,9 @@
 package eu.stratosphere.api.java.record.operators;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.base.MapOperatorBase;
@@ -60,6 +62,7 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 	protected MapOperator(Builder builder) {
 		super(builder.udf, builder.name);
 		setInputs(builder.inputs);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 
@@ -80,6 +83,7 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 		
 		/* The optional parameters */
 		private List<Operator> inputs;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		/**
@@ -90,6 +94,7 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 		private Builder(UserCodeWrapper<MapFunction> udf) {
 			this.udf = udf;
 			this.inputs = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -112,6 +117,24 @@ public class MapOperator extends MapOperatorBase<MapFunction> implements RecordO
 		 */
 		public Builder inputs(List<Operator> inputs) {
 			this.inputs = inputs;
+			return this;
+		}
+		
+		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
 			return this;
 		}
 		

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/RecordOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/RecordOperator.java
@@ -14,7 +14,6 @@
 package eu.stratosphere.api.java.record.operators;
 
 import eu.stratosphere.types.Key;
-import eu.stratosphere.types.Record;
 
 /**
  * Interface marking contract classes to be referring to the {@link Record} data model.

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/operators/ReduceOperator.java
@@ -18,7 +18,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.common.operators.Ordering;
@@ -99,6 +101,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 		this.keyTypes = builder.getKeyClassesArray();
 		setInputs(builder.inputs);
 		setGroupOrder(builder.secondaryOrder);
+		setBroadcastVariables(builder.broadcastInputs);
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -191,6 +194,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 		/* The optional parameters */
 		private Ordering secondaryOrder = null;
 		private List<Operator> inputs;
+		private Map<String, Operator> broadcastInputs;
 		private String name = DEFAULT_NAME;
 		
 		/**
@@ -203,6 +207,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 			this.keyClasses = new ArrayList<Class<? extends Key>>();
 			this.keyColumns = new ArrayList<Integer>();
 			this.inputs = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		/**
@@ -219,6 +224,7 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 			this.keyColumns = new ArrayList<Integer>();
 			this.keyColumns.add(keyColumn);
 			this.inputs = new ArrayList<Operator>();
+			this.broadcastInputs = new HashMap<String, Operator>();
 		}
 		
 		private int[] getKeyColumnsArray() {
@@ -276,6 +282,24 @@ public class ReduceOperator extends ReduceOperatorBase<ReduceFunction> implement
 		 */
 		public Builder inputs(List<Operator> inputs) {
 			this.inputs = inputs;
+			return this;
+		}
+		
+		/**
+		 * Binds the result produced by a plan rooted at {@code root} to a 
+		 * variable used by the UDF wrapped in this operator.
+		 */
+		public Builder setBroadcastVariable(String name, Operator input) {
+			this.broadcastInputs.put(name, input);
+			return this;
+		}
+		
+		/**
+		 * Binds multiple broadcast variables.
+		 */
+		public Builder setBroadcastVariables(Map<String, Operator> inputs) {
+			this.broadcastInputs.clear();
+			this.broadcastInputs.putAll(inputs);
 			return this;
 		}
 		

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/util/TaskConfig.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/util/TaskConfig.java
@@ -73,6 +73,8 @@ public class TaskConfig {
 
 	private static final String NUM_INPUTS = "pact.in.num";
 	
+	private static final String NUM_BROADCAST_INPUTS = "pact.in.broadcast.num";
+	
 	/*
 	 * If one input has multiple predecessors (bag union), multiple
 	 * inputs must be grouped together. For a map or reduce there is
@@ -86,9 +88,15 @@ public class TaskConfig {
 	 */
 	private static final String INPUT_GROUP_SIZE_PREFIX = "pact.in.groupsize.";
 	
+	private static final String BROADCAST_INPUT_GROUP_SIZE_PREFIX = "pact.in.broadcast.groupsize.";
+	
 	private static final String INPUT_TYPE_SERIALIZER_FACTORY_PREFIX = "pact.in.serializer.";
 	
+	private static final String BROADCAST_INPUT_TYPE_SERIALIZER_FACTORY_PREFIX = "pact.in.broadcast.serializer.";
+	
 	private static final String INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX = "pact.in.serializer.param.";
+	
+	private static final String BROADCAST_INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX = "pact.in.broadcast.serializer.param.";
 	
 	private static final String INPUT_LOCAL_STRATEGY_PREFIX = "pact.in.strategy.";
 	
@@ -101,6 +109,8 @@ public class TaskConfig {
 	private static final String INPUT_REPLAYABLE_PREFIX = "pact.in.dam.replay.";
 	
 	private static final String INPUT_DAM_MEMORY_PREFIX = "pact.in.dam.mem.";
+	
+	private static final String BROADCAST_INPUT_NAME_PREFIX = "pact.in.broadcast.name.";
 	
 	
 	// -------------------------------------- Outputs ---------------------------------------------
@@ -384,9 +394,19 @@ public class TaskConfig {
 			INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR);
 	}
 	
+	public void setBroadcastInputSerializer(TypeSerializerFactory<?> factory, int inputNum) {
+		setTypeSerializerFactory(factory, BROADCAST_INPUT_TYPE_SERIALIZER_FACTORY_PREFIX + inputNum,
+			BROADCAST_INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR);
+	}
+	
 	public <T> TypeSerializerFactory<T> getInputSerializer(int inputNum, ClassLoader cl) {
 		return getTypeSerializerFactory(INPUT_TYPE_SERIALIZER_FACTORY_PREFIX + inputNum,
 			INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR, cl);
+	}
+	
+	public <T> TypeSerializerFactory<T> getBroadcastInputSerializer(int inputNum, ClassLoader cl) {
+		return getTypeSerializerFactory(BROADCAST_INPUT_TYPE_SERIALIZER_FACTORY_PREFIX + inputNum,
+			BROADCAST_INPUT_TYPE_SERIALIZER_PARAMETERS_PREFIX + inputNum + SEPARATOR, cl);
 	}
 	
 	public void setInputComparator(TypeComparatorFactory<?> factory, int inputNum) {
@@ -403,14 +423,28 @@ public class TaskConfig {
 		return this.config.getInteger(NUM_INPUTS, 0);
 	}
 	
+	public int getNumBroadcastInputs() {
+		return this.config.getInteger(NUM_BROADCAST_INPUTS, 0);
+	}
+	
 	public int getGroupSize(int groupIndex) {
 		return this.config.getInteger(INPUT_GROUP_SIZE_PREFIX + groupIndex, -1);
+	}
+	
+	public int getBroadcastGroupSize(int groupIndex) {
+		return this.config.getInteger(BROADCAST_INPUT_GROUP_SIZE_PREFIX + groupIndex, -1);
 	}
 	
 	public void addInputToGroup(int groupIndex) {
 		final String grp = INPUT_GROUP_SIZE_PREFIX + groupIndex;
 		this.config.setInteger(grp, this.config.getInteger(grp, 0) + 1);
 		this.config.setInteger(NUM_INPUTS, this.config.getInteger(NUM_INPUTS, 0) + 1);
+	}
+	
+	public void addBroadcastInputToGroup(int groupIndex) {
+		final String grp = BROADCAST_INPUT_GROUP_SIZE_PREFIX + groupIndex;
+		this.config.setInteger(grp, this.config.getInteger(grp, 0) + 1);
+		this.config.setInteger(NUM_BROADCAST_INPUTS, this.config.getInteger(NUM_BROADCAST_INPUTS, 0) + 1);
 	}
 	
 	public void setInputAsynchronouslyMaterialized(int inputNum, boolean temp) {
@@ -435,6 +469,14 @@ public class TaskConfig {
 	
 	public long getInputMaterializationMemory(int inputNum) {
 		return this.config.getLong(INPUT_DAM_MEMORY_PREFIX + inputNum, -1);
+	}
+	
+	public void setBroadcastInputName(String name, int groupIndex) {
+		this.config.setString(BROADCAST_INPUT_NAME_PREFIX + groupIndex, name);
+	}
+	
+	public String getBroadcastInputName(int groupIndex) {
+		return this.config.getString(BROADCAST_INPUT_NAME_PREFIX + groupIndex, String.format("broadcastVar%04d", groupIndex));
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/udf/RuntimeUDFContext.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/udf/RuntimeUDFContext.java
@@ -12,6 +12,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.pact.runtime.udf;
 
+import java.util.Collection;
 import java.util.HashMap;
 
 import eu.stratosphere.api.common.accumulators.Accumulator;
@@ -21,6 +22,7 @@ import eu.stratosphere.api.common.accumulators.Histogram;
 import eu.stratosphere.api.common.accumulators.IntCounter;
 import eu.stratosphere.api.common.accumulators.LongCounter;
 import eu.stratosphere.api.common.functions.RuntimeContext;
+import eu.stratosphere.types.Record;
 
 /**
  *
@@ -34,6 +36,8 @@ public class RuntimeUDFContext implements RuntimeContext {
 	private final int subtaskIndex;
 
 	private HashMap<String, Accumulator<?, ?>> accumulators = new HashMap<String, Accumulator<?, ?>>();
+
+	private HashMap<String, Collection<?>> broadcastVars = new HashMap<String, Collection<?>>();
 
 	public RuntimeUDFContext(String name, int numParallelSubtasks, int subtaskIndex) {
 		this.name = name;
@@ -118,4 +122,23 @@ public class RuntimeUDFContext implements RuntimeContext {
 		return this.accumulators;
 	}
 
+	@Override
+	public void setBroadcastVariable(String name, Collection<?> value) {
+		if (this.broadcastVars.containsKey(name)) {
+			throw new UnsupportedOperationException("The broadcast variable '" + name
+					+ "' already exists and cannot be added.");
+		}
+		this.broadcastVars.put(name, value);
+	}
+
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <RT> Collection<RT> getBroadcastVariable(String name) {
+		if (!this.broadcastVars.containsKey(name)) {
+			throw new UnsupportedOperationException("Trying to access an unbound broadcast variable '" 
+					+ name + "'.");
+		}
+		return (Collection<RT>) this.broadcastVars.get(name);
+	}
 }

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/BroadcastVarsNepheleITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/BroadcastVarsNepheleITCase.java
@@ -1,0 +1,327 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.test.broadcastvars;
+
+import java.io.BufferedReader;
+import java.util.Collection;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+
+import eu.stratosphere.api.common.io.FileOutputFormat;
+import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
+import eu.stratosphere.api.common.typeutils.TypeSerializerFactory;
+import eu.stratosphere.api.java.record.functions.MapFunction;
+import eu.stratosphere.api.java.record.io.CsvInputFormat;
+import eu.stratosphere.api.java.record.io.CsvOutputFormat;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.nephele.io.DistributionPattern;
+import eu.stratosphere.nephele.io.channels.ChannelType;
+import eu.stratosphere.nephele.jobgraph.JobGraph;
+import eu.stratosphere.nephele.jobgraph.JobGraphDefinitionException;
+import eu.stratosphere.nephele.jobgraph.JobInputVertex;
+import eu.stratosphere.nephele.jobgraph.JobOutputVertex;
+import eu.stratosphere.nephele.jobgraph.JobTaskVertex;
+import eu.stratosphere.pact.runtime.plugable.pactrecord.RecordSerializerFactory;
+import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
+import eu.stratosphere.pact.runtime.task.DriverStrategy;
+import eu.stratosphere.pact.runtime.task.MapDriver;
+import eu.stratosphere.pact.runtime.task.RegularPactTask;
+import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
+import eu.stratosphere.pact.runtime.task.util.TaskConfig;
+import eu.stratosphere.test.iterative.nephele.JobGraphUtils;
+import eu.stratosphere.test.util.TestBase2;
+import eu.stratosphere.types.LongValue;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.util.Collector;
+
+public class BroadcastVarsNepheleITCase extends TestBase2 {
+
+	private static final long SEED_POINTS = 0xBADC0FFEEBEEFL;
+
+	private static final long SEED_MODELS = 0x39134230AFF32L;
+
+	private static final int NUM_POINTS = 10000;
+
+	private static final int NUM_MODELS = 42;
+
+	private static final int NUM_FEATURES = 3;
+
+	protected String pointsPath;
+
+	protected String modelsPath;
+
+	protected String resultPath;
+
+	public BroadcastVarsNepheleITCase() {
+		super(new Configuration());
+	}
+
+	public static final String getInputPoints(int numPoints, int numDimensions, long seed) {
+		if (numPoints < 1 || numPoints > 1000000)
+			throw new IllegalArgumentException();
+
+		Random r = new Random();
+
+		StringBuilder bld = new StringBuilder(3 * (1 + numDimensions) * numPoints);
+		for (int i = 1; i <= numPoints; i++) {
+			bld.append(i);
+			bld.append(' ');
+
+			r.setSeed(seed + 1000 * i);
+			for (int j = 1; j <= numDimensions; j++) {
+				bld.append(r.nextInt(1000));
+				bld.append(' ');
+			}
+			bld.append('\n');
+		}
+		return bld.toString();
+	}
+
+	public static final String getInputModels(int numModels, int numDimensions, long seed) {
+		if (numModels < 1 || numModels > 100)
+			throw new IllegalArgumentException();
+
+		Random r = new Random();
+
+		StringBuilder bld = new StringBuilder(3 * (1 + numDimensions) * numModels);
+		for (int i = 1; i <= numModels; i++) {
+			bld.append(i);
+			bld.append(' ');
+
+			r.setSeed(seed + 1000 * i);
+			for (int j = 1; j <= numDimensions; j++) {
+				bld.append(r.nextInt(100));
+				bld.append(' ');
+			}
+			bld.append('\n');
+		}
+		return bld.toString();
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		this.pointsPath = createTempFile("points.txt", getInputPoints(NUM_POINTS, NUM_FEATURES, SEED_POINTS));
+		this.modelsPath = createTempFile("models.txt", getInputModels(NUM_MODELS, NUM_FEATURES, SEED_MODELS));
+		this.resultPath = getTempFilePath("results");
+	}
+
+	@Override
+	protected JobGraph getJobGraph() throws Exception {
+		return createJobGraphV1(this.pointsPath, this.modelsPath, this.resultPath, 4);
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		final Random randPoints = new Random();
+		final Random randModels = new Random();
+		final Pattern p = Pattern.compile("(\\d+) (\\d+) (\\d+)");
+		
+		long [][] results = new long[NUM_POINTS][NUM_MODELS];
+		boolean [][] occurs = new boolean[NUM_POINTS][NUM_MODELS];
+		for (int i = 0; i < NUM_POINTS; i++) {
+			for (int j = 0; j < NUM_MODELS; j++) {
+				long actDotProd = 0;
+				randPoints.setSeed(SEED_POINTS + 1000 * (i+1));
+				randModels.setSeed(SEED_MODELS + 1000 * (j+1));
+				for (int z = 1; z <= NUM_FEATURES; z++) {
+					actDotProd += randPoints.nextInt(1000) * randModels.nextInt(100);
+				}
+				results[i][j] = actDotProd;
+				occurs[i][j] = false;
+			}
+		}
+
+		for (BufferedReader reader : getResultReader(this.resultPath)) {
+			String line = null;
+			while (null != (line = reader.readLine())) {
+				final Matcher m = p.matcher(line);
+				Assert.assertTrue(m.matches());
+
+				int modelId = Integer.parseInt(m.group(1));
+				int pointId = Integer.parseInt(m.group(2));
+				long expDotProd = Long.parseLong(m.group(3));
+
+				Assert.assertFalse("Dot product for record (" + pointId + ", " + modelId + ") occurs more than once", occurs[pointId-1][modelId-1]);
+				Assert.assertEquals(String.format("Bad product for (%04d, %04d)", pointId, modelId), expDotProd, results[pointId-1][modelId-1]);
+
+				occurs[pointId-1][modelId-1] = true;
+			}
+		}
+
+		for (int i = 0; i < NUM_POINTS; i++) {
+			for (int j = 0; j < NUM_MODELS; j++) {
+				Assert.assertTrue("Dot product for record (" + (i+1) + ", " + (j+1) + ") does not occur", occurs[i][j]);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// UDFs
+	// -------------------------------------------------------------------------------------------------------------
+
+	public static final class DotProducts extends MapFunction {
+
+		private final Record result = new Record(3);
+
+		private final LongValue lft = new LongValue();
+
+		private final LongValue rgt = new LongValue();
+
+		private final LongValue prd = new LongValue();
+
+		private Collection<Record> models;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			this.models = this.getRuntimeContext().getBroadcastVariable("models");
+		}
+
+		@Override
+		public void map(Record record, Collector<Record> out) throws Exception {
+
+			for (Record model : this.models) {
+				// compute dot product between model and pair
+				long product = 0;
+				for (int i = 1; i <= NUM_FEATURES; i++) {
+					product += model.getField(i, this.lft).getValue() * record.getField(i, this.rgt).getValue();
+				}
+				this.prd.setValue(product);
+
+				// construct result
+				this.result.copyFrom(model, new int[] { 0 }, new int[] { 0 });
+				this.result.copyFrom(record, new int[] { 0 }, new int[] { 1 });
+				this.result.setField(2, this.prd);
+
+				// emit result
+				out.collect(this.result);
+			}
+		}
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Job vertex builder methods
+	// -------------------------------------------------------------------------------------------------------------
+
+	@SuppressWarnings("unchecked")
+	private static JobInputVertex createPointsInput(JobGraph jobGraph, String pointsPath, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		CsvInputFormat pointsInFormat = new CsvInputFormat(' ', LongValue.class, LongValue.class, LongValue.class, LongValue.class);
+		JobInputVertex pointsInput = JobGraphUtils.createInput(pointsInFormat, pointsPath, "Input[Points]", jobGraph, numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(pointsInput.getConfiguration());
+			taskConfig.addOutputShipStrategy(ShipStrategyType.FORWARD);
+			taskConfig.setOutputSerializer(serializer);
+		}
+
+		return pointsInput;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static JobInputVertex createModelsInput(JobGraph jobGraph, String pointsPath, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		CsvInputFormat modelsInFormat = new CsvInputFormat(' ', LongValue.class, LongValue.class, LongValue.class, LongValue.class);
+		JobInputVertex modelsInput = JobGraphUtils.createInput(modelsInFormat, pointsPath, "Input[Models]", jobGraph, numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(modelsInput.getConfiguration());
+			taskConfig.addOutputShipStrategy(ShipStrategyType.BROADCAST);
+			taskConfig.setOutputSerializer(serializer);
+		}
+
+		return modelsInput;
+	}
+
+	private static JobTaskVertex createMapper(JobGraph jobGraph, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		JobTaskVertex pointsInput = JobGraphUtils.createTask(RegularPactTask.class, "Map[DotProducts]", jobGraph, numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(pointsInput.getConfiguration());
+
+			taskConfig.setStubWrapper(new UserCodeClassWrapper<DotProducts>(DotProducts.class));
+			taskConfig.addOutputShipStrategy(ShipStrategyType.FORWARD);
+			taskConfig.setOutputSerializer(serializer);
+			taskConfig.setDriver(MapDriver.class);
+			taskConfig.setDriverStrategy(DriverStrategy.MAP);
+
+			taskConfig.addInputToGroup(0);
+			taskConfig.setInputLocalStrategy(0, LocalStrategy.NONE);
+			taskConfig.setInputSerializer(serializer, 0);
+
+			taskConfig.setBroadcastInputName("models", 0);
+			taskConfig.addBroadcastInputToGroup(0);
+			taskConfig.setBroadcastInputSerializer(serializer, 0);
+		}
+
+		return pointsInput;
+	}
+
+	private static JobOutputVertex createOutput(JobGraph jobGraph, String resultPath, int numSubTasks, TypeSerializerFactory<?> serializer) {
+		JobOutputVertex output = JobGraphUtils.createFileOutput(jobGraph, "Output", numSubTasks, numSubTasks);
+
+		{
+			TaskConfig taskConfig = new TaskConfig(output.getConfiguration());
+			taskConfig.addInputToGroup(0);
+			taskConfig.setInputSerializer(serializer, 0);
+
+			taskConfig.setStubWrapper(new UserCodeClassWrapper<CsvOutputFormat>(CsvOutputFormat.class));
+			taskConfig.setStubParameter(FileOutputFormat.FILE_PARAMETER_KEY, resultPath);
+
+			Configuration stubConfig = taskConfig.getStubParameters();
+			stubConfig.setString(CsvOutputFormat.RECORD_DELIMITER_PARAMETER, "\n");
+			stubConfig.setString(CsvOutputFormat.FIELD_DELIMITER_PARAMETER, " ");
+			stubConfig.setClass(CsvOutputFormat.FIELD_TYPE_PARAMETER_PREFIX + 0, LongValue.class);
+			stubConfig.setInteger(CsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + 0, 0);
+			stubConfig.setClass(CsvOutputFormat.FIELD_TYPE_PARAMETER_PREFIX + 1, LongValue.class);
+			stubConfig.setInteger(CsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + 1, 1);
+			stubConfig.setClass(CsvOutputFormat.FIELD_TYPE_PARAMETER_PREFIX + 2, LongValue.class);
+			stubConfig.setInteger(CsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + 2, 2);
+			stubConfig.setInteger(CsvOutputFormat.NUM_FIELDS_PARAMETER, 3);
+		}
+
+		return output;
+	}
+
+	// -------------------------------------------------------------------------------------------------------------
+	// Unified solution set and workset tail update
+	// -------------------------------------------------------------------------------------------------------------
+
+	private JobGraph createJobGraphV1(String pointsPath, String centersPath, String resultPath, int numSubTasks) throws JobGraphDefinitionException {
+
+		// -- init -------------------------------------------------------------------------------------------------
+		final TypeSerializerFactory<?> serializer = RecordSerializerFactory.get();
+
+		JobGraph jobGraph = new JobGraph("Distance Builder");
+
+		// -- vertices ---------------------------------------------------------------------------------------------
+		JobInputVertex points = createPointsInput(jobGraph, pointsPath, numSubTasks, serializer);
+		JobInputVertex models = createModelsInput(jobGraph, centersPath, numSubTasks, serializer);
+		JobTaskVertex mapper = createMapper(jobGraph, numSubTasks, serializer);
+		JobOutputVertex output = createOutput(jobGraph, resultPath, numSubTasks, serializer);
+
+		// -- edges ------------------------------------------------------------------------------------------------
+		JobGraphUtils.connect(points, mapper, ChannelType.NETWORK, DistributionPattern.POINTWISE);
+		JobGraphUtils.connect(models, mapper, ChannelType.NETWORK, DistributionPattern.BIPARTITE);
+		JobGraphUtils.connect(mapper, output, ChannelType.NETWORK, DistributionPattern.POINTWISE);
+
+		// -- instance sharing -------------------------------------------------------------------------------------
+		points.setVertexToShareInstancesWith(output);
+		models.setVertexToShareInstancesWith(output);
+		mapper.setVertexToShareInstancesWith(output);
+
+		return jobGraph;
+	}
+}

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/KMeansStepBroadcastITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/KMeansStepBroadcastITCase.java
@@ -1,0 +1,233 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.test.broadcastvars;
+
+import java.io.BufferedReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.compiler.PactCompiler;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.example.java.record.kmeans.KMeansSingleStepBroadcast;
+import eu.stratosphere.test.util.TestBase2;
+
+@RunWith(Parameterized.class)
+public class KMeansStepBroadcastITCase extends TestBase2 {
+
+	public final static String DATAPOINTS = "0|50.90|16.20|72.08|\n" + "1|73.65|61.76|62.89|\n" + "2|61.73|49.95|92.74|\n"
+			+ "3|1.60|70.11|16.32|\n" + "4|2.43|19.81|89.56|\n" + "5|67.99|9.00|14.48|\n" + "6|87.80|84.49|55.83|\n"
+			+ "7|90.26|42.99|53.29|\n" + "8|51.36|6.16|9.35|\n" + "9|12.43|9.52|12.54|\n" + "10|80.01|8.78|29.74|\n"
+			+ "11|92.76|2.93|80.07|\n" + "12|46.32|100.00|22.98|\n" + "13|34.11|45.61|58.60|\n"
+			+ "14|68.82|16.36|96.60|\n" + "15|81.47|76.45|28.40|\n" + "16|65.55|40.21|43.43|\n"
+			+ "17|84.22|88.56|13.31|\n" + "18|36.99|68.36|57.12|\n" + "19|28.87|37.69|91.04|\n"
+			+ "20|31.56|13.22|86.00|\n" + "21|18.49|34.45|54.52|\n" + "22|13.33|94.02|92.07|\n"
+			+ "23|91.19|81.62|55.06|\n" + "24|85.78|39.02|25.58|\n" + "25|94.41|47.07|78.23|\n"
+			+ "26|90.62|10.43|80.20|\n" + "27|31.52|85.81|39.79|\n" + "28|24.65|77.98|26.35|\n"
+			+ "29|69.34|75.79|63.96|\n" + "30|22.56|78.61|66.66|\n" + "31|91.74|83.82|73.92|\n"
+			+ "32|76.64|89.53|44.66|\n" + "33|36.02|73.01|92.32|\n" + "34|87.86|18.94|10.74|\n"
+			+ "35|91.94|34.61|5.20|\n" + "36|12.52|47.01|95.29|\n" + "37|44.01|26.19|78.50|\n"
+			+ "38|26.20|73.36|10.08|\n" + "39|15.21|17.37|54.33|\n" + "40|27.96|94.81|44.41|\n"
+			+ "41|26.44|44.81|70.88|\n" + "42|53.29|26.69|2.40|\n" + "43|23.94|11.50|1.71|\n"
+			+ "44|19.00|25.48|50.80|\n" + "45|82.26|1.88|58.08|\n" + "46|47.56|82.54|82.73|\n"
+			+ "47|51.54|35.10|32.95|\n" + "48|86.71|55.51|19.08|\n" + "49|54.16|23.68|32.41|\n"
+			+ "50|71.81|32.83|46.66|\n" + "51|20.70|14.19|64.96|\n" + "52|57.17|88.56|55.23|\n"
+			+ "53|91.39|49.38|70.55|\n" + "54|47.90|62.07|76.03|\n" + "55|55.70|37.77|30.15|\n"
+			+ "56|87.87|74.62|25.95|\n" + "57|95.70|45.04|15.27|\n" + "58|41.61|89.37|24.45|\n"
+			+ "59|82.19|20.84|11.13|\n" + "60|49.88|2.62|18.62|\n" + "61|16.42|53.30|74.13|\n"
+			+ "62|38.37|72.62|35.16|\n" + "63|43.26|49.59|92.56|\n" + "64|28.96|2.36|78.49|\n"
+			+ "65|88.41|91.43|92.55|\n" + "66|98.61|79.58|33.03|\n" + "67|4.94|18.65|30.78|\n"
+			+ "68|75.89|79.30|63.90|\n" + "69|93.18|76.26|9.50|\n" + "70|73.43|70.50|76.49|\n"
+			+ "71|78.64|90.87|34.49|\n" + "72|58.47|63.07|8.82|\n" + "73|69.74|54.36|64.43|\n"
+			+ "74|38.47|36.60|33.39|\n" + "75|51.07|14.75|2.54|\n" + "76|24.18|16.85|15.00|\n"
+			+ "77|7.56|50.72|93.45|\n" + "78|64.28|97.01|57.31|\n" + "79|85.30|24.13|76.57|\n"
+			+ "80|72.78|30.78|13.11|\n" + "81|18.42|17.45|32.20|\n" + "82|87.44|74.98|87.90|\n"
+			+ "83|38.30|17.77|37.33|\n" + "84|63.62|7.90|34.23|\n" + "85|8.84|67.87|30.65|\n"
+			+ "86|76.12|51.83|80.12|\n" + "87|32.30|74.79|4.39|\n" + "88|41.73|45.34|18.66|\n"
+			+ "89|58.13|18.43|83.38|\n" + "90|98.10|33.46|83.07|\n" + "91|17.76|4.10|88.51|\n"
+			+ "92|60.58|18.15|59.96|\n" + "93|50.11|33.25|85.64|\n" + "94|97.74|60.93|38.97|\n"
+			+ "95|76.31|52.50|95.43|\n" + "96|7.71|85.85|36.26|\n" + "97|9.32|72.21|42.17|\n"
+			+ "98|71.29|51.88|57.62|\n" + "99|31.39|7.27|88.74|";
+
+	public final static String CLUSTERCENTERS = "0|1.96|65.04|20.82|\n" + "1|53.99|84.23|81.59|\n" + "2|97.28|74.50|40.32|\n"
+			+ "3|63.57|24.53|87.07|\n" + "4|28.10|43.27|86.53|\n" + "5|99.51|62.70|64.48|\n" + "6|30.31|30.36|80.46|";
+
+	private final String NEWCLUSTERCENTERS = "0|28.47|54.80|21.88|\n" + "1|52.74|80.10|73.03|\n"
+			+ "2|83.92|60.45|25.17|\n" + "3|70.73|20.18|67.06|\n" + "4|22.51|47.19|86.23|\n" + "5|82.70|53.79|68.68|\n"
+			+ "6|29.74|19.17|59.16|";
+
+	protected String dataPath;
+	protected String clusterPath;
+	protected String resultPath;
+
+	
+	public KMeansStepBroadcastITCase(Configuration config) {
+		super(config);
+	}
+	
+	protected String getNewCenters() {
+		return NEWCLUSTERCENTERS;
+	}
+
+	@Override
+	protected void preSubmit() throws Exception {
+		final String dataPointDir = "dataPoints";
+		
+		dataPath = getTempDirPath(dataPointDir);
+		resultPath = getTempFilePath("iter_1");
+		
+		int numPartitions = 4;
+		String[] splits = splitInputString(DATAPOINTS, '\n', numPartitions);
+
+		for (int i = 0; i < numPartitions; i++) {
+			String split = splits[i];
+			createTempFile(dataPointDir + "/part_" + i + ".txt", split);
+		}
+		
+		// create cluster path and copy data
+		clusterPath = createTempFile("iter_0", CLUSTERCENTERS);
+	}
+	
+
+	@Override
+	protected Plan getTestJob() {
+		KMeansSingleStepBroadcast kmi = new KMeansSingleStepBroadcast();
+		return kmi.getPlan(config.getString("KMeansIterationTest#NoSubtasks", "1"), dataPath, clusterPath, resultPath);
+	}
+
+
+	@Override
+	protected void postSubmit() throws Exception {
+
+		final double MAX_DELTA = 0.1;
+		
+		Comparator<String> deltaComp = new Comparator<String>() {
+
+			@Override
+			public int compare(String o1, String o2) {
+				
+				StringTokenizer st1 = new StringTokenizer(o1, "|");
+				StringTokenizer st2 = new StringTokenizer(o2, "|");
+				
+				if(st1.countTokens() != st2.countTokens()) {
+					return st1.countTokens() - st2.countTokens();
+				}
+				
+				// first token is ID
+				String t1 = st1.nextToken();
+				String t2 = st2.nextToken();
+				if(!t1.equals(t2)) {
+					return t1.compareTo(t2);
+				}
+				
+				while(st1.hasMoreTokens()) {
+					t1 = st1.nextToken();
+					t2 = st2.nextToken();
+					
+					double d1 = Double.parseDouble(t1);
+					double d2 = Double.parseDouble(t2);
+					
+					if (Math.abs(d1-d2) > MAX_DELTA) {
+						return d1 < d2 ? -1 : 1;
+					}
+				}
+				
+				return 0;
+			}
+		};
+		
+		// ------- Test results -----------
+		
+		// Determine all result files
+
+
+		// collect lines of all result files
+		ArrayList<String> resultLines = new ArrayList<String>();
+		for (BufferedReader reader : getResultReader(resultPath)) {
+			String line = null;
+			while ((line = reader.readLine()) != null) {
+				resultLines.add(line);
+			}
+			reader.close();
+		}
+		
+		Collections.sort(resultLines, deltaComp);
+		
+		final String[] should = getNewCenters().split("\n");
+		final String[] is = (String[]) resultLines.toArray(new String[resultLines.size()]);
+		
+		Assert.assertEquals("Wrong number of result lines.", should.length, is.length);
+		
+		for (int i = 0; i < should.length; i++) {
+			StringTokenizer shouldRecord = new StringTokenizer(should[i], "|");
+			StringTokenizer isRecord = new StringTokenizer(is[i], "|");
+			
+			Assert.assertEquals("Records don't match.", shouldRecord.countTokens(), isRecord.countTokens());
+			
+			// first token is ID
+			String shouldToken = shouldRecord.nextToken();
+			String isToken = isRecord.nextToken();
+			
+			Assert.assertEquals("Records don't match.", shouldToken, isToken);
+
+			while (shouldRecord.hasMoreTokens()) {
+				shouldToken = shouldRecord.nextToken();
+				isToken = isRecord.nextToken();
+				
+				double shouldDouble = Double.parseDouble(shouldToken);
+				double isDouble = Double.parseDouble(isToken);
+				
+				Assert.assertTrue(shouldDouble - MAX_DELTA < isDouble && shouldDouble + MAX_DELTA > isDouble);
+			}
+		}
+	}
+
+	@Parameters
+	public static Collection<Object[]> getConfigurations() {
+		Configuration config1 = new Configuration();
+		config1.setInteger("KMeansIterationTest#NoSubtasks", 4);
+		config1.setString("KMeansIterationTest#ForwardSide", PactCompiler.HINT_SHIP_STRATEGY_FIRST_INPUT);
+		
+		Configuration config2 = new Configuration();
+		config2.setInteger("KMeansIterationTest#NoSubtasks", 4);
+		config2.setString("KMeansIterationTest#ForwardSide", PactCompiler.HINT_SHIP_STRATEGY_SECOND_INPUT);
+
+		return toParameterList(config1, config2);
+	}
+
+	private String[] splitInputString(String inputString, char splitChar, int noSplits) {
+		String splitString = inputString.toString();
+		String[] splits = new String[noSplits];
+		int partitionSize = (splitString.length() / noSplits) - 2;
+
+		// split data file and copy parts
+		for (int i = 0; i < noSplits - 1; i++) {
+			int cutPos = splitString.indexOf(splitChar, (partitionSize < splitString.length() ? partitionSize
+				: (splitString.length() - 1)));
+			splits[i] = splitString.substring(0, cutPos) + "\n";
+			splitString = splitString.substring(cutPos + 1);
+		}
+		splits[noSplits - 1] = splitString;
+
+		return splits;
+	}
+}


### PR DESCRIPTION
This is the third an final PR for issue #66 after PR #383 and PR #418. With this PR broadcast variables should be supported in trivial dataflows where the broadcast input is within the same iteration scope.

Please check [my comment](https://github.com/stratosphere/stratosphere/pull/383#issuecomment-33047450) in PR #383 for a proposed solution in order to add proper support for broadcast variables with nested iterations.
