### PR TITLE
stratosphere debian package fixes

### DIFF
--- a/stratosphere-dist/src/deb/control/control
+++ b/stratosphere-dist/src/deb/control/control
@@ -1,8 +1,8 @@
 Package: [[name]]
-Version: 0.2
+Version: [[version]]
 Section: misc
-Depends: java6-runtime
+Depends: default-jre
 Priority: low
 Architecture: all
-Description: [[description]]
-Maintainer: christian_richter@gmx.de
+Description: Stratosphere is a distributed parallel data processing system
+Maintainer: Stratosphere team <contact@getstratosphere.org>

--- a/stratosphere-dist/src/deb/control/postinst
+++ b/stratosphere-dist/src/deb/control/postinst
@@ -38,6 +38,8 @@ case "$1" in
             chown -R stratosphere:stratosphere /var/log/stratosphere-dist
         fi
 	sed -i s'#./resources/web-docs#/usr/share/stratosphere-dist/resources/web-docs#' /usr/share/stratosphere-dist/conf/stratosphere-conf.yaml
+    # append infoserver configuration
+    echo "jobmanager.web.rootpath: /usr/share/stratosphere-dist/resources/web-docs-infoserver" >> /usr/share/stratosphere-dist/conf/stratosphere-conf.yaml
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
The debian package is working quite well actually. I just fixed some minor naming issues.
(build it with `mvn clean package -DskipTests -Pdebian-package`)

```
ubuntu@ubuntu-VirtualBox:~$ sudo dpkg -i stratosphere-dist_0.5-SNAPSHOT.deb 
[sudo] password for ubuntu: 
Selecting previously unselected package stratosphere-dist.
(Reading database ... 177788 files and directories currently installed.)
Unpacking stratosphere-dist (from stratosphere-dist_0.5-SNAPSHOT.deb) ...
Setting up stratosphere-dist (0.5~SNAPSHOT) ...
Adding group `stratosphere' (GID 125) ...
Done.
Processing triggers for ureadahead ...
ureadahead will be reprofiled on next reboot
ubuntu@ubuntu-VirtualBox:~$ sudo /etc/init.d/jobmanager start
Starting stratosphere jobmanager daemon: Starting job manager
stratosphere-jobmanager.
ubuntu@ubuntu-VirtualBox:~$ sudo /etc/init.d/taskmanager start
Starting stratosphere taskmanager daemon: Starting task manager on host ubuntu-VirtualBox
stratosphere-taskmanager.
ubuntu@ubuntu-VirtualBox:~$ /usr/share/stratosphere-dist/bin/stratosphere
ERROR: Please specify an action.
./stratosphere [ACTION] [GENERAL_OPTIONS] [ACTION_ARGUMENTS]
  general options:
     -h,--help      Show the help for the CLI Frontend.
     -v,--verbose   Print more detailed error messages.
```

This PR resolves issue https://github.com/stratosphere/stratosphere/issues/247
