### PR TITLE
Stratosphere Job to generate input data for wordcount

### DIFF
--- a/stratosphere-examples/stratosphere-java-examples/pom.xml
+++ b/stratosphere-examples/stratosphere-java-examples/pom.xml
@@ -298,6 +298,7 @@
 
 							<includes>
 								<include>**/wordcount/*.class</include>
+								<include>**/util/*.class</include>
 							</includes>
 						</configuration>
 					</execution>

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/util/WordCountDataGenerator.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/util/WordCountDataGenerator.java
@@ -1,0 +1,85 @@
+package eu.stratosphere.example.java.record.util;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.Random;
+
+import org.apache.commons.lang.RandomStringUtils;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.common.operators.CollectionDataSource;
+import eu.stratosphere.api.common.operators.FileDataSink;
+import eu.stratosphere.api.common.operators.GenericDataSource;
+import eu.stratosphere.api.java.record.io.CsvOutputFormat;
+import eu.stratosphere.api.java.record.io.FileOutputFormat;
+import eu.stratosphere.api.java.record.io.GenericInputFormat;
+import eu.stratosphere.client.LocalExecutor;
+import eu.stratosphere.types.Record;
+import eu.stratosphere.types.StringValue;
+
+
+/**
+ * A simple Stratosphere Job that generates input data for wordcount.
+ *
+ */
+public class WordCountDataGenerator implements  Program {
+
+	public static class GeneratingIterator extends GenericInputFormat {
+
+		private Random rnd = new Random(1337);
+		int limit = 0;
+		StringValue line = new StringValue();
+		
+		public GeneratingIterator(int l) {
+			this.limit = l;
+		}
+		@Override
+		public boolean reachedEnd() throws IOException {
+			return limit-- <= 0;
+		}
+		@Override
+		public boolean nextRecord(Record record) throws IOException {
+			int words = rnd.nextInt(50);
+			StringBuffer r = new StringBuffer();
+			for(int i = 0; i < words; i++) {
+				r.append(RandomStringUtils.randomAlphabetic(rnd.nextInt(15)));
+				r.append(" ");
+			}
+			line.setValue(r);
+			record.setField(0, line);
+			return true;
+		}
+		
+	}
+	@Override
+	public Plan getPlan(String... args) {
+		if(args.length < 2) {
+			System.err.println("Wrong parameters. <outPath> <Lines per node> <Nodes>");
+			System.exit(1);
+		}
+		String outPath = args[0];
+		int l = Integer.parseInt(args[1]);
+		int dop = Integer.parseInt(args[2]);
+		
+		GenericDataSource<GeneratingIterator> src = new GenericDataSource<GeneratingIterator>(new GeneratingIterator(l), "Generate");
+		FileDataSink sink = new FileDataSink(new CsvOutputFormat(StringValue.class), outPath);
+		sink.setInput(src);
+		Plan p = new Plan(sink, "Generate Wordcount data");
+		p.setDefaultParallelism(dop);
+		return p;
+	}
+	public static void generateWCInput(String to) throws Exception {
+		WordCountDataGenerator wcg = new WordCountDataGenerator();
+		Plan p = wcg.getPlan(to, "100", "1");
+		System.err.println("Generating wordcount input to "+to);
+		LocalExecutor.execute(p);
+	}
+
+	public static void main(String[] args) throws Exception {
+		String tmp = System.getProperty("java.io.tmpdir");
+		String path = "file://"+tmp+"/wcinput";
+		generateWCInput(path);
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/WordCount.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/WordCount.java
@@ -13,6 +13,7 @@
 
 package eu.stratosphere.example.java.record.wordcount;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Iterator;
@@ -36,6 +37,7 @@ import eu.stratosphere.api.java.record.operators.MapOperator;
 import eu.stratosphere.api.java.record.operators.ReduceOperator;
 import eu.stratosphere.api.java.record.operators.ReduceOperator.Combinable;
 import eu.stratosphere.client.LocalExecutor;
+import eu.stratosphere.example.java.record.util.WordCountDataGenerator;
 import eu.stratosphere.nephele.client.JobExecutionResult;
 import eu.stratosphere.types.IntValue;
 import eu.stratosphere.types.Record;
@@ -141,9 +143,15 @@ public class WordCount implements Program, ProgramDescription {
 	public static void main(String[] args) throws Exception {
 		WordCount wc = new WordCount();
 		
-		if (args.length < 3) {
-			System.err.println(wc.getDescription());
-			System.exit(1);
+		if(args.length < 3) {
+			System.err.println("No arguments given.");
+			String tmp = System.getProperty("java.io.tmpdir");
+			String in = "file://"+tmp+"/wordcount-input";
+			if(!new File(tmp+"/wordcount-input").exists()) {
+				WordCountDataGenerator.generateWCInput(in);
+			}
+			String[] newArgs = {"1", in, "file://"+System.getProperty("java.io.tmpdir")+"/wordcount-output" };
+			args = newArgs;
 		}
 		
 		Plan plan = wc.getPlan(args);
@@ -152,6 +160,8 @@ public class WordCount implements Program, ProgramDescription {
 		// succeeding line to send the job to a local installation or to a cluster for execution
 		JobExecutionResult result = LocalExecutor.execute(plan);
 		System.err.println("Total runtime: " + result.getNetRuntime());
+		
+		System.err.println("\nWordcount has finished. Find the output in "+args[2]);
 //		PlanExecutor ex = new RemoteExecutor("localhost", 6123, "target/pact-examples-0.4-SNAPSHOT-WordCount.jar");
 //		ex.executePlan(plan);
 	}


### PR DESCRIPTION
I hacked together a little utility Stratosphere job that generates input data for wordcount. I wanted to have this to demonstrate Stratosphere with a few TB of input data on an Amazon AWS cloud.

Its not sophisticated at all, uses the same seed for all data sources and the generated strings are equally random distributed, not zipf or so. (So its not very good for a Wordcount-benchmark).

I also changed the current word count to generate some (really small) input data. It generates data automatically if the user did not specify any arguments. BUT: Our Wordcount now runs out of the box!
