### PR TITLE
Compiler deadlock detection

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
@@ -30,13 +30,13 @@ import org.apache.commons.logging.LogFactory;
 
 import eu.stratosphere.api.common.Plan;
 import eu.stratosphere.api.common.operators.BulkIteration;
+import eu.stratosphere.api.common.operators.BulkIteration.PartialSolutionPlaceHolder;
+import eu.stratosphere.api.common.operators.DeltaIteration;
+import eu.stratosphere.api.common.operators.DeltaIteration.SolutionSetPlaceHolder;
+import eu.stratosphere.api.common.operators.DeltaIteration.WorksetPlaceHolder;
 import eu.stratosphere.api.common.operators.GenericDataSink;
 import eu.stratosphere.api.common.operators.GenericDataSource;
 import eu.stratosphere.api.common.operators.Operator;
-import eu.stratosphere.api.common.operators.DeltaIteration;
-import eu.stratosphere.api.common.operators.BulkIteration.PartialSolutionPlaceHolder;
-import eu.stratosphere.api.common.operators.DeltaIteration.SolutionSetPlaceHolder;
-import eu.stratosphere.api.common.operators.DeltaIteration.WorksetPlaceHolder;
 import eu.stratosphere.api.common.operators.base.CoGroupOperatorBase;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
@@ -61,6 +61,7 @@ import eu.stratosphere.compiler.dag.SolutionSetNode;
 import eu.stratosphere.compiler.dag.TempMode;
 import eu.stratosphere.compiler.dag.WorksetIterationNode;
 import eu.stratosphere.compiler.dag.WorksetNode;
+import eu.stratosphere.compiler.deadlockdetect.DeadlockPreventer;
 import eu.stratosphere.compiler.plan.BinaryUnionPlanNode;
 import eu.stratosphere.compiler.plan.BulkIterationPlanNode;
 import eu.stratosphere.compiler.plan.BulkPartialSolutionPlanNode;
@@ -719,6 +720,9 @@ public class PactCompiler {
 		} else if (bestPlanRoot instanceof SinkJoinerPlanNode) {
 			((SinkJoinerPlanNode) bestPlanRoot).getDataSinks(bestPlanSinks);
 		}
+		
+		DeadlockPreventer dp = new DeadlockPreventer();
+		dp.resolveDeadlocks(bestPlanSinks);
 
 		// finalize the plan
 		OptimizedPlan plan = new PlanFinalizer().createFinalPlan(bestPlanSinks, program.getJobName(), program, memoryPerInstance);

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockEdge.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockEdge.java
@@ -1,0 +1,19 @@
+package eu.stratosphere.compiler.deadlockdetect;
+
+public class DeadlockEdge {
+	
+	private DeadlockVertex destination;
+	
+	public DeadlockEdge( DeadlockVertex d ){
+		destination = d;
+	}
+	   
+	public DeadlockVertex getDestination() {
+		return destination;
+	}
+
+	public void setDestination(DeadlockVertex destination) {
+		this.destination = destination;
+	}
+
+}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockGraph.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockGraph.java
@@ -1,0 +1,110 @@
+package eu.stratosphere.compiler.deadlockdetect;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+
+import eu.stratosphere.compiler.plan.PlanNode;
+
+public class DeadlockGraph {
+	
+	public Set<DeadlockVertex> vertices;
+	
+	public DeadlockGraph() {
+		this.vertices = new HashSet<DeadlockVertex>();
+	}
+	   
+	public Set<DeadlockVertex> vertices() {
+		return vertices;
+	}
+	   
+	public DeadlockVertex addVertex(PlanNode original) {
+		
+		DeadlockVertex v = new DeadlockVertex(original);
+		this.vertices.add(v);
+		return v;
+	}
+	
+	public void addEdge(PlanNode source, PlanNode destination) {
+		
+		DeadlockVertex dest = null;
+		for(DeadlockVertex v : vertices) {
+			if(v.getOriginal().equals(destination))
+				dest = v;
+		}
+		
+		for(DeadlockVertex v : vertices) {
+			if(v.getOriginal().equals(source)) {
+				v.addEdge(dest);
+			}
+		}
+		
+	}
+	   
+	public long size() {
+		return vertices.size();
+	}
+	
+	public String toString() {
+		StringBuilder out = new StringBuilder();
+		out.append("------------ GRAPH ------------\n");
+		for (DeadlockVertex n : vertices) {
+			out.append("Node " +n+"_\n");
+			for(DeadlockEdge a: n.getOutEdges()) {
+				out.append("\t->"+a.getDestination()+"\n");
+			}
+			out.append("\n");
+		}
+		
+		return out.toString();
+	}
+
+	public boolean hasCycle() {
+		
+	   Collection <DeadlockVertex> vertexCollect = this.vertices();
+	   
+	   Queue <DeadlockVertex> q; // Queue will store vertices that have in-degree of zero
+	
+	   // Calculate the in-degree of all vertices
+	   for (DeadlockVertex v: vertexCollect)
+	      v.setInDegree(0);
+	   
+	   for (DeadlockVertex v: vertexCollect) {
+	      for(DeadlockEdge edge : v.getOutEdges())
+	         edge.getDestination().setInDegree(edge.getDestination().getInDegree()+1);
+	   }
+	
+	   // Find all vertices with in-degree == 0 and put in queue 
+	   q = new LinkedList<DeadlockVertex>();
+	   for (DeadlockVertex v : vertexCollect) {
+	      if (v.getInDegree() == 0)
+	         q.offer(v);
+	   }
+	   
+	   while (!q.isEmpty()) {
+		   
+		   DeadlockVertex v = q.poll();
+		   this.vertices.remove(v);
+		   
+		   for (DeadlockEdge e: v.getOutEdges()) {
+			   
+			   DeadlockVertex w = e.getDestination();
+			   w.setInDegree(w.getInDegree() - 1);
+			   
+			   if(w.getInDegree() == 0) {
+				   q.offer(w);
+			   }
+		   }
+	   }
+	   
+	   if (!vertexCollect.isEmpty() ){
+	      return true;  //Cycle found
+	   }
+	   
+	   return false;
+	}
+
+	
+}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockPreventer.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockPreventer.java
@@ -1,0 +1,198 @@
+package eu.stratosphere.compiler.deadlockdetect;
+
+import java.util.ArrayList;
+import java.util.List;
+import eu.stratosphere.compiler.plan.BulkIterationPlanNode;
+import eu.stratosphere.compiler.plan.DualInputPlanNode;
+import eu.stratosphere.compiler.plan.PlanNode;
+import eu.stratosphere.compiler.plan.SingleInputPlanNode;
+import eu.stratosphere.compiler.plan.WorksetIterationPlanNode;
+import eu.stratosphere.pact.runtime.task.DamBehavior;
+import eu.stratosphere.pact.runtime.task.DriverStrategy;
+import eu.stratosphere.util.Visitor;
+
+/**
+ * 	Certain pipelined flows may lead to deadlocks, in which case we need to make sure the pipelines are broken or made elastic enough to prevent that.
+ *
+ *  This is only relevat to pipelined data flows where one operator has more than one consumers (successors in the flow).
+ *	
+ *	Most cases are caught by the general logic that deals with branching/joining flows. The following cases need additional checks:
+ *
+ *                    <build>
+ *  (source1) ------ (join)
+ *	          \    /    <probe>
+ *	           \  /
+ *	            \/
+ *	            /\
+ *	           /  \
+ *	          /    \    <probe>
+ *	(source2) ------(join)
+ *	                    <build>
+ *	
+ *	Since both sources pipeline their data into a build and a probe side, they get stalled by the back pressure from the probe side (which waits for the build side to complete) and never finish the build side.
+ *	
+ *	We can model dependencies of pipelined / materialized connections and do a reguar cyclic dependencies check to detect such situations. Pipelined connections have a dependency from sender to receiver, non-pipelined (fully dammed) connections have a dependency from receiver to sender.
+ *
+ */
+public class DeadlockPreventer implements Visitor<PlanNode> {
+	
+	private DeadlockGraph g;
+	
+	public DeadlockPreventer() {
+		this.g = new DeadlockGraph();
+	}
+
+	public void resolveDeadlocks(List<? extends PlanNode> sinks) {
+
+		for(PlanNode s : sinks) {
+			s.accept(this);
+		}
+		if(g.hasCycle()) {
+			
+			// in the remaining plan is a cycle
+			for(DeadlockVertex v : g.vertices) {
+
+				// first strategy to fix -> swap build and probe side
+				if(v.getOriginal().getDriverStrategy().equals(DriverStrategy.HYBRIDHASH_BUILD_FIRST)) {
+
+					v.getOriginal().setDriverStrategy(DriverStrategy.HYBRIDHASH_BUILD_SECOND);
+					
+					if(hasDeadlock(sinks)) {
+						// Didn't fix anything -> revert
+						v.getOriginal().setDriverStrategy(DriverStrategy.HYBRIDHASH_BUILD_FIRST);
+					}
+					else {
+						// deadlock resolved
+						break;
+					}
+				}
+				
+				// other direction
+				if(v.getOriginal().getDriverStrategy().equals(DriverStrategy.HYBRIDHASH_BUILD_SECOND)) {
+					
+					v.getOriginal().setDriverStrategy(DriverStrategy.HYBRIDHASH_BUILD_FIRST);
+					
+					if(hasDeadlock(sinks)) {
+						// Didn't fix anything -> revert
+						v.getOriginal().setDriverStrategy(DriverStrategy.HYBRIDHASH_BUILD_SECOND);
+					}
+					else {
+						// deadlock resolved
+						break;
+					}
+				}
+			}
+			
+			// switching build and probe side did not help -> pipeline breaker
+			for(DeadlockVertex v : g.vertices) {
+				if(v.getOriginal() instanceof DualInputPlanNode) {
+					DualInputPlanNode n = (DualInputPlanNode) v.getOriginal();
+					
+					// what is the pipelined side? (other side should be a dam, otherwise operator could not be source of deadlock)
+					if(!(n.getDriverStrategy().firstDam().equals(DamBehavior.FULL_DAM) || n.getInput1().getLocalStrategy().dams() || n.getInput1().getTempMode().breaksPipeline())
+							&& (n.getDriverStrategy().secondDam().equals(DamBehavior.FULL_DAM) || n.getInput2().getLocalStrategy().dams() || n.getInput2().getTempMode().breaksPipeline())) {
+						n.getInput1().setTempMode(n.getInput1().getTempMode().makePipelineBreaker());
+					}
+					else if( !(n.getDriverStrategy().secondDam().equals(DamBehavior.FULL_DAM) || n.getInput2().getLocalStrategy().dams() || n.getInput2().getTempMode().breaksPipeline())
+							&& (n.getDriverStrategy().firstDam().equals(DamBehavior.FULL_DAM) || n.getInput1().getLocalStrategy().dams() || n.getInput1().getTempMode().breaksPipeline())) {
+						n.getInput2().setTempMode(n.getInput2().getTempMode().makePipelineBreaker());
+					}
+					
+					// Deadlock resolved?
+					if(!hasDeadlock(sinks)) {
+						break;
+					}
+				}
+			}
+		}
+	
+	}
+	
+	/**
+	 * Creates new DeadlockGraph from plan and checks for cycles
+	 * 
+	 * @param plan
+	 * @return
+	 */
+	public boolean hasDeadlock(List<? extends PlanNode> sinks) {
+		this.g = new DeadlockGraph();
+		
+		for(PlanNode s : sinks) {
+			s.accept(this);
+		}
+		
+		if(g.hasCycle())
+			return true;
+		else
+			return false;
+	}
+
+	/**
+	 * 
+	 * @param visitable
+	 * @return
+	 */
+	@Override
+	public boolean preVisit(PlanNode visitable) {
+		
+		g.addVertex(visitable);
+		return true;
+	}
+
+	@Override
+	public void postVisit(PlanNode visitable) {
+		if(visitable instanceof SingleInputPlanNode) {
+			SingleInputPlanNode n = (SingleInputPlanNode) visitable;
+			
+			if(n.getDriverStrategy().firstDam().equals(DamBehavior.FULL_DAM) || n.getInput().getLocalStrategy().dams() || n.getInput().getTempMode().breaksPipeline()) {
+				g.addEdge(n, n.getPredecessor());
+			}
+			else {
+				g.addEdge(n.getPredecessor(), n);
+			}
+		}
+		else if(visitable instanceof DualInputPlanNode) {
+			DualInputPlanNode n = (DualInputPlanNode) visitable;
+			
+			if(n.getDriverStrategy().firstDam().equals(DamBehavior.FULL_DAM) || n.getInput1().getLocalStrategy().dams() || n.getInput1().getTempMode().breaksPipeline()) {
+				g.addEdge(n, n.getInput1().getSource());
+			}
+			else {
+				g.addEdge(n.getInput1().getSource(), n);
+			}
+			
+			if(!n.getDriverStrategy().equals(DriverStrategy.NONE) && (n.getDriverStrategy().secondDam().equals(DamBehavior.FULL_DAM) || n.getInput2().getLocalStrategy().dams() || n.getInput2().getTempMode().breaksPipeline())) {
+				g.addEdge(n, n.getInput2().getSource());
+			}
+			else {
+				g.addEdge(n.getInput2().getSource(), n);
+			}
+		}
+		
+		
+		// recursively fix iterations
+		if (visitable instanceof BulkIterationPlanNode) {
+			
+			DeadlockPreventer dp = new DeadlockPreventer();
+			List<PlanNode> planSinks = new ArrayList<PlanNode>(1);
+			
+			BulkIterationPlanNode pspn = (BulkIterationPlanNode) visitable;
+			planSinks.add(pspn.getRootOfStepFunction());
+			
+			dp.resolveDeadlocks(planSinks);
+			
+		}
+		else if (visitable instanceof WorksetIterationPlanNode) {
+			
+			DeadlockPreventer dp = new DeadlockPreventer();
+			List<PlanNode> planSinks = new ArrayList<PlanNode>(2);
+			
+			WorksetIterationPlanNode pspn = (WorksetIterationPlanNode) visitable;
+			planSinks.add(pspn.getSolutionSetDeltaPlanNode());
+			planSinks.add(pspn.getNextWorkSetPlanNode());
+			
+			dp.resolveDeadlocks(planSinks);
+			
+		}
+	}
+}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockVertex.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/deadlockdetect/DeadlockVertex.java
@@ -1,0 +1,76 @@
+package eu.stratosphere.compiler.deadlockdetect;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import eu.stratosphere.compiler.plan.PlanNode;
+
+public class DeadlockVertex {
+	
+	private PlanNode original;
+	   
+	private List<DeadlockEdge> outEdges;
+	   
+	private int inDegree;
+	   
+	public DeadlockVertex( PlanNode original ) {
+		this.original = original;
+		outEdges = new LinkedList<DeadlockEdge>();
+		inDegree = 0;
+	}
+	   
+	public void addEdge(DeadlockVertex destination) {
+		
+		// no duplicates
+		for(DeadlockEdge e : outEdges) {
+			if(e.getDestination().equals(destination))
+				return;
+		}
+		
+		DeadlockEdge e = new DeadlockEdge(destination);
+		this.outEdges.add(e);
+	}
+	   
+	public boolean equals(Object o) {
+		   
+		if(!(o instanceof DeadlockVertex))
+			return false;
+		   
+		DeadlockVertex v = (DeadlockVertex) o;
+		if(v.getOriginal().equals(this.getOriginal()))
+			return true;
+		
+		return false;
+	}
+	
+	public int hashCode() {
+		return this.original.hashCode();
+	}
+	
+	public String toString() {
+		return original.toString();
+	}
+	public PlanNode getOriginal() {
+		return original;
+	}
+
+	public void setOriginal(PlanNode original) {
+		this.original = original;
+	}
+
+	public int getInDegree() {
+		return inDegree;
+	}
+
+	public void setInDegree(int inDegree) {
+		this.inDegree = inDegree;
+	}
+	
+	public List<DeadlockEdge> getOutEdges() {
+		return outEdges;
+	}
+
+	public void setOutEdges(List<DeadlockEdge> outEdges) {
+		this.outEdges = outEdges;
+	}
+}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
@@ -52,7 +52,7 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	
 	private final String nodeName; 
 	
-	private final DriverStrategy driverStrategy;	// The local strategy (sorting / hashing, ...)
+	private DriverStrategy driverStrategy;	// The local strategy (sorting / hashing, ...)
 	
 	protected LocalProperties localProps; 			// local properties of the data produced by this node
 
@@ -181,6 +181,15 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	 */
 	public DriverStrategy getDriverStrategy() {
 		return this.driverStrategy;
+	}
+	
+	/**
+	 * Sets the driver strategy for this node. Usually should not be changed.
+	 * 
+	 * @return The driver strategy.
+	 */
+	public void setDriverStrategy(DriverStrategy newDriverStrategy) {
+		this.driverStrategy = newDriverStrategy;
 	}
 	
 	public void initProperties(GlobalProperties globals, LocalProperties locals) {


### PR DESCRIPTION
I implemented a deadlock detection inside the compiler. For details see #516. Basically I build a dependency graph and check for cycles. If there is a cycle I try to fix the deadlock by first trying to switch build and probe side of hash joins. If that does not work I insert pipeline breakers and force materialization.

I am not 100% sure that all cases of deadlocks in combinations with iterations are detected. Especially I couldn't take care of deadlocks that occure in combination with the termination criterion of the BulkIteration, since it is not yet part of the master.
