### PR TITLE
[yarn] Major YARN-Client improvements

### DIFF
--- a/stratosphere-addons/yarn/pom.xml
+++ b/stratosphere-addons/yarn/pom.xml
@@ -38,5 +38,11 @@
 			<artifactId>hadoop-hdfs</artifactId>
 			<version>${hadoop.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-mapreduce-client-core</artifactId>
+			<version>${hadoop.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/stratosphere-core/src/main/java/eu/stratosphere/configuration/ConfigConstants.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/configuration/ConfigConstants.java
@@ -198,6 +198,9 @@ public final class ConfigConstants {
 	 */
 	public static final String JOB_MANAGER_WEB_ARCHIVE_COUNT = "jobmanager.web.history";
 	
+	public static final String JOB_MANAGER_WEB_LOG_PATH_KEY = "jobmanager.web.logpath";
+	
+	
 	// ------------------------------ Web Client ------------------------------
 	
 	/**
@@ -236,6 +239,10 @@ public final class ConfigConstants {
 	 * The key for Stratosphere's base directory path
 	 */
 	public static final String STRATOSPHERE_BASE_DIR_PATH_KEY = "stratosphere.base.dir.path";
+	
+	public static final String STRATOSPHERE_JVM_OPTIONS = "env.java.opts";
+	
+	
 
 	
 	
@@ -404,6 +411,7 @@ public final class ConfigConstants {
 	 * The default directory to store uploaded jobs in.
 	 */
 	public static final String DEFAULT_WEB_JOB_STORAGE_DIR = DEFAULT_WEB_TMP_DIR + "/webclient-jobs/";
+	
 
 	/**
 	 * The default path to the file containing the list of access privileged users and passwords.
@@ -416,12 +424,13 @@ public final class ConfigConstants {
 	/**
 	 * The default definition for an instance type, if no other configuration is provided.
 	 */
-	public static final String DEFAULT_INSTANCE_TYPE = "default,2,1,1024,10,10";
+	public static final String DEFAULT_INSTANCE_TYPE = "default,1,1,1,1,0"; // minimalistic instance type until "cloud" model is fully removed.
 
 	/**
 	 * The default index for the default instance type.
 	 */
 	public static final int DEFAULT_DEFAULT_INSTANCE_TYPE_INDEX = 1;
+
 	
 	// ------------------------------------------------------------------------
 	

--- a/stratosphere-dist/src/main/assemblies/yarn.xml
+++ b/stratosphere-dist/src/main/assemblies/yarn.xml
@@ -30,6 +30,17 @@
 				<exclude>**/*</exclude>
 			</excludes>
 		</fileSet>
+
+		<fileSet>
+			<!-- create an empty ship directory -->
+			<directory>src/main/stratosphere-bin/</directory>
+			<outputDirectory>ship</outputDirectory>
+			<fileMode>0644</fileMode>
+			<excludes>
+				<exclude>**/*</exclude>
+			</excludes>
+		</fileSet>
+
 		<fileSet>
 			<!-- copy *.txt files -->
 			<directory>src/main/stratosphere-bin/</directory>

--- a/stratosphere-dist/src/main/stratosphere-bin/conf/stratosphere-conf.yaml
+++ b/stratosphere-dist/src/main/stratosphere-bin/conf/stratosphere-conf.yaml
@@ -50,6 +50,9 @@ jobmanager.web.history: 5
 #                                                   TASK MANAGER (WORKERs)
 #=======================================================================================================================
 
+# Stratosphere chooses a port automatically, if this value is not set.
+# If setting this variable when using YARN, beware that there might be conflicts when multiple
+# TaskManagers are running on the same machine.
 #taskmanager.rpc.port: 6122
 
 # JVM heap size in MB

--- a/stratosphere-dist/src/main/stratosphere-bin/yarn-bin/yarn-session.sh
+++ b/stratosphere-dist/src/main/stratosphere-bin/yarn-bin/yarn-session.sh
@@ -49,5 +49,5 @@ CC_CLASSPATH=`manglePathList $(constructCLIClientClassPath)`
 export STRATOSPHERE_CONF_DIR
 # $log_setting
 
-$JAVA_RUN $JVM_ARGS  -classpath $CC_CLASSPATH eu.stratosphere.yarn.Client -j $STRATOSPHERE_LIB_DIR/*yarn-uberjar.jar -c $STRATOSPHERE_CONF_DIR/stratosphere-conf.yaml $*
+$JAVA_RUN $JVM_ARGS  -classpath $CC_CLASSPATH eu.stratosphere.yarn.Client -ship ship/ -confDir $STRATOSPHERE_CONF_DIR -j $STRATOSPHERE_LIB_DIR/*yarn-uberjar.jar $*
 

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/InstanceConnectionInfo.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/instance/InstanceConnectionInfo.java
@@ -238,11 +238,13 @@ public class InstanceConnectionInfo implements IOReadableWritable, Comparable<In
 	public String toString() {
 
 		String iaString;
+		String portsString = " (ipcPort="+ipcPort+", dataPort="+dataPort+")";
 		if (this.hostName != null) {
-			iaString = this.hostName;
+			iaString = this.hostName+portsString;
 		} else {
 			iaString = inetAddress.toString();
 			iaString = iaString.replace("/", "");
+			iaString += portsString;
 		}
 
 		return iaString;

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/jobmanager/web/LogfileInfoServlet.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/jobmanager/web/LogfileInfoServlet.java
@@ -51,7 +51,9 @@ public class LogfileInfoServlet extends HttpServlet {
 				// Find current stdtout file
 				for(File f : logDir.listFiles()) {
 					// contains "jobmanager" ".log" and no number in the end ->needs improvement
-					if(f.getName().indexOf("jobmanager") != -1 && f.getName().indexOf(".out") != -1 && ! Character.isDigit(f.getName().charAt(f.getName().length() - 1) )) {
+					if( f.getName().equals("jobmanager-stdout.log") ||
+							(f.getName().indexOf("jobmanager") != -1 && f.getName().indexOf(".out") != -1 && ! Character.isDigit(f.getName().charAt(f.getName().length() - 1) ))
+							) {
 						
 						resp.setStatus(HttpServletResponse.SC_OK);
 						resp.setContentType("text/plain ");
@@ -64,7 +66,8 @@ public class LogfileInfoServlet extends HttpServlet {
 				// Find current logfile
 				for(File f : logDir.listFiles()) {
 					// contains "jobmanager" ".log" and no number in the end ->needs improvement
-					if(f.getName().indexOf("jobmanager") != -1 && f.getName().indexOf(".log") != -1 && ! Character.isDigit(f.getName().charAt(f.getName().length() - 1) )) {
+					if( f.getName().equals("jobmanager-stderr.log") ||
+							(f.getName().indexOf("jobmanager") != -1 && f.getName().indexOf(".log") != -1 && ! Character.isDigit(f.getName().charAt(f.getName().length() - 1) ))) {
 						
 						resp.setStatus(HttpServletResponse.SC_OK);
 						resp.setContentType("text/plain ");

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/jobmanager/web/WebInfoServer.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/jobmanager/web/WebInfoServer.java
@@ -77,6 +77,8 @@ public class WebInfoServer {
 		// get base path of Stratosphere installation
 		String basePath = nepheleConfig.getString(ConfigConstants.STRATOSPHERE_BASE_DIR_PATH_KEY, "");
 		String webDirPath = nepheleConfig.getString(ConfigConstants.JOB_MANAGER_WEB_ROOT_PATH_KEY, ConfigConstants.DEFAULT_JOB_MANAGER_WEB_ROOT_PATH);
+		String logDirPath = nepheleConfig.getString(ConfigConstants.JOB_MANAGER_WEB_LOG_PATH_KEY, 
+				basePath+"/log");
 		
 		File webDir;
 		if(webDirPath.startsWith("/")) {
@@ -110,7 +112,7 @@ public class WebInfoServer {
 		ServletContextHandler servletContext = new ServletContextHandler(ServletContextHandler.SESSIONS);
 		servletContext.setContextPath("/");
 		servletContext.addServlet(new ServletHolder(new JobmanagerInfoServlet(jobmanager)), "/jobsInfo");
-		servletContext.addServlet(new ServletHolder(new LogfileInfoServlet(new File(basePath+"/log"))), "/logInfo");
+		servletContext.addServlet(new ServletHolder(new LogfileInfoServlet(new File(logDirPath))), "/logInfo");
 
 
 		// ----- the handler serving all the static files -----


### PR DESCRIPTION
- HDFS security token support (resolves https://github.com/stratosphere/stratosphere/issues/492)
- "ship/" directory to transfer files to all TaskManagers (user-files)
- Log4j-based logging (YARN now respects the logging configuration) (resolves https://github.com/stratosphere/stratosphere/issues/493)
- the YARN-client deletes all "temp" files from HDFS.
- The JVMs started by YARN now respect the configured JVM opts in the yaml-file (resolves https://github.com/stratosphere/stratosphere/issues/501)
- the JobManager webinterface shows the log file (e.g it is aware of the YARN-specific log-directory)
- The YARN-client now creates a hidden ".yarn-jobmanager" with the address of the JobManager in YARN. users do not have to specify the -m argument anymore.
- Fix a little bug with the JobManager's "cloud" model for taskManager with less that 1GB memory.
- TM ports are now assigned based on the ports availability on the machine. (Users can still "hardcode" a port)
- Tested on Cloudera Hadoop 5 Beta 2
- Tested on Cloduera Hadoop 5 Beta 2 WITH CDH5-B2 Maven Dependencies.
- Tested on Hadoop 2.2.0
- Tested on Hadoop 2.3.0 (resolves https://github.com/stratosphere/stratosphere/issues/500)
- Tested on Amazon EMR
