### PR TITLE
Reuse of already generated OptimizerNodes in the recursive descent step of GraphCreatingVisitor

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
@@ -787,11 +787,16 @@ public class PactCompiler {
 
 		
 		private GraphCreatingVisitor(int maxMachines, int defaultParallelism) {
-			this(null, false, maxMachines, defaultParallelism);
+			this(null, false, maxMachines, defaultParallelism, null);
 		}
 		
-		private GraphCreatingVisitor(GraphCreatingVisitor parent, boolean forceDOP, int maxMachines, int defaultParallelism) {
-			this.con2node = new HashMap<Operator, OptimizerNode>();
+		private GraphCreatingVisitor(GraphCreatingVisitor parent, boolean forceDOP, int maxMachines,
+                                     int defaultParallelism, HashMap<Operator, OptimizerNode> closure) {
+            if(closure == null){
+                con2node = new HashMap<Operator, OptimizerNode>();
+            }else{
+                con2node = closure;
+            }
 			this.sources = new ArrayList<DataSourceNode>(4);
 			this.sinks = new ArrayList<DataSinkNode>(2);
 			this.maxMachines = maxMachines;
@@ -931,10 +936,13 @@ public class PactCompiler {
 			if (n instanceof BulkIterationNode) {
 				final BulkIterationNode iterNode = (BulkIterationNode) n;
 				final BulkIteration iter = iterNode.getIterationContract();
-				
+
+                // calculate closure of the anonymous function
+                HashMap<Operator, OptimizerNode> closure = new HashMap<Operator, OptimizerNode>(con2node);
+
 				// first, recursively build the data flow for the step function
 				final GraphCreatingVisitor recursiveCreator = new GraphCreatingVisitor(this, true,
-					this.maxMachines, iterNode.getDegreeOfParallelism());
+					this.maxMachines, iterNode.getDegreeOfParallelism(), closure);
 				
 				BulkPartialSolutionNode partialSolution = null;
 				
@@ -979,10 +987,13 @@ public class PactCompiler {
 			else if (n instanceof WorksetIterationNode) {
 				final WorksetIterationNode iterNode = (WorksetIterationNode) n;
 				final DeltaIteration iter = iterNode.getIterationContract();
+
+                // calculate the closure of the anonymous function
+                HashMap<Operator, OptimizerNode> closure = new HashMap<Operator, OptimizerNode>(con2node);
 				
 				// first, recursively build the data flow for the step function
 				final GraphCreatingVisitor recursiveCreator = new GraphCreatingVisitor(this, true,
-					this.maxMachines, iterNode.getDegreeOfParallelism());
+					this.maxMachines, iterNode.getDegreeOfParallelism(), closure);
 				// descend from the solution set delta. check that it depends on both the workset
 				// and the solution set. If it does depend on both, this descend should create both nodes
 				iter.getSolutionSetDelta().accept(recursiveCreator);
@@ -1047,7 +1058,7 @@ public class PactCompiler {
 				// go over the contained data flow and mark the dynamic path nodes
 				StaticDynamicPathIdentifier pathIdentifier = new StaticDynamicPathIdentifier(iterNode.getCostWeight());
 				nextWorksetNode.accept(pathIdentifier);
-				solutionSetDeltaNode.accept(pathIdentifier);
+				iterNode.getSolutionSetDelta().accept(pathIdentifier);
 			}
 		}
 		
@@ -1188,11 +1199,11 @@ public class PactCompiler {
 
 		@Override
 		public void postVisit(OptimizerNode node) {
-			node.computeUnclosedBranchStack();
-			
 			if (node instanceof IterationNode) {
 				((IterationNode) node).acceptForStepFunction(this);
 			}
+
+            node.computeUnclosedBranchStack();
 		}
 	};
 	

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
@@ -789,14 +789,14 @@ public class PactCompiler {
 		private GraphCreatingVisitor(int maxMachines, int defaultParallelism) {
 			this(null, false, maxMachines, defaultParallelism, null);
 		}
-		
+
 		private GraphCreatingVisitor(GraphCreatingVisitor parent, boolean forceDOP, int maxMachines,
-                                     int defaultParallelism, HashMap<Operator, OptimizerNode> closure) {
-            if(closure == null){
-                con2node = new HashMap<Operator, OptimizerNode>();
-            }else{
-                con2node = closure;
-            }
+									 int defaultParallelism, HashMap<Operator, OptimizerNode> closure) {
+			if(closure == null){
+				con2node = new HashMap<Operator, OptimizerNode>();
+			}else{
+				con2node = closure;
+			}
 			this.sources = new ArrayList<DataSourceNode>(4);
 			this.sinks = new ArrayList<DataSinkNode>(2);
 			this.maxMachines = maxMachines;
@@ -937,8 +937,8 @@ public class PactCompiler {
 				final BulkIterationNode iterNode = (BulkIterationNode) n;
 				final BulkIteration iter = iterNode.getIterationContract();
 
-                // calculate closure of the anonymous function
-                HashMap<Operator, OptimizerNode> closure = new HashMap<Operator, OptimizerNode>(con2node);
+				// calculate closure of the anonymous function
+				HashMap<Operator, OptimizerNode> closure = new HashMap<Operator, OptimizerNode>(con2node);
 
 				// first, recursively build the data flow for the step function
 				final GraphCreatingVisitor recursiveCreator = new GraphCreatingVisitor(this, true,
@@ -988,9 +988,9 @@ public class PactCompiler {
 				final WorksetIterationNode iterNode = (WorksetIterationNode) n;
 				final DeltaIteration iter = iterNode.getIterationContract();
 
-                // calculate the closure of the anonymous function
-                HashMap<Operator, OptimizerNode> closure = new HashMap<Operator, OptimizerNode>(con2node);
-				
+				// calculate the closure of the anonymous function
+				HashMap<Operator, OptimizerNode> closure = new HashMap<Operator, OptimizerNode>(con2node);
+
 				// first, recursively build the data flow for the step function
 				final GraphCreatingVisitor recursiveCreator = new GraphCreatingVisitor(this, true,
 					this.maxMachines, iterNode.getDegreeOfParallelism(), closure);
@@ -1203,7 +1203,7 @@ public class PactCompiler {
 				((IterationNode) node).acceptForStepFunction(this);
 			}
 
-            node.computeUnclosedBranchStack();
+			node.computeUnclosedBranchStack();
 		}
 	};
 	

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
@@ -238,27 +238,27 @@ public class BulkIterationNode extends SingleInputNode implements IterationNode 
 		this.inConn.setInterestingProperties(inProps);
 	}
 
-    @Override
-    public void computeUnclosedBranchStack() {
-        if (this.openBranches != null) {
-            return;
-        }
+	@Override
+	public void computeUnclosedBranchStack() {
+		if (this.openBranches != null) {
+			return;
+		}
 
-        // handle the data flow branching for the regular inputs
-        addClosedBranches(getPredecessorNode().closedBranchingNodes);
-        addClosedBranches(getNextPartialSolution().closedBranchingNodes);
+		// handle the data flow branching for the regular inputs
+		addClosedBranches(getPredecessorNode().closedBranchingNodes);
+		addClosedBranches(getNextPartialSolution().closedBranchingNodes);
 
-        List<UnclosedBranchDescriptor> result1 = getPredecessorNode().getBranchesForParent(this.inConn);
-        List<UnclosedBranchDescriptor> result2 = getSingleRootOfStepFunction().openBranches;
+		List<UnclosedBranchDescriptor> result1 = getPredecessorNode().getBranchesForParent(this.inConn);
+		List<UnclosedBranchDescriptor> result2 = getSingleRootOfStepFunction().openBranches;
 
-        ArrayList<UnclosedBranchDescriptor> inputsMerged = new ArrayList<UnclosedBranchDescriptor>();
-        mergeLists(result1, result2, inputsMerged);
+		ArrayList<UnclosedBranchDescriptor> inputsMerged = new ArrayList<UnclosedBranchDescriptor>();
+		mergeLists(result1, result2, inputsMerged);
 
-        // handle the data flow branching for the broadcast inputs
-        List<UnclosedBranchDescriptor> result = computeUnclosedBranchStackForBroadcastInputs(inputsMerged);
+		// handle the data flow branching for the broadcast inputs
+		List<UnclosedBranchDescriptor> result = computeUnclosedBranchStackForBroadcastInputs(inputsMerged);
 
-        this.openBranches = (result == null || result.isEmpty()) ? Collections.<UnclosedBranchDescriptor>emptyList() : result;
-    }
+		this.openBranches = (result == null || result.isEmpty()) ? Collections.<UnclosedBranchDescriptor>emptyList() : result;
+	}
 
 
     @Override

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
@@ -13,10 +13,7 @@
 
 package eu.stratosphere.compiler.dag;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import eu.stratosphere.api.common.operators.BulkIteration;
 import eu.stratosphere.compiler.CompilerException;
@@ -240,8 +237,31 @@ public class BulkIterationNode extends SingleInputNode implements IterationNode 
 		inProps.addLocalProperties(new RequestedLocalProperties());
 		this.inConn.setInterestingProperties(inProps);
 	}
-	
-	@Override
+
+    @Override
+    public void computeUnclosedBranchStack() {
+        if (this.openBranches != null) {
+            return;
+        }
+
+        // handle the data flow branching for the regular inputs
+        addClosedBranches(getPredecessorNode().closedBranchingNodes);
+        addClosedBranches(getNextPartialSolution().closedBranchingNodes);
+
+        List<UnclosedBranchDescriptor> result1 = getPredecessorNode().getBranchesForParent(this.inConn);
+        List<UnclosedBranchDescriptor> result2 = getSingleRootOfStepFunction().openBranches;
+
+        ArrayList<UnclosedBranchDescriptor> inputsMerged = new ArrayList<UnclosedBranchDescriptor>();
+        mergeLists(result1, result2, inputsMerged);
+
+        // handle the data flow branching for the broadcast inputs
+        List<UnclosedBranchDescriptor> result = computeUnclosedBranchStackForBroadcastInputs(inputsMerged);
+
+        this.openBranches = (result == null || result.isEmpty()) ? Collections.<UnclosedBranchDescriptor>emptyList() : result;
+    }
+
+
+    @Override
 	protected void instantiateCandidate(OperatorDescriptorSingle dps, Channel in, List<Set<? extends NamedChannel>> broadcastPlanChannels, 
 			List<PlanNode> target, CostEstimator estimator, RequestedGlobalProperties globPropsReq, RequestedLocalProperties locPropsReq)
 	{

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/PlanCacheCleaner.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/PlanCacheCleaner.java
@@ -20,7 +20,7 @@ final class PlanCacheCleaner implements Visitor<OptimizerNode> {
 
 	@Override
 	public boolean preVisit(OptimizerNode visitable) {
-		if (visitable.cachedPlans != null) {
+		if (visitable.cachedPlans != null && visitable.isOnDynamicPath()) {
 			visitable.cachedPlans = null;
 			return true;
 		} else {

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/WorksetIterationNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/WorksetIterationNode.java
@@ -379,32 +379,32 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 		}
 	}
 
-    @Override
-    public void computeUnclosedBranchStack() {
-        if (this.openBranches != null) {
-            return;
-        }
+	@Override
+	public void computeUnclosedBranchStack() {
+		if (this.openBranches != null) {
+			return;
+		}
 
-        // handle the data flow branching for the regular inputs
-        addClosedBranches(getFirstPredecessorNode().closedBranchingNodes);
-        addClosedBranches(getSecondPredecessorNode().closedBranchingNodes);
-        addClosedBranches(getSingleRootOfStepFunction().closedBranchingNodes);
+		// handle the data flow branching for the regular inputs
+		addClosedBranches(getFirstPredecessorNode().closedBranchingNodes);
+		addClosedBranches(getSecondPredecessorNode().closedBranchingNodes);
+		addClosedBranches(getSingleRootOfStepFunction().closedBranchingNodes);
 
-        List<UnclosedBranchDescriptor> result1 = getFirstPredecessorNode().getBranchesForParent(getFirstIncomingConnection());
-        List<UnclosedBranchDescriptor> result2 = getSecondPredecessorNode().getBranchesForParent(getSecondIncomingConnection());
-        List<UnclosedBranchDescriptor> result3 = getSingleRootOfStepFunction().openBranches;
+		List<UnclosedBranchDescriptor> result1 = getFirstPredecessorNode().getBranchesForParent(getFirstIncomingConnection());
+		List<UnclosedBranchDescriptor> result2 = getSecondPredecessorNode().getBranchesForParent(getSecondIncomingConnection());
+		List<UnclosedBranchDescriptor> result3 = getSingleRootOfStepFunction().openBranches;
 
-        ArrayList<UnclosedBranchDescriptor> inputsMerged1 = new ArrayList<UnclosedBranchDescriptor>();
-        ArrayList<UnclosedBranchDescriptor> inputsMerged2 = new ArrayList<UnclosedBranchDescriptor>();
+		ArrayList<UnclosedBranchDescriptor> inputsMerged1 = new ArrayList<UnclosedBranchDescriptor>();
+		ArrayList<UnclosedBranchDescriptor> inputsMerged2 = new ArrayList<UnclosedBranchDescriptor>();
 
-        mergeLists(result1, result2, inputsMerged1);
-        mergeLists(inputsMerged1, result3, inputsMerged2);
+		mergeLists(result1, result2, inputsMerged1);
+		mergeLists(inputsMerged1, result3, inputsMerged2);
 
-        // handle the data flow branching for the broadcast inputs
-        List<UnclosedBranchDescriptor> result = computeUnclosedBranchStackForBroadcastInputs(inputsMerged2);
+		// handle the data flow branching for the broadcast inputs
+		List<UnclosedBranchDescriptor> result = computeUnclosedBranchStackForBroadcastInputs(inputsMerged2);
 
-        this.openBranches = (result == null || result.isEmpty()) ? Collections.<UnclosedBranchDescriptor>emptyList() : result;
-    }
+		this.openBranches = (result == null || result.isEmpty()) ? Collections.<UnclosedBranchDescriptor>emptyList() : result;
+	}
 	
 	// --------------------------------------------------------------------------------------------
 	//                      Iteration Specific Traversals

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/WorksetIterationNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/WorksetIterationNode.java
@@ -378,6 +378,33 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 			}
 		}
 	}
+
+    @Override
+    public void computeUnclosedBranchStack() {
+        if (this.openBranches != null) {
+            return;
+        }
+
+        // handle the data flow branching for the regular inputs
+        addClosedBranches(getFirstPredecessorNode().closedBranchingNodes);
+        addClosedBranches(getSecondPredecessorNode().closedBranchingNodes);
+        addClosedBranches(getSingleRootOfStepFunction().closedBranchingNodes);
+
+        List<UnclosedBranchDescriptor> result1 = getFirstPredecessorNode().getBranchesForParent(getFirstIncomingConnection());
+        List<UnclosedBranchDescriptor> result2 = getSecondPredecessorNode().getBranchesForParent(getSecondIncomingConnection());
+        List<UnclosedBranchDescriptor> result3 = getSingleRootOfStepFunction().openBranches;
+
+        ArrayList<UnclosedBranchDescriptor> inputsMerged1 = new ArrayList<UnclosedBranchDescriptor>();
+        ArrayList<UnclosedBranchDescriptor> inputsMerged2 = new ArrayList<UnclosedBranchDescriptor>();
+
+        mergeLists(result1, result2, inputsMerged1);
+        mergeLists(inputsMerged1, result3, inputsMerged2);
+
+        // handle the data flow branching for the broadcast inputs
+        List<UnclosedBranchDescriptor> result = computeUnclosedBranchStackForBroadcastInputs(inputsMerged2);
+
+        this.openBranches = (result == null || result.isEmpty()) ? Collections.<UnclosedBranchDescriptor>emptyList() : result;
+    }
 	
 	// --------------------------------------------------------------------------------------------
 	//                      Iteration Specific Traversals
@@ -466,5 +493,6 @@ public class WorksetIterationNode extends TwoInputNode implements IterationNode 
 		protected void computeOperatorSpecificDefaultEstimates(DataStatistics statistics) {
 			// no estimates are needed here
 		}
+
 	}
 }

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/BulkIterationPlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/BulkIterationPlanNode.java
@@ -25,6 +25,8 @@ import eu.stratosphere.compiler.dag.TwoInputNode;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
 import eu.stratosphere.util.Visitor;
 
+import java.util.Map;
+
 /**
  * 
  */
@@ -46,6 +48,8 @@ public class BulkIterationPlanNode extends SingleInputPlanNode implements Iterat
 		super(template, nodeName, input, DriverStrategy.NONE);
 		this.partialSolutionPlanNode = pspn;
 		this.rootOfStepFunction = rootOfStepFunction;
+
+        mergeBranchPlanMaps();
 	}
 	
 	public BulkIterationPlanNode(BulkIterationNode template, String nodeName, Channel input,
@@ -131,7 +135,9 @@ public class BulkIterationPlanNode extends SingleInputPlanNode implements Iterat
 			// we always have a dam in the back channel
 			return FOUND_SOURCE_AND_DAM;
 		} else {
-			return fromOutside;
+            // check the step function for dams
+            SourceAndDamReport fromStepFunction = this.rootOfStepFunction.hasDamOnPathDownTo(source);
+			return fromStepFunction;
 		}
 	}
 
@@ -144,4 +150,25 @@ public class BulkIterationPlanNode extends SingleInputPlanNode implements Iterat
 			this.rootOfTerminationCriterion.accept(visitor);
 		
 	}
+
+    private void mergeBranchPlanMaps() {
+        for(OptimizerNode.UnclosedBranchDescriptor desc: template.getOpenBranches()){
+            OptimizerNode brancher = desc.getBranchingNode();
+
+            if(!branchPlan.containsKey(brancher)){
+                PlanNode selectedCandidate = null;
+
+                if(rootOfStepFunction.branchPlan != null){
+                    selectedCandidate = rootOfStepFunction.branchPlan.get(brancher);
+                }
+
+                if (selectedCandidate == null) {
+                    throw new CompilerException(
+                            "Candidates for a node with open branches are missing information about the selected candidate ");
+                }
+
+                this.branchPlan.put(brancher, selectedCandidate);
+            }
+        }
+    }
 }

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/BulkIterationPlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/BulkIterationPlanNode.java
@@ -49,7 +49,7 @@ public class BulkIterationPlanNode extends SingleInputPlanNode implements Iterat
 		this.partialSolutionPlanNode = pspn;
 		this.rootOfStepFunction = rootOfStepFunction;
 
-        mergeBranchPlanMaps();
+		mergeBranchPlanMaps();
 	}
 	
 	public BulkIterationPlanNode(BulkIterationNode template, String nodeName, Channel input,
@@ -127,7 +127,7 @@ public class BulkIterationPlanNode extends SingleInputPlanNode implements Iterat
 	@Override
 	public SourceAndDamReport hasDamOnPathDownTo(PlanNode source) {
 		SourceAndDamReport fromOutside = super.hasDamOnPathDownTo(source);
-		
+
 		if (fromOutside == FOUND_SOURCE_AND_DAM) {
 			return FOUND_SOURCE_AND_DAM;
 		}
@@ -135,8 +135,8 @@ public class BulkIterationPlanNode extends SingleInputPlanNode implements Iterat
 			// we always have a dam in the back channel
 			return FOUND_SOURCE_AND_DAM;
 		} else {
-            // check the step function for dams
-            SourceAndDamReport fromStepFunction = this.rootOfStepFunction.hasDamOnPathDownTo(source);
+			// check the step function for dams
+			SourceAndDamReport fromStepFunction = this.rootOfStepFunction.hasDamOnPathDownTo(source);
 			return fromStepFunction;
 		}
 	}
@@ -151,24 +151,24 @@ public class BulkIterationPlanNode extends SingleInputPlanNode implements Iterat
 		
 	}
 
-    private void mergeBranchPlanMaps() {
-        for(OptimizerNode.UnclosedBranchDescriptor desc: template.getOpenBranches()){
-            OptimizerNode brancher = desc.getBranchingNode();
+	private void mergeBranchPlanMaps() {
+		for(OptimizerNode.UnclosedBranchDescriptor desc: template.getOpenBranches()){
+			OptimizerNode brancher = desc.getBranchingNode();
 
-            if(!branchPlan.containsKey(brancher)){
-                PlanNode selectedCandidate = null;
+			if(!branchPlan.containsKey(brancher)){
+				PlanNode selectedCandidate = null;
 
-                if(rootOfStepFunction.branchPlan != null){
-                    selectedCandidate = rootOfStepFunction.branchPlan.get(brancher);
-                }
+				if(rootOfStepFunction.branchPlan != null){
+					selectedCandidate = rootOfStepFunction.branchPlan.get(brancher);
+				}
 
-                if (selectedCandidate == null) {
-                    throw new CompilerException(
-                            "Candidates for a node with open branches are missing information about the selected candidate ");
-                }
+				if (selectedCandidate == null) {
+					throw new CompilerException(
+							"Candidates for a node with open branches are missing information about the selected candidate ");
+				}
 
-                this.branchPlan.put(brancher, selectedCandidate);
-            }
-        }
-    }
+				this.branchPlan.put(brancher, selectedCandidate);
+			}
+		}
+	}
 }

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
@@ -337,7 +337,11 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 	}
 	
 	public PlanNode getCandidateAtBranchPoint(OptimizerNode branchPoint) {
-		return this.branchPlan.get(branchPoint);
+        if(branchPlan == null){
+            return null;
+        }else{
+		    return this.branchPlan.get(branchPoint);
+        }
 	}
 	
 	/**

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/PlanNode.java
@@ -335,13 +335,13 @@ public abstract class PlanNode implements Visitable<PlanNode>, DumpableNode<Plan
 			this.localProps.addUniqueFields(fields);
 		}
 	}
-	
+
 	public PlanNode getCandidateAtBranchPoint(OptimizerNode branchPoint) {
-        if(branchPlan == null){
-            return null;
-        }else{
-		    return this.branchPlan.get(branchPoint);
-        }
+		if(branchPlan == null){
+			return null;
+		}else{
+			return this.branchPlan.get(branchPoint);
+		}
 	}
 	
 	/**

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/WorksetIterationPlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/WorksetIterationPlanNode.java
@@ -58,13 +58,13 @@ public class WorksetIterationPlanNode extends DualInputPlanNode implements Itera
 			SolutionSetPlanNode solutionSetPlanNode, WorksetPlanNode worksetPlanNode,
 			PlanNode nextWorkSetPlanNode, PlanNode solutionSetDeltaPlanNode)
 	{
-        super(template, nodeName, initialSolutionSet, initialWorkset, DriverStrategy.NONE);
+		super(template, nodeName, initialSolutionSet, initialWorkset, DriverStrategy.NONE);
 		this.solutionSetPlanNode = solutionSetPlanNode;
 		this.worksetPlanNode = worksetPlanNode;
 		this.solutionSetDeltaPlanNode = solutionSetDeltaPlanNode;
 		this.nextWorkSetPlanNode = nextWorkSetPlanNode;
 
-        mergeBranchPlanMaps();
+		mergeBranchPlanMaps();
 
 	}
 
@@ -166,7 +166,7 @@ public class WorksetIterationPlanNode extends DualInputPlanNode implements Itera
 	@Override
 	public SourceAndDamReport hasDamOnPathDownTo(PlanNode source) {
 		SourceAndDamReport fromOutside = super.hasDamOnPathDownTo(source);
-		
+
 		if (fromOutside == FOUND_SOURCE_AND_DAM) {
 			return FOUND_SOURCE_AND_DAM;
 		}
@@ -174,17 +174,17 @@ public class WorksetIterationPlanNode extends DualInputPlanNode implements Itera
 			// we always have a dam in the solution set index
 			return FOUND_SOURCE_AND_DAM;
 		} else {
-            SourceAndDamReport fromNextWorkset = nextWorkSetPlanNode.hasDamOnPathDownTo(source);
+			SourceAndDamReport fromNextWorkset = nextWorkSetPlanNode.hasDamOnPathDownTo(source);
 
-            if(fromNextWorkset == FOUND_SOURCE_AND_DAM){
-                return FOUND_SOURCE_AND_DAM;
-            }else if(fromNextWorkset == FOUND_SOURCE){
-                return FOUND_SOURCE_AND_DAM;
-            }else{
-                SourceAndDamReport fromSolutionSetDelta = solutionSetDeltaPlanNode.hasDamOnPathDownTo(source);
+			if(fromNextWorkset == FOUND_SOURCE_AND_DAM){
+				return FOUND_SOURCE_AND_DAM;
+			}else if(fromNextWorkset == FOUND_SOURCE){
+				return FOUND_SOURCE_AND_DAM;
+			}else{
+				SourceAndDamReport fromSolutionSetDelta = solutionSetDeltaPlanNode.hasDamOnPathDownTo(source);
 
-                return fromSolutionSetDelta;
-            }
+				return fromSolutionSetDelta;
+			}
 		}
 	}
 
@@ -194,57 +194,57 @@ public class WorksetIterationPlanNode extends DualInputPlanNode implements Itera
 		this.nextWorkSetPlanNode.accept(visitor);
 	}
 
-    /**
-     * Merging can only take place after the solutionSetDelta and nextWorkset PlanNode has been set,
-     * because they can contain also some of the branching nodes.
-     */
-    @Override
-    protected void mergeBranchPlanMaps(Map<OptimizerNode, PlanNode> branchPlan1, Map<OptimizerNode,
-            PlanNode> branchPlan2){
+	/**
+	 * Merging can only take place after the solutionSetDelta and nextWorkset PlanNode has been set,
+	 * because they can contain also some of the branching nodes.
+	 */
+	@Override
+	protected void mergeBranchPlanMaps(Map<OptimizerNode, PlanNode> branchPlan1, Map<OptimizerNode,
+			PlanNode> branchPlan2){
 
-    }
+	}
 
-    protected void mergeBranchPlanMaps() {
-        Map<OptimizerNode, PlanNode> branchPlan1 = input1.getSource().branchPlan;
-        Map<OptimizerNode, PlanNode> branchPlan2 = input2.getSource().branchPlan;
+	protected void mergeBranchPlanMaps() {
+		Map<OptimizerNode, PlanNode> branchPlan1 = input1.getSource().branchPlan;
+		Map<OptimizerNode, PlanNode> branchPlan2 = input2.getSource().branchPlan;
 
-        // merge the branchPlan maps according the the template's uncloseBranchesStack
-        if (this.template.hasUnclosedBranches()) {
-            if (this.branchPlan == null) {
-                this.branchPlan = new HashMap<OptimizerNode, PlanNode>(8);
-            }
+		// merge the branchPlan maps according the the template's uncloseBranchesStack
+		if (this.template.hasUnclosedBranches()) {
+			if (this.branchPlan == null) {
+				this.branchPlan = new HashMap<OptimizerNode, PlanNode>(8);
+			}
 
-            for (OptimizerNode.UnclosedBranchDescriptor uc : this.template.getOpenBranches()) {
-                OptimizerNode brancher = uc.getBranchingNode();
-                PlanNode selectedCandidate = null;
+			for (OptimizerNode.UnclosedBranchDescriptor uc : this.template.getOpenBranches()) {
+				OptimizerNode brancher = uc.getBranchingNode();
+				PlanNode selectedCandidate = null;
 
-                if (branchPlan1 != null) {
-                    // predecessor 1 has branching children, see if it got the branch we are looking for
-                    selectedCandidate = branchPlan1.get(brancher);
-                }
+				if (branchPlan1 != null) {
+					// predecessor 1 has branching children, see if it got the branch we are looking for
+					selectedCandidate = branchPlan1.get(brancher);
+				}
 
-                if (selectedCandidate == null && branchPlan2 != null) {
-                    // predecessor 2 has branching children, see if it got the branch we are looking for
-                    selectedCandidate = branchPlan2.get(brancher);
-                }
+				if (selectedCandidate == null && branchPlan2 != null) {
+					// predecessor 2 has branching children, see if it got the branch we are looking for
+					selectedCandidate = branchPlan2.get(brancher);
+				}
 
-                if(selectedCandidate == null && getSolutionSetDeltaPlanNode() != null && getSolutionSetDeltaPlanNode()
-                        .branchPlan != null){
-                    selectedCandidate = getSolutionSetDeltaPlanNode().branchPlan.get(brancher);
-                }
+				if(selectedCandidate == null && getSolutionSetDeltaPlanNode() != null && getSolutionSetDeltaPlanNode()
+						.branchPlan != null){
+					selectedCandidate = getSolutionSetDeltaPlanNode().branchPlan.get(brancher);
+				}
 
-                if(selectedCandidate == null && getNextWorkSetPlanNode() != null && getNextWorkSetPlanNode()
-                        .branchPlan != null){
-                    selectedCandidate = getNextWorkSetPlanNode().branchPlan.get(brancher);
-                }
+				if(selectedCandidate == null && getNextWorkSetPlanNode() != null && getNextWorkSetPlanNode()
+						.branchPlan != null){
+					selectedCandidate = getNextWorkSetPlanNode().branchPlan.get(brancher);
+				}
 
-                if (selectedCandidate == null) {
-                    throw new CompilerException(
-                            "Candidates for a node with open branches are missing information about the selected candidate ");
-                }
+				if (selectedCandidate == null) {
+					throw new CompilerException(
+							"Candidates for a node with open branches are missing information about the selected candidate ");
+				}
 
-                this.branchPlan.put(brancher, selectedCandidate);
-            }
-        }
-    }
+				this.branchPlan.put(brancher, selectedCandidate);
+			}
+		}
+	}
 }

--- a/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
+++ b/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
@@ -18,15 +18,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import eu.stratosphere.api.common.operators.*;
+import eu.stratosphere.types.LongValue;
 import junit.framework.Assert;
 
 import org.junit.Test;
 
 import eu.stratosphere.api.common.Plan;
-import eu.stratosphere.api.common.operators.BulkIteration;
-import eu.stratosphere.api.common.operators.FileDataSink;
-import eu.stratosphere.api.common.operators.FileDataSource;
-import eu.stratosphere.api.common.operators.GenericDataSink;
 import eu.stratosphere.api.java.record.operators.CoGroupOperator;
 import eu.stratosphere.api.java.record.operators.CrossOperator;
 import eu.stratosphere.api.java.record.operators.JoinOperator;
@@ -662,4 +660,97 @@ public class BranchingPlansCompilerTest extends CompilerTestBase {
 			Assert.fail(e.getMessage());
 		}
 	}
+
+    /**
+     * Test to ensure that sourceA is inside as well as outside of the iteration the same
+     * node.
+     *
+     * <pre>
+     *       (SRC A)               (SRC B)
+     *      /       \             /       \
+     *  (SINK 1)   (ITERATION)    |     (SINK 2)
+     *             /        \     /
+     *         (SINK 3)     (CROSS)
+     * </pre>
+     */
+    @Test
+    public void testClosure() {
+        FileDataSource sourceA = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source 1");
+        FileDataSource sourceB = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source 2");
+
+        FileDataSink sink1 = new FileDataSink(DummyOutputFormat.class, OUT_FILE, sourceA, "Sink 1");
+        FileDataSink sink2 = new FileDataSink(DummyOutputFormat.class, OUT_FILE, sourceB, "Sink 2");
+
+        BulkIteration iteration = new BulkIteration("Loop");
+        iteration.setInput(sourceA);
+        iteration.setMaximumNumberOfIterations(10);
+
+        CrossOperator stepFunction = CrossOperator.builder(DummyCrossStub.class).name("StepFunction").
+            input1(iteration.getPartialSolution()).
+            input2(sourceB).
+            build();
+
+        iteration.setNextPartialSolution(stepFunction);
+
+        FileDataSink sink3 = new FileDataSink(DummyOutputFormat.class, OUT_FILE, iteration, "Sink 3");
+
+        List<GenericDataSink> sinks = new ArrayList<GenericDataSink>();
+        sinks.add(sink1);
+        sinks.add(sink2);
+        sinks.add(sink3);
+
+        Plan plan = new Plan(sinks);
+
+        try{
+            compileNoStats(plan);
+        }catch(Exception e){
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testClosureDeltaIteration() {
+        FileDataSource sourceA = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source 1");
+        FileDataSource sourceB = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source 2");
+        FileDataSource sourceC = new FileDataSource(DummyInputFormat.class, IN_FILE, "Source 3");
+
+        FileDataSink sink1 = new FileDataSink(DummyOutputFormat.class, OUT_FILE, sourceA, "Sink 1");
+        FileDataSink sink2 = new FileDataSink(DummyOutputFormat.class, OUT_FILE, sourceC, "Sink 2");
+
+        DeltaIteration iteration = new DeltaIteration(0, "Loop");
+        iteration.setInitialSolutionSet(sourceA);
+        iteration.setInitialWorkset(sourceB);
+        iteration.setMaximumNumberOfIterations(10);
+
+        CrossOperator nextWorkset = CrossOperator.builder(DummyCrossStub.class).name("Next workset").
+                input1(iteration.getWorkset()).
+                input2(sourceC).
+                build();
+
+        JoinOperator solutionSetDelta = JoinOperator.builder(DummyMatchStub.class, LongValue.class,0,0).
+                name("Next solution set.").
+                input1(nextWorkset).
+                input2(iteration.getSolutionSet()).
+                build();
+
+        iteration.setNextWorkset(nextWorkset);
+        iteration.setSolutionSetDelta(solutionSetDelta);
+
+        FileDataSink sink3 = new FileDataSink(DummyOutputFormat.class, OUT_FILE, iteration, "Sink 3");
+
+        List<GenericDataSink> sinks = new ArrayList<GenericDataSink>();
+        sinks.add(sink1);
+        sinks.add(sink2);
+        sinks.add(sink3);
+
+        Plan plan = new Plan(sinks);
+
+        try{
+            compileNoStats(plan);
+        }catch(Exception e){
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+    }
 }

--- a/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
+++ b/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
@@ -36,7 +36,6 @@ import eu.stratosphere.compiler.plan.OptimizedPlan;
 import eu.stratosphere.compiler.plan.SinkPlanNode;
 import eu.stratosphere.compiler.plantranslate.NepheleJobGraphGenerator;
 import eu.stratosphere.types.IntValue;
-import sun.net.www.content.text.Generic;
 
 /**
  */

--- a/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
+++ b/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/BranchingPlansCompilerTest.java
@@ -762,19 +762,19 @@ public class BranchingPlansCompilerTest extends CompilerTestBase {
 
 	/**
 	 * <prev>
-	 *                           +----Iteration-------+
-	 *                           |                    |
-	 *				  /---------< >---------join-----< >---sink
-	 *				 / (Solution)|           /        |
-	 *				/		     |          /         |
-	 *			   /--map-------< >----\   /       /--|
-	 *			  /     (Workset)|      \ /       /   |
-	 *	   src-map               |     join------/    |
-	 *		 	  \   		     |      /             |
-	 *             \ 		     +-----/--------------+
-	 *				\                 /
-	 *				 \--reduce-------/
-	 *
+	 *                  +----Iteration-------+
+	 *                  |                    |
+	 *       /---------< >---------join-----< >---sink
+	 *      / (Solution)|           /        |
+	 *     /            |          /         |
+	 *    /--map-------< >----\   /       /--|
+	 *   /     (Workset)|      \ /       /   |
+	 * src-map          |     join------/    |
+	 *   \   		    |      /             |
+	 *    \             +-----/--------------+
+	 *     \                 /
+	 *      \--reduce-------/
+	 * <p/>
 	 * </prev>
 	 */
 	@Test
@@ -828,16 +828,16 @@ public class BranchingPlansCompilerTest extends CompilerTestBase {
 
 	/**
 	 * <prev>
-	 *                      +----Delta Iteration------+
-	 *						|                         |
-	 *			   /--map--< >----\                   |
-	 *			  /         |      \         /-------< >---sink
-	 *	   src-map          |     join------/         |
-	 *		 	  \   		|      /                  |
-	 *             \ 		+-----/-------------------+
-	 *				\            /
-	 *				 \--reduce--/
-	 *
+	 *             +----Delta Iteration------+
+	 *             |                         |
+	 *    /--map--< >----\                   |
+	 *   /         |      \         /-------< >---sink
+	 * src-map     |     join------/         |
+	 *   \         |      /                  |
+	 *    \        +-----/-------------------+
+	 *     \            /
+	 *      \--reduce--/
+	 * <p/>
 	 * </prev>
 	 */
 	@Test


### PR DESCRIPTION
I tried to tackle the problem of generating multiple OptimizerNodes for one and the same Operator during recursive descent steps of the GraphCreatingVisitor as they happen for the step function generation of iterations. This poses a problem, because flows with multiple sinks, where one of the inputs to the step function is outputted as well, will be wrongly recognised as an unconnected data flow. Moreover, in the case of an Operator which produces random results, the generated data of this Operator inside and outside of the iteration would be distinct and thus false.

My solution is to forward the generated OptimizerNodes to the recursive GraphCreatingVisitor. This implies, however, to consider the step function for the computation of the unclosed branch stack. Furthermore, the branch plans of the step function has to be taken account of as well when merging the branch plans of the iteration plan nodes. For the WorksetIterationPlanNode, I could only come up with a nasty hack to disable the mergeBranchPlanMaps of the DualInputPlanNode.

So far, all test cases succeed locally but I'm not sure whether I found all code positions requiring a change for this modification. Would be great if you could review it to make sure that I didn't forget anything.
