### PR TITLE
Fix bug in MapNode

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/MapNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/MapNode.java
@@ -37,8 +37,8 @@ public class MapNode extends SingleInputNode {
 	}
 
 	@Override
-	public MapOperatorBase<?> getPactContract() {
-		return (MapOperatorBase<?>) super.getPactContract();
+	public PlainMapOperatorBase<?> getPactContract() {
+		return (PlainMapOperatorBase<?>) super.getPactContract();
 	}
 
 	@Override


### PR DESCRIPTION
MapNode is responsible for PlainMapOperatorBase and not for
MapOperatorBase, but this is a mess right now.

Maybe we should think about cleaning the situation a bit. CollectorMap is the same as FlatMap, only the function in the interface is called map instead of flatMap. I know that this is because of historic reasons but it is still a mess because we handle all three types through the layers. For example, some code in PactCompiler looks like this:

``` java
else if (c instanceof MapOperatorBase) {
    n = new CollectorMapNode((MapOperatorBase<?>) c);
}
else if (c instanceof PlainMapOperatorBase) {
    n = new MapNode((PlainMapOperatorBase<?>) c);
}
else if (c instanceof FlatMapOperatorBase) {
    n = new FlatMapNode((FlatMapOperatorBase<?>) c);
}
```
