### PR TITLE
Fixes a bug when using Double types as sorting key

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/TypeComparator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/TypeComparator.java
@@ -178,12 +178,12 @@ public abstract class TypeComparator<T> {
 	public abstract int getNormalizeKeyLen();
 	
 	/**
-	 * Checks, whether the given number of bytes for a normalized suffice to determine the order of elements
+	 * Checks, whether the given number of bytes for a normalized is only a prefix to determine the order of elements
 	 * of the data type for which this comparator provides the comparison methods. For example, if the
 	 * data type is ordered with respect to an integer value it contains, then this method would return
-	 * true, if the number of key bytes was larger or equal to four.
+	 * true, if the number of key bytes is smaller than four.
 	 * 
-	 * @return True, if the given number of bytes for a normalized suffice to determine the order of elements,
+	 * @return True, if the given number of bytes is only a prefix,
 	 *         false otherwise.
 	 */
 	public abstract boolean isNormalizedKeyPrefixOnly(int keyBytes);

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/sort/NormalizedKeySorter.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/sort/NormalizedKeySorter.java
@@ -266,7 +266,9 @@ public final class NormalizedKeySorter<T> implements InMemorySorter<T>
 		
 		// add the pointer and the normalized key
 		this.currentSortIndexSegment.putLong(this.currentSortIndexOffset, this.currentDataBufferOffset);
-		this.comparator.putNormalizedKey(record, this.currentSortIndexSegment, this.currentSortIndexOffset + OFFSET_LEN, this.numKeyBytes);
+		if(this.numKeyBytes != 0) {
+			this.comparator.putNormalizedKey(record, this.currentSortIndexSegment, this.currentSortIndexOffset + OFFSET_LEN, this.numKeyBytes);
+		}
 		
 		// serialize the record into the data buffers
 		try {


### PR DESCRIPTION
Fixes the `UnsupportedOperationException` mentioned in #551. And corrects the documentation of the `isNormalizedKeyPrefixOnly()` method in `TypeComparator`.
