### PR TITLE
Add support for group sorting to new Java API

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/BasicTypeComparator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/BasicTypeComparator.java
@@ -31,7 +31,7 @@ public abstract class BasicTypeComparator<T extends Comparable<T>> extends TypeC
 	
 
 	protected BasicTypeComparator(boolean ascending) {
-		this.ascendingComparison = !ascending;
+		this.ascendingComparison = ascending;
 	}
 
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/Grouping.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/Grouping.java
@@ -14,10 +14,14 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.operators;
 
+import java.util.Arrays;
+
 import eu.stratosphere.api.common.InvalidProgramException;
+import eu.stratosphere.api.common.operators.Order;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.aggregation.Aggregations;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
+import eu.stratosphere.api.java.functions.KeySelector;
 import eu.stratosphere.api.java.functions.ReduceFunction;
 
 public class Grouping<T> {
@@ -26,6 +30,8 @@ public class Grouping<T> {
 	
 	private final Keys<T> keys;
 	
+	private int[] groupSortKeyPositions = null;
+	private Order[] groupSortOrders = null;
 
 	public Grouping(DataSet<T> set, Keys<T> keys) {
 		if (set == null || keys == null)
@@ -48,11 +54,53 @@ public class Grouping<T> {
 		return this.keys;
 	}
 	
+	public int[] getGroupSortKeyPositions() {
+		return this.groupSortKeyPositions;
+	}
+	
+	public Order[] getGroupSortOrders() {
+		return this.groupSortOrders;
+	}
+	
 	// --------------------------------------------------------------------------------------------
 	//  Operations / Transformations
 	// --------------------------------------------------------------------------------------------
 	
+	public <K extends Comparable<K>> Grouping<T> sortGroup(KeySelector<T, K> keyExtractor, Order order) {
+		// TODO
+		throw new UnsupportedOperationException("Group sorting not supported for KeyExtractor functions.");
+	}
+	
+	public Grouping<T> sortGroup(String fieldExpression, Order order) {
+		// TODO
+		throw new UnsupportedOperationException("Group sorting not supported for FieldExpression keys.");
+	}
+	
+	public Grouping<T> sortGroup(int field, Order order) {
+		
+		int pos;
+		
+		if(this.groupSortKeyPositions == null) {
+			this.groupSortKeyPositions = new int[1];
+			this.groupSortOrders = new Order[1];
+			pos = 0;
+		} else {
+			int newLength = this.groupSortKeyPositions.length + 1;
+			this.groupSortKeyPositions = Arrays.copyOf(this.groupSortKeyPositions, newLength);
+			this.groupSortOrders = Arrays.copyOf(this.groupSortOrders, newLength);
+			pos = newLength - 1;
+		}
+		
+		this.groupSortKeyPositions[pos] = field;
+		this.groupSortOrders[pos] = order;
+		return this;
+	}
+	
 	public AggregateOperator<T> aggregate(Aggregations agg, int field) {
+		if(this.groupSortKeyPositions != null) {
+			// TODO
+			throw new UnsupportedOperationException("Sorted groups not supported for Aggregation operation at the moment.");
+		}
 		return new AggregateOperator<T>(this, agg, field);
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
@@ -14,6 +14,8 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.operators;
 
+import eu.stratosphere.api.common.operators.Order;
+import eu.stratosphere.api.common.operators.Ordering;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.functions.ReduceFunction;
 import eu.stratosphere.api.java.operators.translation.KeyExtractingMapper;
@@ -85,8 +87,22 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		}
 		else if (grouper.getKeys() instanceof Keys.FieldPositionKeys) {
 			int[] logicalKeyPositions = grouper.getKeys().computeLogicalKeyPositions();
+			PlanReduceOperator<IN> reduceOp = new PlanReduceOperator<IN>(function, logicalKeyPositions, name, getInputType());
+			
+			// set group order
+			if(grouper.getGroupSortKeyPositions() != null) {
+								
+				int[] sortKeyPositions = grouper.getGroupSortKeyPositions();
+				Order[] sortOrders = grouper.getGroupSortOrders();
+				
+				Ordering o = new Ordering();
+				for(int i=0; i < sortKeyPositions.length; i++) {
+					o.appendOrdering(sortKeyPositions[i], null, sortOrders[i]);
+				}
+				reduceOp.setGroupOrder(o);
+			}
 
-			return new UnaryNodeTranslation(new PlanReduceOperator<IN>(function, logicalKeyPositions, name, getInputType()));
+			return new UnaryNodeTranslation(reduceOp);
 		}
 		else {
 			throw new UnsupportedOperationException("Unrecognized key type.");

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
@@ -233,7 +233,7 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 			{
 				int len = this.normalizedKeyLengths[i]; 
 				len = numBytes >= len ? len : numBytes;
-				this.comparators[i].putNormalizedKey(value.getField(this.keyPositions[i]), target, offset, numBytes);
+				this.comparators[i].putNormalizedKey(value.getField(this.keyPositions[i]), target, offset, len);
 				numBytes -= len;
 				offset += len;
 			}
@@ -242,9 +242,6 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 			throw new NullKeyFieldException(this.keyPositions[i]);
 		}
 	}
-
-
-
 
 	@Override
 	public boolean invertNormalizedKey() {


### PR DESCRIPTION
Adds initial support for group sorting. Currently limited to:
- Reduce operator
- Tuple data types with field selector key definition

Also includes a fix for sorting of Tuples (multi field sorting and sort order #543) in `TupleComparator` and `BasicTypeComparator`.
