### PR TITLE
Fix for termination criterion issues

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
@@ -989,7 +989,11 @@ public class PactCompiler {
 				this.numMemoryConsumers += recursiveCreator.numMemoryConsumers;
 				
 				// go over the contained data flow and mark the dynamic path nodes
-				rootOfStepFunction.accept(new StaticDynamicPathIdentifier(iterNode.getCostWeight()));
+				StaticDynamicPathIdentifier identifier = new StaticDynamicPathIdentifier(iterNode.getCostWeight());
+				rootOfStepFunction.accept(identifier);
+				if(terminationCriterion != null){
+					terminationCriterion.accept(identifier);
+				}
 			}
 			else if (n instanceof WorksetIterationNode) {
 				final WorksetIterationNode iterNode = (WorksetIterationNode) n;

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BulkIterationNode.java
@@ -283,7 +283,7 @@ public class BulkIterationNode extends SingleInputNode implements IterationNode 
 				target.add(node);
 			}
 		}
-		else {
+		else if(candidates.size() > 0) {
 			List<PlanNode> terminationCriterionCandidates = this.terminationCriterion.getAlternativePlans(estimator);
 
 			for (PlanNode candidate : candidates) {

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/OptimizerNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/OptimizerNode.java
@@ -1108,7 +1108,8 @@ public abstract class OptimizerNode implements Visitable<OptimizerNode>, Estimat
 		// 2) if one side is null (or empty), the result is the other side.
 		// 3) both are set, then we need to merge.
 		if (child1open == null || child1open.isEmpty()) {
-			result.addAll(child2open);
+			if(child2open != null && !child2open.isEmpty())
+				result.addAll(child2open);
 			return false;
 		}
 		

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plantranslate/NepheleJobGraphGenerator.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plantranslate/NepheleJobGraphGenerator.java
@@ -764,11 +764,13 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 				}
 			}
 			// cannot chain the nodes that produce the next workset in a bulk iteration if a termination criterion follows
-			if (this.currentIteration != null && this.currentIteration instanceof BulkIterationPlanNode &&
-					node.getOutgoingChannels().size() > 0)
+			if (this.currentIteration != null && this.currentIteration instanceof BulkIterationPlanNode)
 			{
 				BulkIterationPlanNode wspn = (BulkIterationPlanNode) this.currentIteration;
-				if (wspn.getRootOfStepFunction() == pred || wspn.getRootOfTerminationCriterion() == pred) {
+				if(node == wspn.getRootOfTerminationCriterion() && wspn.getRootOfStepFunction() == pred){
+					chaining = false;
+				}else if(node.getOutgoingChannels().size() > 0 &&(wspn.getRootOfStepFunction() == pred ||
+						wspn.getRootOfTerminationCriterion() == pred)) {
 					chaining = false;
 				}
 			}


### PR DESCRIPTION
I encountered some minor problems while testing the new termination criterion for bulk iterations and I tried to fix them.
1. NullPointerException in OptimizerNode.mergeLists because child2open is not checked for being not null
2. Faulty chaining of root of termination criterion and root of step function. This happens if one uses the next partial solution as the termination criterion
3. BulkIterationNode tries to generate alternative plans for the termination criterion even if there are no plans for the next partial solution. If the termination criterion depends on the next partial solution, then the algorithm won't find a plan fulfilling the requirements and thus throw an exception.
4. Some of the termination criterion nodes are instantiated as a RegularPactTasks instead of IntermediateIterationTasks. This is caused by not setting the dynamic paths of the termination criterion.

I hope that I haven't broken anything while trying to fix the issues.
