### PR TITLE
Scala termination criterion

### DIFF
--- a/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/iterative/TerminationCriterion.scala
+++ b/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/iterative/TerminationCriterion.scala
@@ -1,0 +1,57 @@
+package eu.stratosphere.examples.scala.iterative
+
+import eu.stratosphere.client.LocalExecutor
+import eu.stratosphere.api.common.Program
+import eu.stratosphere.api.common.ProgramDescription
+
+import eu.stratosphere.api.scala._
+import eu.stratosphere.api.scala.operators._
+import eu.stratosphere.types.DoubleValue
+
+
+class TerminationCriterion extends Program with ProgramDescription with Serializable {
+  override def getDescription() = {
+    "Parameters: <maxNumberIterations> <output>"
+  }
+
+  override def getPlan(args: String*) = {
+    getScalaPlan(args(0).toInt, args(1))
+  }
+
+  def getScalaPlan(maxNumberIterations: Int, resultOutput: String) = {
+    val dataSource = CollectionDataSource[Double](List(1.0))
+
+    val halve = (partialSolution: DataSet[Double]) => {
+      partialSolution map { x => x /2 }
+    }
+
+    val terminationCriterion = (prev: DataSet[Double], cur: DataSet[Double]) => {
+      val diff = prev cross cur map { (valuePrev, valueCurrent) => math.abs(valuePrev - valueCurrent) }
+      diff filter {
+        difference => difference > 0.1
+      }
+    }
+
+    val iteration = dataSource.iterateWithTermination(maxNumberIterations, halve, terminationCriterion)
+
+
+    val sink = iteration.write(resultOutput, CsvOutputFormat())
+
+    val plan = new ScalaPlan(Seq(sink))
+    plan.setDefaultParallelism(1)
+    plan
+  }
+}
+
+object RunTerminationCriterion {
+  def main(args: Array[String]) {
+    val tc = new TerminationCriterion
+
+    if(args.size < 2) {
+      println(tc.getDescription())
+      return
+    }
+    val plan = tc.getScalaPlan(args(0).toInt, args(1))
+    LocalExecutor.execute(plan)
+  }
+}

--- a/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/iterative/TerminationCriterion.scala
+++ b/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/iterative/TerminationCriterion.scala
@@ -1,3 +1,16 @@
+/***********************************************************************************************************************
+  * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+  * the License. You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  * specific language governing permissions and limitations under the License.
+  **********************************************************************************************************************/
+
 package eu.stratosphere.examples.scala.iterative
 
 import eu.stratosphere.client.LocalExecutor
@@ -6,9 +19,11 @@ import eu.stratosphere.api.common.ProgramDescription
 
 import eu.stratosphere.api.scala._
 import eu.stratosphere.api.scala.operators._
-import eu.stratosphere.types.DoubleValue
 
-
+/**
+ * Example of using the bulk iteration with termination criterion with the
+ * scala api.
+ */
 class TerminationCriterion extends Program with ProgramDescription with Serializable {
   override def getDescription() = {
     "Parameters: <maxNumberIterations> <output>"

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/DataSet.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/DataSet.scala
@@ -47,8 +47,11 @@ class DataSet[T] (val contract: Operator with ScalaOperator[T]) {
   
   def iterateWithDelta[DeltaItem](stepFunction: DataSet[T] => (DataSet[T], DataSet[DeltaItem])) = macro IterateMacros.iterateWithDelta[T, DeltaItem]
   def iterate(n: Int, stepFunction: DataSet[T] => DataSet[T])= macro IterateMacros.iterate[T]
+  def iterateWithTermination[C](n: Int, stepFunction: DataSet[T] => DataSet[T], terminationFunction: (DataSet[T],
+    DataSet[T]) => DataSet[C]) = macro IterateMacros.iterateWithTermination[T, C]
   def iterateWithDelta[SolutionKey, WorksetItem](workset: DataSet[WorksetItem], solutionSetKey: T => SolutionKey, stepFunction: (DataSet[T], DataSet[WorksetItem]) => (DataSet[T], DataSet[WorksetItem]), maxIterations: Int) = macro WorksetIterateMacros.iterateWithDelta[T, SolutionKey, WorksetItem]
   
   def write(url: String, format: ScalaOutputFormat[T]) = DataSinkOperator.write(this, url, format)
+  def write(url: String, format: ScalaOutputFormat[T], name: String) = DataSinkOperator.write(this, url, format, name)
   
 }

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/DataSink.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/DataSink.scala
@@ -23,13 +23,16 @@ import eu.stratosphere.api.common.io.FileOutputFormat
 import eu.stratosphere.api.common.operators.GenericDataSink
 
 object DataSinkOperator {
+  val DEFAULT_DATASINKOPERATOR_NAME = "<Unnamed Scala Data Sink>"
 
-  def write[In](input: DataSet[In], url: String, format: ScalaOutputFormat[In]): ScalaSink[In] = {
+  def write[In](input: DataSet[In], url: String, format: ScalaOutputFormat[In],
+                name: String = DEFAULT_DATASINKOPERATOR_NAME): ScalaSink[In]
+  = {
     val uri = getUri(url)
 
     val ret = uri.getScheme match {
-      case "file" | "hdfs" => new FileDataSink(format.asInstanceOf[FileOutputFormat[_]], uri.toString, input.contract)
-          with OneInputScalaOperator[In, Nothing] {
+      case "file" | "hdfs" => new FileDataSink(format.asInstanceOf[FileOutputFormat[_]], uri.toString,
+        input.contract, name) with OneInputScalaOperator[In, Nothing] {
 
         def getUDF = format.getUDF
         override def persistConfiguration() = format.persistConfiguration(this.getParameters())

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaGenerator.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaGenerator.scala
@@ -38,6 +38,7 @@ import eu.stratosphere.api.scala.BulkIterationScalaOperator
 import eu.stratosphere.api.common.operators.DeltaIteration
 import eu.stratosphere.api.scala.DeltaIterationScalaOperator
 import eu.stratosphere.api.common.operators.GenericDataSink
+import eu.stratosphere.api.common.operators.base.MapOperatorBase
 
 class GlobalSchemaGenerator {
 
@@ -151,7 +152,7 @@ class GlobalSchemaGenerator {
         contract.getUDF.setOutputGlobalIndexes(freePos2, fixedOutputs)
       }
 
-      case contract : MapOperator with OneInputScalaOperator[_, _] => {
+      case contract : MapOperatorBase[_] with OneInputScalaOperator[_, _] => {
 
         val freePos1 = globalizeContract(contract.getInputs().get(0), Seq(contract.getUDF.inputFields), proxies, None, freePos)
 

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/IterateOperators.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/IterateOperators.scala
@@ -113,11 +113,9 @@ object IterateMacros {
   }
 
   def iterateWithTermination[SolutionItem: c.WeakTypeTag, TerminationItem: c.WeakTypeTag](c: Context { type
-  PrefixType =
-  DataSet[SolutionItem] })(n:
-                           c.Expr[Int], stepFunction: c.Expr[DataSet[SolutionItem] => DataSet[SolutionItem]],
-                           convergenceFunction: c.Expr[(DataSet[SolutionItem], DataSet[SolutionItem]) => DataSet[TerminationItem]]):
-  c.Expr[DataSet[SolutionItem]] = {
+  PrefixType = DataSet[SolutionItem] })(n: c.Expr[Int], stepFunction: c.Expr[DataSet[SolutionItem] => 
+    DataSet[SolutionItem]], terminationFunction: c.Expr[(DataSet[SolutionItem], 
+    DataSet[SolutionItem]) => DataSet[TerminationItem]]): c.Expr[DataSet[SolutionItem]] = {
     import c.universe._
 
     val slave = MacroContextHolder.newMacroHelper(c)
@@ -155,13 +153,13 @@ object IterateMacros {
       val partialSolution = new DataSet(contract.getPartialSolution().asInstanceOf[Operator with ScalaOperator[SolutionItem]])
 
       val output = stepFunction.splice.apply(partialSolution)
-      val convergenceCriterion = convergenceFunction.splice.apply(partialSolution, output)
+      val terminationCriterion = terminationFunction.splice.apply(partialSolution, output)
 
 
       contract.setInput(c.prefix.splice.contract)
       contract.setNextPartialSolution(output.contract)
       contract.setMaximumNumberOfIterations(n.splice)
-      contract.setTerminationCriterion(convergenceCriterion.contract)
+      contract.setTerminationCriterion(terminationCriterion.contract)
 
       new DataSet(contract)
     }


### PR DESCRIPTION
I tried to extend the scala api by the newly introduced termination criterion for bulk iterations. Since one has neither direct access to the partial solution nor to the next partial solution one has to specify a termination function of type (previousState: DataSet[T], currentState: DataSet[T]) => DataSet[U] which is supplied with the partial and next partial solution. I hope this is flexible enough to cover many termination caluclations.

Additionally I extended the scala api by a name parameter for the write method of DataSet. It makes debugging a lot easier if one can name the data sinks properly.

I also included a small example which has however only instructional value.
