### PR TITLE
Fix issue #505 removing trailing \r from lines in Windows text files

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
@@ -77,6 +77,17 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 	 */
 	private static int MAX_SAMPLE_LEN;
 	
+	/**
+	 * Code of \r, used to remove \r from a line when the line ends with \r\n
+	 */
+	private static final byte CARRIAGE_RETURN = 13;
+
+	/**
+	 * Code of \n, used to identify if \n is used as delimiter
+	 */
+	private static final byte NEW_LINE = 10;
+
+	
 	static { loadGloablConfigParams(); }
 	
 	protected static final void loadGloablConfigParams() {
@@ -515,6 +526,12 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 				// line end
 				count = this.readPos - startPos - this.delimiter.length;
 
+				//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
+				if (this.delimiter.length == 1 && this.delimiter[0] == NEW_LINE && 
+						this.readPos >= 2 && this.readBuffer[this.readPos-2] == CARRIAGE_RETURN){
+					count -= 1;
+				}
+				
 				// copy to byte array
 				if (countInWrapBuffer > 0) {
 					// check wrap buffer size

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
@@ -31,6 +31,17 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 	
 	private transient Charset charset;
 
+	/**
+	 * Code of \r, used to remove \r from a line when the line ends with \r\n
+	 */
+	private static final byte CARRIAGE_RETURN = 13;
+
+	/**
+	 * Code of \n, used to identify if \n is used as delimiter
+	 */
+	private static final byte NEW_LINE = 10;
+
+	
 	// --------------------------------------------------------------------------------------------
 	
 	public TextInputFormat(Path filePath) {
@@ -74,6 +85,12 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	@Override
 	public String readRecord(String reusable, byte[] bytes, int offset, int numBytes) {
+		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
+		if (this.getDelimiter().length == 1 && this.getDelimiter()[0] == NEW_LINE && 
+				offset+numBytes >= 1 && bytes[offset+numBytes-1] == CARRIAGE_RETURN){
+			numBytes -= 1;
+		}
+		
 		return new String(bytes, offset, numBytes, this.charset);
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
@@ -56,6 +56,17 @@ public class TextInputFormat extends DelimitedInputFormat {
 	
 	protected transient boolean ascii;
 	
+	/**
+	 * Code of \r, used to remove \r from a line when the line ends with \r\n
+	 */
+	private static final byte CARRIAGE_RETURN = 13;
+
+	/**
+	 * Code of \n, used to identify if \n is used as delimiter
+	 */
+	private static final byte NEW_LINE = 10;
+
+	
 	// --------------------------------------------------------------------------------------------
 	
 	@Override
@@ -86,6 +97,13 @@ public class TextInputFormat extends DelimitedInputFormat {
 
 	public Record readRecord(Record reuse, byte[] bytes, int offset, int numBytes) {
 		StringValue str = this.theString;
+		
+		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
+		if (this.getDelimiter().length == 1 && this.getDelimiter()[0] == NEW_LINE && 
+				offset+numBytes >= 1 && bytes[offset+numBytes-1] == CARRIAGE_RETURN){
+			numBytes -= 1;
+		}
+
 		
 		if (this.ascii) {
 			str.setValueAscii(bytes, offset, numBytes);


### PR DESCRIPTION
Window uses \r\n to split lines. so, for text files from Windows, when
\n is used as delimiter, \r is still appear at the end of lines.

The code checks to see if \n is used as delimiter and end of a line is
\r, then \r is removed from the line
