### PR TITLE
Fix for ReduceOperator mutable object return bug.

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -31,6 +31,7 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 	
 	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type) {
 		super(udf, logicalGroupingFields, name);
+		udf.setTypeSerializer(type.createSerializer());
 		this.type = type;
 	}
 	

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/ReduceFunctionTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/ReduceFunctionTest.java
@@ -1,0 +1,104 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.functions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import eu.stratosphere.api.common.typeutils.TypeComparator;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.api.java.functions.util.CollectionOutputCollector;
+import eu.stratosphere.api.java.functions.util.KeyGroupedIterator;
+import eu.stratosphere.api.java.functions.util.MutableObjectIteratorWrapper;
+import eu.stratosphere.api.java.tuple.Tuple2;
+import eu.stratosphere.api.java.typeutils.BasicTypeInfo;
+import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
+import eu.stratosphere.util.Collector;
+import eu.stratosphere.util.MutableObjectIterator;
+
+public class ReduceFunctionTest {
+
+	@Test
+	public void reduceTest() throws Exception {
+		
+		// input and output data
+		List<Tuple2<Integer, Integer>> inData = new ArrayList<Tuple2<Integer, Integer>>();
+		List<Tuple2<Integer, Integer>> outData = new ArrayList<Tuple2<Integer, Integer>>();
+		
+		// initialize input data
+		for(int i=1; i<6; i++) {
+			for(int j=0; j<i; j++) {
+				inData.add(new Tuple2<Integer, Integer>(i,1));
+			}
+		}
+				
+		// create serializer and comparators
+		TupleTypeInfo<Tuple2<Integer, Integer>> typeInfo = 
+				new TupleTypeInfo<Tuple2<Integer, Integer>>(
+						BasicTypeInfo.INT_TYPE_INFO,
+						BasicTypeInfo.INT_TYPE_INFO);
+		
+		TypeSerializer<Tuple2<Integer, Integer>> serializer = 
+				typeInfo.createSerializer();
+		TypeComparator<Tuple2<Integer, Integer>> comparator = 
+				typeInfo.createComparator(new int[]{0}, new boolean[]{true});
+		
+		// create mutable iterators as in runtime
+		MutableObjectIterator<Tuple2<Integer, Integer>> moi = 
+				new MutableObjectIteratorWrapper<Tuple2<Integer, Integer>>(inData.iterator(), serializer);
+		KeyGroupedIterator<Tuple2<Integer, Integer>> kgi = 
+				new KeyGroupedIterator<Tuple2<Integer, Integer>>(moi, serializer, comparator);
+		
+		// initialize reduce function
+		ReduceFunction<Tuple2<Integer, Integer>> testFunc = new ReduceTestFunction();
+		testFunc.setTypeSerializer(serializer);
+				
+		// initialize output collector
+		Collector<Tuple2<Integer, Integer>> out = 
+				new CollectionOutputCollector<Tuple2<Integer, Integer>>(outData, serializer);
+		
+		// run reduce function on input data
+		while (kgi.nextKey()) {
+			testFunc.reduce(kgi.getValues(), out);
+		}
+		
+		// check result
+		for(int i=0; i<outData.size(); i++) {
+			Assert.assertTrue(
+					((Integer)outData.get(i).getField(0)).intValue() ==
+					((Integer)outData.get(i).getField(1)).intValue());
+		}
+		
+	}
+	
+	private static class ReduceTestFunction extends ReduceFunction<Tuple2<Integer, Integer>> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public Tuple2<Integer, Integer> reduce(Tuple2<Integer, Integer> value1, Tuple2<Integer, Integer> value2) 
+				throws Exception 
+		{
+
+			int newVal = ((Integer)value1.getField(1)).intValue() + 
+						 ((Integer)value2.getField(1)).intValue();
+			value1.setField(newVal, 1);
+			return value1;
+		}
+	}
+	
+}

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/util/CollectionOutputCollector.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/util/CollectionOutputCollector.java
@@ -1,0 +1,44 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.functions.util;
+
+import java.util.Collection;
+
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.util.Collector;
+
+/**
+ * Implements an output collector that stores its collected elements in a supplied list.
+ */
+public class CollectionOutputCollector<E> implements Collector<E> {
+	
+	private final Collection<E> output;
+	private final TypeSerializer<E> serializer;
+	
+	public CollectionOutputCollector(Collection<E> outputList, TypeSerializer<E> serializer) {
+		this.output = outputList;
+		this.serializer = serializer;
+	}
+
+	@Override
+	public void collect(E in) {
+		E copy = serializer.createInstance();
+		serializer.copy(in, copy);
+		this.output.add(copy);
+	}
+
+	@Override
+	public void close() {}
+}

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/util/KeyGroupedIterator.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/util/KeyGroupedIterator.java
@@ -1,0 +1,212 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.functions.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import eu.stratosphere.api.common.typeutils.TypeComparator;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.util.MutableObjectIterator;
+
+/**
+ * This class is an exact copy of the KeyGroupedIterator in stratosphere-runtime.
+ * Stratosphere-runtime cannot be added as a dependency because this would cause cyclic dependencies.
+ */
+public class KeyGroupedIterator<E> {
+
+	private final MutableObjectIterator<E> iterator;
+
+	private final TypeSerializer<E> serializer;
+	
+	private final TypeComparator<E> comparator;
+	
+	private E current;
+	
+	private E lookahead;
+
+	private ValuesIterator valuesIterator;
+
+	private boolean lookAheadHasNext;
+	
+	private boolean done;
+
+	/**
+	 * Initializes the KeyGroupedIterator. It requires an iterator which returns its result
+	 * sorted by the key fields.
+	 * 
+	 * @param iterator An iterator over records, which are sorted by the key fields, in any order.
+	 * @param serializer The serializer for the data type iterated over.
+	 * @param comparator The comparator for the data type iterated over.
+	 */
+	public KeyGroupedIterator(MutableObjectIterator<E> iterator,
+			TypeSerializer<E> serializer, TypeComparator<E> comparator)
+	{
+		if (iterator == null || serializer == null || comparator == null) {
+			throw new NullPointerException();
+		}
+		
+		this.iterator = iterator;
+		this.serializer = serializer;
+		this.comparator = comparator;
+	}
+
+	/**
+	 * Moves the iterator to the next key. This method may skip any values that have not yet been returned by the
+	 * iterator created by the {@link #getValues()} method. Hence, if called multiple times it "removes" pairs.
+	 * 
+	 * @return true if the input iterator has an other group of key-value pairs that share the same key.
+	 */
+	public boolean nextKey() throws IOException
+	{
+		// first element (or empty)
+		if (this.current == null) {
+			if (this.done) {
+				this.valuesIterator = null;
+				return false;
+			}
+			this.current = this.serializer.createInstance();
+			if ((this.current = this.iterator.next(this.current)) != null) {
+				this.comparator.setReference(this.current);
+				this.lookAheadHasNext = false;
+				this.valuesIterator = new ValuesIterator();
+				this.valuesIterator.currentIsUnconsumed = true;
+				return true;
+			} else {
+				// empty input, set everything null
+				this.valuesIterator = null;
+				this.current = null;
+				this.done = true;
+				return false;
+			}
+		}
+
+		// Whole value-iterator was read and a new key is available.
+		if (this.lookAheadHasNext) {
+			this.lookAheadHasNext = false;
+			this.current = this.lookahead;
+			this.lookahead = null;
+			this.comparator.setReference(this.current);
+			this.valuesIterator.currentIsUnconsumed = true;
+			return true;
+		}
+
+		// try to move to next key.
+		// Required if user code / reduce() method did not read the whole value iterator.
+		while (true) {
+			if (!this.done && ((this.current = this.iterator.next(this.current)) != null)) {
+				if (!this.comparator.equalToReference(this.current)) {
+					// the keys do not match, so we have a new group. store the current keys
+					this.comparator.setReference(this.current);
+					this.lookAheadHasNext = false;
+					this.valuesIterator.currentIsUnconsumed = true;
+					return true;
+				}
+			}
+			else {
+				this.valuesIterator = null;
+				this.current = null;
+				this.done = true;
+				return false;
+			}
+		}
+	}
+	
+	/**
+	 * Returns an iterator over all values that belong to the current key. The iterator is initially <code>null</code>
+	 * (before the first call to {@link #nextKey()} and after all keys are consumed. In general, this method returns
+	 * always a non-null value, if a previous call to {@link #nextKey()} return <code>true</code>.
+	 * 
+	 * @return Iterator over all values that belong to the current key.
+	 */
+	public ValuesIterator getValues() {
+		return this.valuesIterator;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	
+	public final class ValuesIterator implements Iterator<E>
+	{
+		private final TypeSerializer<E> serializer = KeyGroupedIterator.this.serializer;
+		private final TypeComparator<E> comparator = KeyGroupedIterator.this.comparator; 
+		
+		private E staging = this.serializer.createInstance();
+		private boolean currentIsUnconsumed = false;
+		
+		private ValuesIterator() {}
+
+		@Override
+		public boolean hasNext()
+		{
+			if (KeyGroupedIterator.this.current == null || KeyGroupedIterator.this.lookAheadHasNext) {
+				return false;
+			}
+			if (this.currentIsUnconsumed) {
+				return true;
+			}
+			
+			try {
+				// read the next value into the staging record to make sure we keep the
+				// current as it is in case the key changed
+				E stagingStaging = KeyGroupedIterator.this.iterator.next(this.staging);
+				if (stagingStaging != null) {
+					this.staging = stagingStaging;
+					if (this.comparator.equalToReference(this.staging)) {
+						// same key, next value is in staging, so exchange staging with current
+						final E tmp = this.staging;
+						this.staging = KeyGroupedIterator.this.current;
+						KeyGroupedIterator.this.current = tmp;
+						this.currentIsUnconsumed = true;
+						return true;
+					} else {
+						// moved to the next key, no more values here
+						KeyGroupedIterator.this.lookAheadHasNext = true;
+						KeyGroupedIterator.this.lookahead = this.staging;
+						this.staging = KeyGroupedIterator.this.current;
+						return false;						
+					}
+				}
+				else {
+					// backing iterator is consumed
+					KeyGroupedIterator.this.done = true;
+					return false;
+				}
+			}
+			catch (IOException ioex) {
+				throw new RuntimeException("An error occurred while reading the next record: " + 
+					ioex.getMessage(), ioex);
+			}
+		}
+
+		/**
+		 * Prior to call this method, call hasNext() once!
+		 */
+		@Override
+		public E next() {
+			if (this.currentIsUnconsumed || hasNext()) {
+				this.currentIsUnconsumed = false;
+				return KeyGroupedIterator.this.current;
+			} else {
+				throw new NoSuchElementException();
+			}
+		}
+
+		@Override
+		public void remove() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/util/MutableObjectIteratorWrapper.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/functions/util/MutableObjectIteratorWrapper.java
@@ -1,0 +1,47 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.functions.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.util.MutableObjectIterator;
+
+/**
+ * Wraps a regular iterator and emulates a MutableObjectIterator.
+ */
+public class MutableObjectIteratorWrapper<E> implements MutableObjectIterator<E> {
+	private final Iterator<E> source;
+	private final TypeSerializer<E> serializer;
+	
+	public MutableObjectIteratorWrapper(Iterator<E> source, TypeSerializer<E> serializer)
+	{
+		this.source = source;
+		this.serializer = serializer;
+	}
+
+	@Override
+	public E next(E reuse) throws IOException {
+		if (this.source.hasNext()) {
+			this.serializer.copy(this.source.next(), reuse);
+			return reuse;
+		}
+		else {
+			return null;
+		}
+	}
+
+}


### PR DESCRIPTION
This PR proposes a fix for #563.

Performance implications should be tolerable. For Sort-Group strategy only the first value of a group is copied. For Hash-Aggregate strategy (not supported yet), there will be no performance implications.

The fix assumes that the object of the first input value (`val1`) of a `T reduce(T val1, T val2)` may be returned and that the object of the second input value (`val2`) may NOT be returned.
