### PR TITLE
Add triangle enumeration examples for new Java API

### DIFF
--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/EnumTrianglesBasic.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/EnumTrianglesBasic.java
@@ -1,0 +1,162 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.triangles;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import eu.stratosphere.api.common.operators.Order;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.functions.GroupReduceFunction;
+import eu.stratosphere.api.java.functions.JoinFunction;
+import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.example.java.triangles.data.EdgeData;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.Edge;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.Triad;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.TupleEdgeConverter;
+import eu.stratosphere.util.Collector;
+
+/**
+ * Triangle enumeration is a preprocessing step to find closely connected parts in graphs.
+ * A triangle are three edges that connect three vertices with each other.
+ * 
+ * The algorithm works as follows: 
+ * It groups all edges that share a common vertex and builds triads, i.e., triples of vertices 
+ * that are connected by two edges. Finally, all triads are filtered for which no third edge exists 
+ * that closes the triangle.
+ *  
+ * This implementation assumes that edges are represented as pairs of vertices and 
+ * vertices are represented as Integer IDs.
+ * 
+ */
+public class EnumTrianglesBasic {
+
+	/**
+	 *  Projects an edge (pair of vertices) such that the id of the first is smaller than the id of the second.
+	 */
+	private static class EdgeByIdProjector extends MapFunction<Edge, Edge> {
+		private static final long serialVersionUID = 1L;
+	
+		@Override
+		public Edge map(Edge inEdge) throws Exception {
+			
+			// flip vertices if necessary
+			if(inEdge.getFirstVertex() > inEdge.getSecondVertex()) {
+				inEdge.flipVertics();
+			}
+			
+			return inEdge;
+		}
+	}
+	
+	/**
+	 *  Builds triads (triples of vertices) from pairs of edges that share a vertex.
+	 *  The first vertex of a triad is the shared vertex, the second and third vertex are ordered by vertexId. 
+	 *  Assumes that input edges share the first vertex and are in ascending order of the second vertex.
+	 */
+	private static class TriadBuilder extends GroupReduceFunction<Edge, Triad> {
+		private static final long serialVersionUID = 1L;
+		
+		private final List<Integer> vertices = new ArrayList<Integer>();
+		private final Triad outTriad = new Triad();
+		
+		@Override
+		public void reduce(Iterator<Edge> edges, Collector<Triad> out) throws Exception {
+			
+			// clear vertex list
+			vertices.clear();
+			
+			// read first edge
+			Edge firstEdge = edges.next();
+			outTriad.setFirstVertex(firstEdge.getFirstVertex());
+			vertices.add(firstEdge.getSecondVertex());
+			
+			// build and emit triads
+			while(edges.hasNext()) {
+				Integer higherVertexId = edges.next().getSecondVertex();
+				
+				// combine vertex with all previously read vertices
+				for(Integer lowerVertexId : vertices) {
+					outTriad.setSecondVertex(lowerVertexId);
+					outTriad.setThirdVertex(higherVertexId);
+					out.collect(outTriad);
+				}
+				vertices.add(higherVertexId);
+			}
+		}
+	}
+	
+	/**
+	 *  Filters triads (three vertices connected by two edges) without a closing third edge.
+	 */
+	private static class TriadFilter extends JoinFunction<Triad, Edge, Triad> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public Triad join(Triad triad, Edge edge) throws Exception {
+			return triad;
+		}
+	}
+	
+	public static void main(String[] args) throws Exception {
+		
+		String edgePath = "TESTDATA";
+		String outPath = "STDOUT";
+		
+		// parse input arguments
+		if(args.length > 0) {
+			edgePath = args[0];
+		}
+		if(args.length > 1) {
+			outPath = args[1];
+		}
+		
+		// set up execution environment
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+	
+		// read input data
+		DataSet<Edge> edges;
+		if(edgePath.equals("TESTDATA")) {
+			edges = EdgeData.getDefaultEdgeDataSet(env);
+		} else {
+			edges = env.readCsvFile(edgePath)
+				.fieldDelimiter(',')
+				.includeFields(true, true)
+				.types(Integer.class, Integer.class)
+				.map(new TupleEdgeConverter());
+		}
+		
+		// project edges by vertex id
+		DataSet<Edge> edgesById = edges
+				.map(new EdgeByIdProjector());
+		
+		// build and filter triads
+		DataSet<Triad> triangles = edgesById
+				.groupBy(Edge.V1).sortGroup(Edge.V2, Order.ASCENDING).reduceGroup(new TriadBuilder())
+ 				.join(edgesById).where(Triad.V2, Triad.V3).equalTo(Edge.V1, Edge.V2).with(new TriadFilter());
+
+		// emit triangles
+		if(outPath.equals("STDOUT")) {
+			triangles.print();
+		} else {
+			triangles.writeAsCsv(outPath, "\n", ",");
+		}
+		
+		// execute program		
+		env.execute();
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/EnumTrianglesOpt.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/EnumTrianglesOpt.java
@@ -1,0 +1,287 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.triangles;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import eu.stratosphere.api.common.operators.Order;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.functions.GroupReduceFunction;
+import eu.stratosphere.api.java.functions.JoinFunction;
+import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.functions.ReduceFunction;
+import eu.stratosphere.example.java.triangles.data.EdgeData;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.Edge;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.EdgeWithDegrees;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.Triad;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.TupleEdgeConverter;
+import eu.stratosphere.util.Collector;
+
+/**
+ * Triangle enumeration is a preprocessing step to find closely connected parts in graphs.
+ * A triangle are three edges that connect three vertices with each other.
+ * 
+ * The basic algorithm works as follows: 
+ * It groups all edges that share a common vertex and builds triads, i.e., triples of vertices 
+ * that are connected by two edges. Finally, all triads are filtered for which no third edge exists 
+ * that closes the triangle.
+ * 
+ * For a group of n edges that share a common vertex, the number of built triads is quadratic ((n*(n-1))/2).
+ * Therefore, an optimization of the algorithm is to group edges on the vertex with the smaller output degree to 
+ * reduce the number of triads. 
+ * This implementation extends the basic algorithm by computing output degrees of edge vertices and 
+ * grouping on edges on the vertex with the smaller degree.
+ *  
+ * This implementation assumes that edges are represented as pairs of vertices and 
+ * vertices are represented as Integer IDs.
+ * 
+ */
+public class EnumTrianglesOpt {
+
+	/**
+	 * Emits for an edge the original edge and its switched version.
+	 */
+	private static class EdgeDuplicator extends FlatMapFunction<Edge, Edge> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public void flatMap(Edge edge, Collector<Edge> out) throws Exception {
+			out.collect(edge);
+			edge.flipVertics();
+			out.collect(edge);
+		}
+	}
+	
+	/**
+	 * Counts the number of edges that share a common vertex.
+	 * Emits one edge for each input edge with a degree annotation for the shared vertex.
+	 * For each emitted edge, the first vertex is the vertex with the smaller id.
+	 */
+	private static class DegreeCounter extends GroupReduceFunction<Edge, EdgeWithDegrees> {
+		private static final long serialVersionUID = 1L;
+		
+		final ArrayList<Integer> otherVertices = new ArrayList<Integer>();
+		final EdgeWithDegrees outputEdge = new EdgeWithDegrees();
+		
+		@Override
+		public void reduce(Iterator<Edge> edges, Collector<EdgeWithDegrees> out) throws Exception {
+			
+			otherVertices.clear();
+			
+			// get first edge
+			Edge edge = edges.next();
+			Integer groupVertex = edge.getFirstVertex();
+			this.otherVertices.add(edge.getSecondVertex());
+			
+			// get all other edges (assumes edges are sorted by second vertex)
+			while(edges.hasNext()) {
+				edge = edges.next();
+				Integer otherVertex = edge.getSecondVertex();
+				// collect unique vertices
+				if(!otherVertices.contains(otherVertex) && otherVertex != groupVertex) {
+					this.otherVertices.add(otherVertex);
+				}
+			}
+			int degree = this.otherVertices.size();
+			
+			// emit edges
+			for(Integer otherVertex : this.otherVertices) {
+				if(groupVertex < otherVertex) {
+					outputEdge.setFirstVertex(groupVertex);
+					outputEdge.setFirstDegree(degree);
+					outputEdge.setSecondVertex(otherVertex);
+					outputEdge.setSecondDegree(0);
+				} else {
+					outputEdge.setFirstVertex(otherVertex);
+					outputEdge.setFirstDegree(0);
+					outputEdge.setSecondVertex(groupVertex);
+					outputEdge.setSecondDegree(degree);
+				}
+				out.collect(outputEdge);
+			}
+		}
+	}
+	
+	/**
+	 * Builds an edge with degree annotation from two edges that have the same vertices and only one 
+	 * degree annotation.
+	 */
+	private static class DegreeJoiner extends ReduceFunction<EdgeWithDegrees> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public EdgeWithDegrees reduce(EdgeWithDegrees edge1, EdgeWithDegrees edge2) throws Exception {
+			
+			if(edge1.getFirstDegree() == 0 && edge1.getSecondDegree() != 0) {
+				edge1.setFirstDegree(edge2.getFirstDegree());
+			} else if (edge1.getFirstDegree() != 0 && edge1.getSecondDegree() == 0) {
+				edge1.setSecondDegree(edge2.getSecondDegree());
+			}
+			return edge1;
+		}
+	}
+		
+	/**
+	 *  Projects an edge (pair of vertices) such that the first vertex is the vertex with the smaller degree.
+	 */
+	private static class EdgeByDegreeProjector extends MapFunction<EdgeWithDegrees, Edge> {
+		private static final long serialVersionUID = 1L;
+		
+		private final Edge outEdge = new Edge();
+		
+		@Override
+		public Edge map(EdgeWithDegrees inEdge) throws Exception {
+
+			// copy vertices to simple edge
+			outEdge.copyVerticesFromEdgeWithDegrees(inEdge);
+
+			// flip vertices if first degree is larger than second degree.
+			if(inEdge.getFirstDegree() > inEdge.getSecondDegree()) {
+				outEdge.flipVertics();
+			}
+
+			// return edge
+			return outEdge;
+		}
+	}
+	
+	/**
+	 *  Projects an edge (pair of vertices) such that the id of the first is smaller than the id of the second. 
+	 */
+	private static class EdgeByIdProjector extends MapFunction<Edge, Edge> {
+		private static final long serialVersionUID = 1L;
+	
+		@Override
+		public Edge map(Edge inEdge) throws Exception {
+			
+			// flip vertices if necessary
+			if(inEdge.getFirstVertex() > inEdge.getSecondVertex()) {
+				inEdge.flipVertics();
+			}
+			
+			return inEdge;
+		}
+	}
+	
+	/**
+	 *  Builds triads (triples of vertices) from pairs of edges that share a vertex.
+	 *  The first vertex of a triad is the shared vertex, the second and third vertex are ordered by vertexId. 
+	 *  Assumes that input edges share the first vertex and are in ascending order of the second vertex.
+	 */
+	private static class TriadBuilder extends GroupReduceFunction<Edge, Triad> {
+		private static final long serialVersionUID = 1L;
+		
+		private final List<Integer> vertices = new ArrayList<Integer>();
+		private final Triad outTriad = new Triad();
+		
+		@Override
+		public void reduce(Iterator<Edge> edges, Collector<Triad> out) throws Exception {
+			
+			// clear vertex list
+			vertices.clear();
+			
+			// read first edge
+			Edge firstEdge = edges.next();
+			outTriad.setFirstVertex(firstEdge.getFirstVertex());
+			vertices.add(firstEdge.getSecondVertex());
+			
+			// build and emit triads
+			while(edges.hasNext()) {
+				Integer higherVertexId = edges.next().getSecondVertex();
+				
+				// combine vertex with all previously read vertices
+				for(Integer lowerVertexId : vertices) {
+					outTriad.setSecondVertex(lowerVertexId);
+					outTriad.setThirdVertex(higherVertexId);
+					out.collect(outTriad);
+				}
+				vertices.add(higherVertexId);
+			}
+		}
+	}
+	
+	/**
+	 *  Filters triads (three vertices connected by two edges) without a closing third edge.
+	 */
+	private static class TriadFilter extends JoinFunction<Triad, Edge, Triad> {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public Triad join(Triad triad, Edge edge) throws Exception {
+			return triad;
+		}
+	}
+	
+	public static void main(String[] args) throws Exception {
+		
+		String edgePath = "TESTDATA";
+		String outPath = "STDOUT";
+		
+		// parse input arguments
+		if(args.length > 0) {
+			edgePath = args[0];
+		}
+		if(args.length > 1) {
+			outPath = args[1];
+		}
+		
+		// set up execution environment
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+	
+		// read input data
+		DataSet<Edge> edges;
+		if(edgePath.equals("TESTDATA")) {
+			edges = EdgeData.getDefaultEdgeDataSet(env);
+		} else {
+			edges = env.readCsvFile(edgePath)
+				.fieldDelimiter(',')
+				.includeFields(true, true)
+				.types(Integer.class, Integer.class)
+				.map(new TupleEdgeConverter());
+		}
+		
+		// annotate edges with degrees
+		DataSet<EdgeWithDegrees> edgesWithDegrees = edges
+				.flatMap(new EdgeDuplicator())
+				.groupBy(Edge.V1).sortGroup(Edge.V2, Order.ASCENDING).reduceGroup(new DegreeCounter())
+				.groupBy(EdgeWithDegrees.V1,EdgeWithDegrees.V2).reduce(new DegreeJoiner());
+		
+		// project edges by degrees
+		DataSet<Edge> edgesByDegree = edgesWithDegrees
+				.map(new EdgeByDegreeProjector());
+		// project edges by vertex id
+		DataSet<Edge> edgesById = edgesByDegree
+				.map(new EdgeByIdProjector());
+		
+		// build and filter triads
+		DataSet<Triad> triangles = edgesByDegree
+				.groupBy(Edge.V1).sortGroup(Edge.V2, Order.ASCENDING).reduceGroup(new TriadBuilder())
+ 				.join(edgesById).where(Triad.V2,Triad.V3).equalTo(Edge.V1,Edge.V2).with(new TriadFilter());
+
+		// emit triangles
+		if(outPath.equals("STDOUT")) {
+			triangles.print();
+		} else {
+			triangles.writeAsCsv(outPath, "\n", ",");
+		}
+		
+		// execute program		
+		env.execute();
+	}
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/data/EdgeData.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/data/EdgeData.java
@@ -1,0 +1,54 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.triangles.data;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.typeutils.BasicTypeInfo;
+import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
+import eu.stratosphere.example.java.triangles.dataTypes.EdgeDataTypes.Edge;
+
+public class EdgeData {
+
+	public static DataSet<Edge> getDefaultEdgeDataSet(ExecutionEnvironment env) {
+		
+		Set<Edge> edgeData = new HashSet<Edge>();
+		
+		edgeData.add(new Edge(1, 2));
+		edgeData.add(new Edge(1, 3));
+		edgeData.add(new Edge(1, 4));
+		edgeData.add(new Edge(1, 5));
+		edgeData.add(new Edge(2, 3));
+		edgeData.add(new Edge(2, 5));
+		edgeData.add(new Edge(3, 4));
+		edgeData.add(new Edge(3, 7));
+		edgeData.add(new Edge(3, 8));
+		edgeData.add(new Edge(5, 6));
+		edgeData.add(new Edge(7, 8));
+				
+		TupleTypeInfo<Edge> edgeType = 
+				new TupleTypeInfo<Edge>(
+						Edge.class,
+						BasicTypeInfo.INT_TYPE_INFO,
+						BasicTypeInfo.INT_TYPE_INFO);
+		
+		return env.fromCollection(edgeData, edgeType);
+		
+	}
+	
+}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/dataTypes/EdgeDataTypes.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/dataTypes/EdgeDataTypes.java
@@ -1,0 +1,122 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.example.java.triangles.dataTypes;
+
+import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.tuple.Tuple2;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.api.java.tuple.Tuple4;
+
+public class EdgeDataTypes {
+
+	public static class EdgeWithDegrees extends Tuple4<Integer, Integer, Integer, Integer> {
+		private static final long serialVersionUID = 1L;
+
+		public static final int V1 = 0;
+		public static final int V2 = 1;
+		public static final int D1 = 2;
+		public static final int D2 = 3;
+		
+		public EdgeWithDegrees() { }
+		
+		public EdgeWithDegrees(Integer vertex1, Integer degree1, Integer vertex2, Integer degree2) {
+			super(vertex1, degree1, vertex2, degree2);
+		}
+		
+		public Integer getFirstVertex() { return this.getField(V1); }
+		
+		public Integer getSecondVertex() { return this.getField(V2); }
+		
+		public Integer getFirstDegree() { return this.getField(D1); }
+		
+		public Integer getSecondDegree() { return this.getField(D2); }
+		
+		public void setFirstVertex(Integer v) { this.setField(v, V1); }
+		
+		public void setSecondVertex(Integer v) { this.setField(v, V2); }
+		
+		public void setFirstDegree(Integer d) { this.setField(d, D1); }
+		
+		public void setSecondDegree(Integer d) { this.setField(d, D2); }
+	}
+	
+	public static class Edge extends Tuple2<Integer, Integer> {
+		private static final long serialVersionUID = 1L;
+		
+		public static final int V1 = 0;
+		public static final int V2 = 1;
+		
+		public Edge() {}
+		
+		public Edge(Integer v1, Integer v2) {
+			this.setFirstVertex(v1);
+			this.setSecondVertex(v2);
+		}
+		
+		public Integer getFirstVertex() { return this.getField(V1); }
+		
+		public Integer getSecondVertex() { return this.getField(V2); }
+		
+		public void setFirstVertex(Integer v) { this.setField(v, V1); }
+		
+		public void setSecondVertex(Integer v) { this.setField(v, V2); }
+		
+		public void copyVerticesFromTuple2(Tuple2<Integer, Integer> t) {
+			this.setFirstVertex(t.T1());
+			this.setSecondVertex(t.T2());
+		}
+		
+		public void copyVerticesFromEdgeWithDegrees(EdgeWithDegrees ewd) {
+			this.setFirstVertex(ewd.getFirstVertex());
+			this.setSecondVertex(ewd.getSecondVertex());
+		}
+		
+		public void flipVertics() {
+			Integer tmp = this.getFirstVertex();
+			this.setFirstVertex(this.getSecondVertex());
+			this.setSecondVertex(tmp);
+		}
+	}
+	
+	public static class Triad extends Tuple3<Integer, Integer, Integer> {
+		private static final long serialVersionUID = 1L;
+		
+		public static final int V1 = 0;
+		public static final int V2 = 1;
+		public static final int V3 = 2;
+		
+		public Triad() {}
+		
+		public void setFirstVertex(Integer v) { this.setField(v, V1); }
+		
+		public void setSecondVertex(Integer v) { this.setField(v, V2); }
+		
+		public void setThirdVertex(Integer v) { this.setField(v, V3); }
+	}
+	
+	public static class TupleEdgeConverter extends MapFunction<Tuple2<Integer, Integer>, Edge> {
+		private static final long serialVersionUID = 1L;
+
+		private final Edge outEdge = new Edge();
+		
+		@Override
+		public Edge map(Tuple2<Integer, Integer> t) throws Exception {
+			outEdge.copyVerticesFromTuple2(t);
+			return outEdge;
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
Adds two triangle enumeration jobs for the new Java API, a basic version and an optimized version with degree computation.
The jobs are written such that parameters input and output parameters are optional. If no parameters are given, the job runs on default data and writes to standard out.

Requires PRs #565 and #578 

To be done (all resolved):
- ~~Set DOP~~
- ~~Integrate CSV output format~~
