### PR TITLE
Fix issue about Windows line break in TextInputFormat

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
@@ -34,12 +34,12 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 	/**
 	 * Code of \r, used to remove \r from a line when the line ends with \r\n
 	 */
-	private static final byte CARRIAGE_RETURN = 13;
+	private static final byte CARRIAGE_RETURN = (byte) '\r';
 
 	/**
 	 * Code of \n, used to identify if \n is used as delimiter
 	 */
-	private static final byte NEW_LINE = 10;
+	private static final byte NEW_LINE = (byte) '\n';
 
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
@@ -31,6 +31,17 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 	
 	private transient Charset charset;
 
+	/**
+	 * Code of \r, used to remove \r from a line when the line ends with \r\n
+	 */
+	private static final byte CARRIAGE_RETURN = 13;
+
+	/**
+	 * Code of \n, used to identify if \n is used as delimiter
+	 */
+	private static final byte NEW_LINE = 10;
+
+	
 	// --------------------------------------------------------------------------------------------
 	
 	public TextInputFormat(Path filePath) {
@@ -74,6 +85,12 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	@Override
 	public String readRecord(String reusable, byte[] bytes, int offset, int numBytes) {
+		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
+		if (this.getDelimiter().length == 1 && this.getDelimiter()[0] == NEW_LINE && 
+				offset+numBytes >= 1 && bytes[offset+numBytes-1] == CARRIAGE_RETURN){
+			numBytes -= 1;
+		}
+		
 		return new String(bytes, offset, numBytes, this.charset);
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/TextInputFormat.java
@@ -86,8 +86,9 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 	@Override
 	public String readRecord(String reusable, byte[] bytes, int offset, int numBytes) {
 		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
-		if (this.getDelimiter().length == 1 && this.getDelimiter()[0] == NEW_LINE && 
-				offset+numBytes >= 1 && bytes[offset+numBytes-1] == CARRIAGE_RETURN){
+		if (this.getDelimiter() != null && this.getDelimiter().length == 1 
+				&& this.getDelimiter()[0] == NEW_LINE && offset+numBytes >= 1 
+				&& bytes[offset+numBytes-1] == CARRIAGE_RETURN){
 			numBytes -= 1;
 		}
 		

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
@@ -56,6 +56,17 @@ public class TextInputFormat extends DelimitedInputFormat {
 	
 	protected transient boolean ascii;
 	
+	/**
+	 * Code of \r, used to remove \r from a line when the line ends with \r\n
+	 */
+	private static final byte CARRIAGE_RETURN = 13;
+
+	/**
+	 * Code of \n, used to identify if \n is used as delimiter
+	 */
+	private static final byte NEW_LINE = 10;
+
+	
 	// --------------------------------------------------------------------------------------------
 	
 	@Override
@@ -86,6 +97,13 @@ public class TextInputFormat extends DelimitedInputFormat {
 
 	public Record readRecord(Record reuse, byte[] bytes, int offset, int numBytes) {
 		StringValue str = this.theString;
+		
+		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
+		if (this.getDelimiter().length == 1 && this.getDelimiter()[0] == NEW_LINE && 
+				offset+numBytes >= 1 && bytes[offset+numBytes-1] == CARRIAGE_RETURN){
+			numBytes -= 1;
+		}
+
 		
 		if (this.ascii) {
 			str.setValueAscii(bytes, offset, numBytes);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
@@ -99,8 +99,9 @@ public class TextInputFormat extends DelimitedInputFormat {
 		StringValue str = this.theString;
 		
 		//Check if \n is used as delimiter and the end of this line is a \r, then remove \r from the line
-		if (this.getDelimiter().length == 1 && this.getDelimiter()[0] == NEW_LINE && 
-				offset+numBytes >= 1 && bytes[offset+numBytes-1] == CARRIAGE_RETURN){
+		if (this.getDelimiter() != null && this.getDelimiter().length == 1 
+				&& this.getDelimiter()[0] == NEW_LINE && offset+numBytes >= 1 
+				&& bytes[offset+numBytes-1] == CARRIAGE_RETURN){
 			numBytes -= 1;
 		}
 

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/TextInputFormat.java
@@ -59,12 +59,12 @@ public class TextInputFormat extends DelimitedInputFormat {
 	/**
 	 * Code of \r, used to remove \r from a line when the line ends with \r\n
 	 */
-	private static final byte CARRIAGE_RETURN = 13;
+	private static final byte CARRIAGE_RETURN = (byte) '\r';
 
 	/**
 	 * Code of \n, used to identify if \n is used as delimiter
 	 */
-	private static final byte NEW_LINE = 10;
+	private static final byte NEW_LINE = (byte) '\n';
 
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/TextInputFormatTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/TextInputFormatTest.java
@@ -13,10 +13,16 @@
 
 package eu.stratosphere.api.java.io;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 
 import org.apache.log4j.Level;
@@ -88,4 +94,78 @@ public class TextInputFormatTest {
 			fail("Test erroneous");
 		}
 	}
+	
+	/**
+	 * This tests cases when line ends with \r\n and \n is used as delimiter, the last \r should be removed 
+	 */
+	@Test
+	public void testRemovingTrailingCR() {
+		
+		testRemovingTrailingCR("\n","\n");
+		testRemovingTrailingCR("\r\n","\n");
+		
+		testRemovingTrailingCR("|","|");
+		testRemovingTrailingCR("|","\n");
+	}
+	
+	private void testRemovingTrailingCR(String lineBreaker,String delimiter) {
+		File tempFile=null;
+		
+		String FIRST = "First line";
+		String SECOND = "Second line";
+		String CONTENT = FIRST + lineBreaker + SECOND + lineBreaker;
+		
+		try {
+			// create input file
+			tempFile = File.createTempFile("TextInputFormatTest", "tmp");
+			tempFile.deleteOnExit();
+			tempFile.setWritable(true);
+			
+			OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
+			wrt.write(CONTENT);
+			wrt.close();
+			
+			TextInputFormat inputFormat = new TextInputFormat(new Path(tempFile.toURI().toString()));
+			inputFormat.setFilePath(tempFile.toURI().toString());
+			
+			Configuration parameters = new Configuration(); 
+			inputFormat.configure(parameters);
+			
+			inputFormat.setDelimiter(delimiter);
+			
+			FileInputSplit[] splits = inputFormat.createInputSplits(1);
+						
+			inputFormat.open(splits[0]);
+			
+
+			String result = "";
+			if (  (delimiter.equals("\n") && (lineBreaker.equals("\n") || lineBreaker.equals("\r\n") ) ) 
+					|| (lineBreaker.equals(delimiter)) ){
+				
+				result = inputFormat.nextRecord("");
+				assertNotNull("Expecting first record here", result);
+				assertEquals(FIRST, result);
+				
+				result = inputFormat.nextRecord(result);
+				assertNotNull("Expecting second record here", result);
+				assertEquals(SECOND, result);
+				
+				result = inputFormat.nextRecord(result);
+				assertNull("The input file is over", result);
+				
+			}else{
+				result = inputFormat.nextRecord("");
+				assertNotNull("Expecting first record here", result);
+				assertEquals(CONTENT, result);
+			}
+			
+			
+		}
+		catch (Throwable t) {
+			System.err.println("test failed with exception: " + t.getMessage());
+			t.printStackTrace(System.err);
+			fail("Test erroneous");
+		}
+	}
+
 }


### PR DESCRIPTION
Window uses \r\n to split lines. so, for text files from Windows, when \n is used as delimiter, \r is still appear at the end of lines.

The code checks to see if \n is used as delimiter and end of a line is \r, then \r is removed from the line

The change is the same as in https://github.com/stratosphere/stratosphere/pull/577, but this time I move it into the TextInputFormat. https://github.com/stratosphere/stratosphere/pull/577 failed the test case for terasort because the input file uses DelimitedInputFormat but it is not a text file.
