### PR TITLE
Change of java version without effect.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,19 +292,6 @@
 	<reporting>
 		<plugins>
 
-			<plugin>
-				<!-- just define the Java version to be used for compiling and plugins -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-
-
-
 			<!-- execution of Unit Tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -505,7 +492,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore/>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>


### PR DESCRIPTION
The compiler plugin was configured under the wrong section. It used to
be a child of reporting but is now a child of build. Changing the source
and target properties in the old pom were without any effect. They were
simply ignored. 
