### PR TITLE
Add project operator to new Java API

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -113,7 +113,7 @@ public abstract class DataSet<T> {
 		if(fieldIndexes.length == 0) {
 			throw new IllegalArgumentException("project() needs to select at least one (1) field.");
 		} else if(fieldIndexes.length > 22) {
-			throw new IllegalArgumentException("project() may to select at most twenty-two (22) fields.");
+			throw new IllegalArgumentException("project() may select only up to twenty-two (22) fields.");
 		}
 		
 		int maxFieldIndex = ((TupleTypeInfo<?>)this.getType()).getArity();

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -15,7 +15,7 @@
 package eu.stratosphere.api.java;
 
 import org.apache.commons.lang3.Validate;
-import java.util.Arrays;
+
 import eu.stratosphere.api.common.io.FileOutputFormat;
 import eu.stratosphere.api.common.io.OutputFormat;
 import eu.stratosphere.api.java.aggregation.Aggregations;
@@ -45,7 +45,6 @@ import eu.stratosphere.api.java.operators.ReduceGroupOperator;
 import eu.stratosphere.api.java.operators.ReduceOperator;
 import eu.stratosphere.api.java.tuple.Tuple;
 import eu.stratosphere.api.java.typeutils.InputTypeConfigurable;
-import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 import eu.stratosphere.core.fs.Path;
 
@@ -96,6 +95,10 @@ public abstract class DataSet<T> {
 		return new FilterOperator<T>(this, filter);
 	}
 	
+	// --------------------------------------------------------------------------------------------
+	//  Projections
+	// --------------------------------------------------------------------------------------------
+	
 	/**
 	 * Selects a subset of fields of a Tuple to create new Tuples. 
 	 * 
@@ -105,24 +108,6 @@ public abstract class DataSet<T> {
 	 *         to create a ProjectOperator. 
 	 */
 	public Projection<T> project(int... fieldIndexes) {
-		
-		if(!(this.getType() instanceof TupleTypeInfo)) {
-			throw new UnsupportedOperationException("project() can only be applied to DataSets of Tuples.");
-		}
-		
-		if(fieldIndexes.length == 0) {
-			throw new IllegalArgumentException("project() needs to select at least one (1) field.");
-		} else if(fieldIndexes.length > 22) {
-			throw new IllegalArgumentException("project() may select only up to twenty-two (22) fields.");
-		}
-		
-		int maxFieldIndex = ((TupleTypeInfo<?>)this.getType()).getArity();
-		for(int i=0; i<fieldIndexes.length; i++) {
-			if(fieldIndexes[i] > maxFieldIndex - 1) {
-				throw new IndexOutOfBoundsException("Provided field index is out of bounds of input tuple.");
-			}
-		}
-		
 		return new Projection<T>(this, fieldIndexes);
 	}
 	
@@ -136,21 +121,7 @@ public abstract class DataSet<T> {
 	 *         to create a ProjectOperator. 
 	 */
 	public Projection<T> project(String fieldMask) {
-		int[] fieldIndexes = new int[fieldMask.length()];
-		int fieldCnt = 0;
-		
-		fieldMask = fieldMask.toUpperCase();
-		for (int i = 0; i < fieldMask.length(); i++) {
-			char c = fieldMask.charAt(i);
-			if (c == '1' || c == 'T') {
-				fieldIndexes[fieldCnt++] = i;
-			} else if (c != '0' && c != 'F') {
-				throw new IllegalArgumentException("Mask string may contain only '0' and '1'.");
-			}
-		}
-		fieldIndexes = Arrays.copyOf(fieldIndexes, fieldCnt);
-		
-		return project(fieldIndexes);
+		return new Projection<T>(this, fieldMask);
 	}
 	
 	/**
@@ -163,17 +134,7 @@ public abstract class DataSet<T> {
 	 *         to create a ProjectOperator. 
 	 */
 	public Projection<T> project(boolean... fieldFlags) {
-		int[] fieldIndexes = new int[fieldFlags.length];
-		int fieldCnt = 0;
-		
-		for (int i = 0; i < fieldFlags.length; i++) {
-			if (fieldFlags[i]) {
-				fieldIndexes[fieldCnt++] = i;
-			}
-		}
-		fieldIndexes = Arrays.copyOf(fieldIndexes, fieldCnt);
-		
-		return project(fieldIndexes);
+		return new Projection<T>(this, fieldFlags);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
@@ -71,12 +71,37 @@ public class ProjectOperator<IN, OUT extends Tuple>
 	public static class Projection<T> {
 		
 		private final DataSet<T> ds;
-		private final int[] fields;
+		private final int[] fieldIndexes;
 		
-		public Projection(DataSet<T> ds, int[] fields) {
+		public Projection(DataSet<T> ds, int[] fieldIndexes) {
+			
+			if(!(ds.getType() instanceof TupleTypeInfo)) {
+				throw new UnsupportedOperationException("project() can only be applied to DataSets of Tuples.");
+			}
+			
+			if(fieldIndexes.length == 0) {
+				throw new IllegalArgumentException("project() needs to select at least one (1) field.");
+			} else if(fieldIndexes.length > 22) {
+				throw new IllegalArgumentException("project() may select only up to twenty-two (22) fields.");
+			}
+			
+			int maxFieldIndex = ((TupleTypeInfo<?>)ds.getType()).getArity();
+			for(int i=0; i<fieldIndexes.length; i++) {
+				if(fieldIndexes[i] > maxFieldIndex - 1) {
+					throw new IndexOutOfBoundsException("Provided field index is out of bounds of input tuple.");
+				}
+			}
 			
 			this.ds = ds;
-			this.fields = fields;
+			this.fieldIndexes = fieldIndexes;
+		}
+		
+		public Projection(DataSet<T> ds, String fieldMask) {
+			this(ds, getFieldIndexesFromMask(fieldMask));
+		}
+		
+		public Projection(DataSet<T> ds, boolean[] fieldFlags) {
+			this(ds, getFieldIndexesFromFlags(fieldFlags));
 		}
 		
 		// --------------------------------------------------------------------------------------------	
@@ -94,14 +119,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0> ProjectOperator<T, Tuple1<T0>> types(Class<T0> type0) {
 			Class<?>[] types = {type0};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple1<T0>> tType = new TupleTypeInfo<Tuple1<T0>>(fTypes);
 
-			return new ProjectOperator<T, Tuple1<T0>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple1<T0>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -114,14 +139,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1> ProjectOperator<T, Tuple2<T0, T1>> types(Class<T0> type0, Class<T1> type1) {
 			Class<?>[] types = {type0, type1};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple2<T0, T1>> tType = new TupleTypeInfo<Tuple2<T0, T1>>(fTypes);
 
-			return new ProjectOperator<T, Tuple2<T0, T1>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple2<T0, T1>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -135,14 +160,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2> ProjectOperator<T, Tuple3<T0, T1, T2>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2) {
 			Class<?>[] types = {type0, type1, type2};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple3<T0, T1, T2>> tType = new TupleTypeInfo<Tuple3<T0, T1, T2>>(fTypes);
 
-			return new ProjectOperator<T, Tuple3<T0, T1, T2>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple3<T0, T1, T2>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -157,14 +182,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3> ProjectOperator<T, Tuple4<T0, T1, T2, T3>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
 			Class<?>[] types = {type0, type1, type2, type3};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple4<T0, T1, T2, T3>> tType = new TupleTypeInfo<Tuple4<T0, T1, T2, T3>>(fTypes);
 
-			return new ProjectOperator<T, Tuple4<T0, T1, T2, T3>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple4<T0, T1, T2, T3>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -180,14 +205,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4> ProjectOperator<T, Tuple5<T0, T1, T2, T3, T4>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
 			Class<?>[] types = {type0, type1, type2, type3, type4};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>> tType = new TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>>(fTypes);
 
-			return new ProjectOperator<T, Tuple5<T0, T1, T2, T3, T4>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple5<T0, T1, T2, T3, T4>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -204,14 +229,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5> ProjectOperator<T, Tuple6<T0, T1, T2, T3, T4, T5>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>> tType = new TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>>(fTypes);
 
-			return new ProjectOperator<T, Tuple6<T0, T1, T2, T3, T4, T5>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple6<T0, T1, T2, T3, T4, T5>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -229,14 +254,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6> ProjectOperator<T, Tuple7<T0, T1, T2, T3, T4, T5, T6>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>> tType = new TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>>(fTypes);
 
-			return new ProjectOperator<T, Tuple7<T0, T1, T2, T3, T4, T5, T6>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple7<T0, T1, T2, T3, T4, T5, T6>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -255,14 +280,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7> ProjectOperator<T, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> tType = new TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(fTypes);
 
-			return new ProjectOperator<T, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -282,14 +307,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8> ProjectOperator<T, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> tType = new TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(fTypes);
 
-			return new ProjectOperator<T, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -310,14 +335,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> ProjectOperator<T, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> tType = new TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(fTypes);
 
-			return new ProjectOperator<T, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -339,14 +364,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ProjectOperator<T, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> tType = new TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(fTypes);
 
-			return new ProjectOperator<T, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -369,14 +394,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> ProjectOperator<T, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> tType = new TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(fTypes);
 
-			return new ProjectOperator<T, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -400,14 +425,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> ProjectOperator<T, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> tType = new TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(fTypes);
 
-			return new ProjectOperator<T, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -432,14 +457,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> ProjectOperator<T, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> tType = new TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(fTypes);
 
-			return new ProjectOperator<T, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -465,14 +490,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> ProjectOperator<T, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> tType = new TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(fTypes);
 
-			return new ProjectOperator<T, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -499,14 +524,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> ProjectOperator<T, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> tType = new TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(fTypes);
 
-			return new ProjectOperator<T, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -534,14 +559,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> ProjectOperator<T, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> tType = new TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(fTypes);
 
-			return new ProjectOperator<T, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -570,14 +595,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> ProjectOperator<T, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> tType = new TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(fTypes);
 
-			return new ProjectOperator<T, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -607,14 +632,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> ProjectOperator<T, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> tType = new TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(fTypes);
 
-			return new ProjectOperator<T, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -645,14 +670,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> ProjectOperator<T, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> tType = new TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(fTypes);
 
-			return new ProjectOperator<T, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -684,14 +709,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> ProjectOperator<T, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> tType = new TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(fTypes);
 
-			return new ProjectOperator<T, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		/**
@@ -724,14 +749,14 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> ProjectOperator<T, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20, Class<T21> type21) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20, type21};
-			if(types.length != this.fields.length) {
+			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types, ds.getType());
 			TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> tType = new TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(fTypes);
 
-			return new ProjectOperator<T, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(this.ds, this.fields, tType);
+			return new ProjectOperator<T, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(this.ds, this.fieldIndexes, tType);
 		}
 
 		// END_OF_TUPLE_DEPENDENT_CODE
@@ -753,6 +778,39 @@ public class ProjectOperator<IN, OUT extends Tuple>
 			}
 			
 			return fieldTypes;
+		}
+		
+		private static int[] getFieldIndexesFromMask(String fieldMask) {
+			
+			int[] fieldIndexes = new int[fieldMask.length()];
+			int fieldCnt = 0;
+			
+			fieldMask = fieldMask.toUpperCase();
+			for (int i = 0; i < fieldMask.length(); i++) {
+				char c = fieldMask.charAt(i);
+				if (c == '1' || c == 'T') {
+					fieldIndexes[fieldCnt++] = i;
+				} else if (c != '0' && c != 'F') {
+					throw new IllegalArgumentException("Mask string may contain only '0' and '1'.");
+				}
+			}
+			fieldIndexes = Arrays.copyOf(fieldIndexes, fieldCnt);
+			
+			return fieldIndexes;
+		}
+		
+		private static int[] getFieldIndexesFromFlags(boolean[] fieldFlags) {
+			int[] fieldIndexes = new int[fieldFlags.length];
+			int fieldCnt = 0;
+			
+			for (int i = 0; i < fieldFlags.length; i++) {
+				if (fieldFlags[i]) {
+					fieldIndexes[fieldCnt++] = i;
+				}
+			}
+			fieldIndexes = Arrays.copyOf(fieldIndexes, fieldCnt);
+			
+			return fieldIndexes;
 		}
 		
 	}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
@@ -1,0 +1,281 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.operators;
+
+import java.util.Arrays;
+
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.operators.translation.PlanProjectOperator;
+import eu.stratosphere.api.java.operators.translation.UnaryNodeTranslation;
+import eu.stratosphere.api.java.tuple.Tuple;
+import eu.stratosphere.api.java.tuple.Tuple1;
+import eu.stratosphere.api.java.tuple.Tuple2;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.api.java.tuple.Tuple4;
+import eu.stratosphere.api.java.tuple.Tuple5;
+import eu.stratosphere.api.java.tuple.Tuple6;
+import eu.stratosphere.api.java.tuple.Tuple7;
+import eu.stratosphere.api.java.tuple.Tuple8;
+import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
+import eu.stratosphere.api.java.typeutils.TypeInformation;
+
+/**
+ *
+ * @param <IN> The type of the data set projected by the operator.
+ * @param <OUT> The type of data set that is the result of the projection.
+ */
+public class ProjectOperator<IN, OUT extends Tuple> 
+	extends SingleInputOperator<IN, OUT, ProjectOperator<IN, OUT>> {
+	
+	protected final int[] fields;
+	
+	public ProjectOperator(DataSet<IN> input, int[] fields, TupleTypeInfo<OUT> returnType) {
+		super(input, returnType);
+	
+		this.fields = fields;
+	}
+
+	@Override
+	protected UnaryNodeTranslation translateToDataFlow() {
+		String name = getName() != null ? getName() : "Projection "+Arrays.toString(fields);
+		return new UnaryNodeTranslation(new PlanProjectOperator<IN, OUT>(fields, name, getInputType(), getResultType()));
+	}
+
+	
+	public static class Projection<T> {
+		
+		private final DataSet<T> ds;
+		private final int[] fields;
+		
+		public Projection(DataSet<T> ds, int[] fields) {
+			
+			this.ds = ds;
+			this.fields = fields;
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1> ProjectOperator<T, Tuple1<T1>> types(Class<T1> type1) {
+			
+			Class<?>[] types = {type1};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple1<T1>> tType = new TupleTypeInfo<Tuple1<T1>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple1<T1>>(this.ds, this.fields, tType);
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1, T2> ProjectOperator<T, Tuple2<T1, T2>> types(Class<T1> type1, Class<T2> type2) {
+			
+			Class<?>[] types = {type1, type2};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple2<T1, T2>> tType = new TupleTypeInfo<Tuple2<T1, T2>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple2<T1, T2>>(this.ds, this.fields, tType);
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @param type3 The class of the 3rd field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1, T2, T3> ProjectOperator<T, Tuple3<T1, T2, T3>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+			
+			Class<?>[] types = {type1, type2, type3};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple3<T1, T2, T3>> tType = new TupleTypeInfo<Tuple3<T1, T2, T3>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple3<T1, T2, T3>>(this.ds, this.fields, tType);
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @param type3 The class of the 3rd field of the result tuples.
+		 * @param type4 The class of the 4th field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1, T2, T3, T4> ProjectOperator<T, Tuple4<T1, T2, T3, T4>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+			
+			Class<?>[] types = {type1, type2, type3, type4};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple4<T1, T2, T3, T4>> tType = new TupleTypeInfo<Tuple4<T1, T2, T3, T4>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple4<T1, T2, T3, T4>>(this.ds, this.fields, tType);
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @param type3 The class of the 3rd field of the result tuples.
+		 * @param type4 The class of the 4th field of the result tuples.
+		 * @param type5 The class of the 5th field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1, T2, T3, T4, T5> ProjectOperator<T, Tuple5<T1, T2, T3, T4, T5>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+			
+			Class<?>[] types = {type1, type2, type3, type4, type5};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple5<T1, T2, T3, T4, T5>> tType = new TupleTypeInfo<Tuple5<T1, T2, T3, T4, T5>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple5<T1, T2, T3, T4, T5>>(this.ds, this.fields, tType);
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @param type3 The class of the 3rd field of the result tuples.
+		 * @param type4 The class of the 4th field of the result tuples.
+		 * @param type5 The class of the 5th field of the result tuples.
+		 * @param type6 The class of the 6th field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1, T2, T3, T4, T5, T6> ProjectOperator<T, Tuple6<T1, T2, T3, T4, T5, T6>> types(
+				Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+			
+			Class<?>[] types = {type1, type2, type3, type4, type5, type6};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple6<T1, T2, T3, T4, T5, T6>> tType = new TupleTypeInfo<Tuple6<T1, T2, T3, T4, T5, T6>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple6<T1, T2, T3, T4, T5, T6>>(this.ds, this.fields, tType);
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @param type3 The class of the 3rd field of the result tuples.
+		 * @param type4 The class of the 4th field of the result tuples.
+		 * @param type5 The class of the 5th field of the result tuples.
+		 * @param type6 The class of the 6th field of the result tuples.
+		 * @param type7 The class of the 7th field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1, T2, T3, T4, T5, T6, T7> ProjectOperator<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>> types(
+				Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+			
+			Class<?>[] types = {type1, type2, type3, type4, type5, type6, type7};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple7<T1, T2, T3, T4, T5, T6, T7>> tType = new TupleTypeInfo<Tuple7<T1, T2, T3, T4, T5, T6, T7>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>>(this.ds, this.fields, tType);
+		}
+		
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples.
+		 * 
+		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @param type3 The class of the 3rd field of the result tuples.
+		 * @param type4 The class of the 4th field of the result tuples.
+		 * @param type5 The class of the 5th field of the result tuples.
+		 * @param type6 The class of the 6th field of the result tuples.
+		 * @param type7 The class of the 7th field of the result tuples.
+		 * @param type8 The class of the 8th field of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T1, T2, T3, T4, T5, T6, T7, T8> ProjectOperator<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> types(
+				Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, 
+				Class<T7> type7, Class<T8> type8) {
+			
+			Class<?>[] types = {type1, type2, type3, type4, type5, type6, type7, type8};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TupleTypeInfo<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> tType = new TupleTypeInfo<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>(fTypes);
+			
+			return new ProjectOperator<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>(this.ds, this.fields, tType);
+		}
+		
+		// TODO: Do all 22 type methods
+		
+		// -----------------------------------------------------------------------------------------
+		
+			
+		private TypeInformation<?>[] extractFieldTypes(int[] fields, TypeInformation<?> inType) {
+			
+			TupleTypeInfo<?> inTupleType = (TupleTypeInfo<?>) inType;
+			TypeInformation<?>[] fieldTypes = new TypeInformation[fields.length];
+					
+			for(int i=0; i<fields.length; i++) {
+				if(fields[i] > inTupleType.getArity() - 1) {
+					throw new IndexOutOfBoundsException("Projection field not in range of input tuple fields.");
+				}
+				fieldTypes[i] = inTupleType.getTypeAt(fields[i]);
+			}
+			
+			return fieldTypes;
+		}
+		
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
@@ -21,13 +21,27 @@ import eu.stratosphere.api.java.operators.translation.PlanProjectOperator;
 import eu.stratosphere.api.java.operators.translation.UnaryNodeTranslation;
 import eu.stratosphere.api.java.tuple.Tuple;
 import eu.stratosphere.api.java.tuple.Tuple1;
+import eu.stratosphere.api.java.tuple.Tuple10;
+import eu.stratosphere.api.java.tuple.Tuple11;
+import eu.stratosphere.api.java.tuple.Tuple12;
+import eu.stratosphere.api.java.tuple.Tuple13;
+import eu.stratosphere.api.java.tuple.Tuple14;
+import eu.stratosphere.api.java.tuple.Tuple15;
+import eu.stratosphere.api.java.tuple.Tuple16;
+import eu.stratosphere.api.java.tuple.Tuple17;
+import eu.stratosphere.api.java.tuple.Tuple18;
+import eu.stratosphere.api.java.tuple.Tuple19;
 import eu.stratosphere.api.java.tuple.Tuple2;
+import eu.stratosphere.api.java.tuple.Tuple20;
+import eu.stratosphere.api.java.tuple.Tuple21;
+import eu.stratosphere.api.java.tuple.Tuple22;
 import eu.stratosphere.api.java.tuple.Tuple3;
 import eu.stratosphere.api.java.tuple.Tuple4;
 import eu.stratosphere.api.java.tuple.Tuple5;
 import eu.stratosphere.api.java.tuple.Tuple6;
 import eu.stratosphere.api.java.tuple.Tuple7;
 import eu.stratosphere.api.java.tuple.Tuple8;
+import eu.stratosphere.api.java.tuple.Tuple9;
 import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
@@ -65,200 +79,662 @@ public class ProjectOperator<IN, OUT extends Tuple>
 			this.fields = fields;
 		}
 		
+		// --------------------------------------------------------------------------------------------	
+		// The following lines are generated.
+		// --------------------------------------------------------------------------------------------	
+		// BEGIN_OF_TUPLE_DEPENDENT_CODE	
+		// GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1> ProjectOperator<T, Tuple1<T1>> types(Class<T1> type1) {
-			
-			Class<?>[] types = {type1};
+		public <T0> ProjectOperator<T, Tuple1<T0>> types(Class<T0> type0) {
+			Class<?>[] types = {type0};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple1<T1>> tType = new TupleTypeInfo<Tuple1<T1>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple1<T1>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple1<T0>> tType = new TupleTypeInfo<Tuple1<T0>>(fTypes);
+
+			return new ProjectOperator<T, Tuple1<T0>>(this.ds, this.fields, tType);
 		}
-		
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
-		 * @param type2 The class of the 2nd field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1, T2> ProjectOperator<T, Tuple2<T1, T2>> types(Class<T1> type1, Class<T2> type2) {
-			
-			Class<?>[] types = {type1, type2};
+		public <T0, T1> ProjectOperator<T, Tuple2<T0, T1>> types(Class<T0> type0, Class<T1> type1) {
+			Class<?>[] types = {type0, type1};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple2<T1, T2>> tType = new TupleTypeInfo<Tuple2<T1, T2>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple2<T1, T2>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple2<T0, T1>> tType = new TupleTypeInfo<Tuple2<T0, T1>>(fTypes);
+
+			return new ProjectOperator<T, Tuple2<T0, T1>>(this.ds, this.fields, tType);
 		}
-		
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
-		 * @param type2 The class of the 2nd field of the result tuples.
-		 * @param type3 The class of the 3rd field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1, T2, T3> ProjectOperator<T, Tuple3<T1, T2, T3>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3) {
-			
-			Class<?>[] types = {type1, type2, type3};
+		public <T0, T1, T2> ProjectOperator<T, Tuple3<T0, T1, T2>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2) {
+			Class<?>[] types = {type0, type1, type2};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple3<T1, T2, T3>> tType = new TupleTypeInfo<Tuple3<T1, T2, T3>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple3<T1, T2, T3>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple3<T0, T1, T2>> tType = new TupleTypeInfo<Tuple3<T0, T1, T2>>(fTypes);
+
+			return new ProjectOperator<T, Tuple3<T0, T1, T2>>(this.ds, this.fields, tType);
 		}
-		
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
-		 * @param type2 The class of the 2nd field of the result tuples.
-		 * @param type3 The class of the 3rd field of the result tuples.
-		 * @param type4 The class of the 4th field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1, T2, T3, T4> ProjectOperator<T, Tuple4<T1, T2, T3, T4>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
-			
-			Class<?>[] types = {type1, type2, type3, type4};
+		public <T0, T1, T2, T3> ProjectOperator<T, Tuple4<T0, T1, T2, T3>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+			Class<?>[] types = {type0, type1, type2, type3};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple4<T1, T2, T3, T4>> tType = new TupleTypeInfo<Tuple4<T1, T2, T3, T4>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple4<T1, T2, T3, T4>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple4<T0, T1, T2, T3>> tType = new TupleTypeInfo<Tuple4<T0, T1, T2, T3>>(fTypes);
+
+			return new ProjectOperator<T, Tuple4<T0, T1, T2, T3>>(this.ds, this.fields, tType);
 		}
-		
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
-		 * @param type2 The class of the 2nd field of the result tuples.
-		 * @param type3 The class of the 3rd field of the result tuples.
-		 * @param type4 The class of the 4th field of the result tuples.
-		 * @param type5 The class of the 5th field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1, T2, T3, T4, T5> ProjectOperator<T, Tuple5<T1, T2, T3, T4, T5>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
-			
-			Class<?>[] types = {type1, type2, type3, type4, type5};
+		public <T0, T1, T2, T3, T4> ProjectOperator<T, Tuple5<T0, T1, T2, T3, T4>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+			Class<?>[] types = {type0, type1, type2, type3, type4};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple5<T1, T2, T3, T4, T5>> tType = new TupleTypeInfo<Tuple5<T1, T2, T3, T4, T5>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple5<T1, T2, T3, T4, T5>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>> tType = new TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>>(fTypes);
+
+			return new ProjectOperator<T, Tuple5<T0, T1, T2, T3, T4>>(this.ds, this.fields, tType);
 		}
-		
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
-		 * @param type2 The class of the 2nd field of the result tuples.
-		 * @param type3 The class of the 3rd field of the result tuples.
-		 * @param type4 The class of the 4th field of the result tuples.
-		 * @param type5 The class of the 5th field of the result tuples.
-		 * @param type6 The class of the 6th field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1, T2, T3, T4, T5, T6> ProjectOperator<T, Tuple6<T1, T2, T3, T4, T5, T6>> types(
-				Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
-			
-			Class<?>[] types = {type1, type2, type3, type4, type5, type6};
+		public <T0, T1, T2, T3, T4, T5> ProjectOperator<T, Tuple6<T0, T1, T2, T3, T4, T5>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple6<T1, T2, T3, T4, T5, T6>> tType = new TupleTypeInfo<Tuple6<T1, T2, T3, T4, T5, T6>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple6<T1, T2, T3, T4, T5, T6>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>> tType = new TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>>(fTypes);
+
+			return new ProjectOperator<T, Tuple6<T0, T1, T2, T3, T4, T5>>(this.ds, this.fields, tType);
 		}
-		
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
-		 * @param type2 The class of the 2nd field of the result tuples.
-		 * @param type3 The class of the 3rd field of the result tuples.
-		 * @param type4 The class of the 4th field of the result tuples.
-		 * @param type5 The class of the 5th field of the result tuples.
-		 * @param type6 The class of the 6th field of the result tuples.
-		 * @param type7 The class of the 7th field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1, T2, T3, T4, T5, T6, T7> ProjectOperator<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>> types(
-				Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
-			
-			Class<?>[] types = {type1, type2, type3, type4, type5, type6, type7};
+		public <T0, T1, T2, T3, T4, T5, T6> ProjectOperator<T, Tuple7<T0, T1, T2, T3, T4, T5, T6>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple7<T1, T2, T3, T4, T5, T6, T7>> tType = new TupleTypeInfo<Tuple7<T1, T2, T3, T4, T5, T6, T7>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>> tType = new TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>>(fTypes);
+
+			return new ProjectOperator<T, Tuple7<T0, T1, T2, T3, T4, T5, T6>>(this.ds, this.fields, tType);
 		}
-		
+
 		/**
 		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples.
+		 * Requires the classes of the fields of the resulting tuples. 
 		 * 
-		 * @param type1 The class of the 1st field of the result tuples.
-		 * @param type2 The class of the 2nd field of the result tuples.
-		 * @param type3 The class of the 3rd field of the result tuples.
-		 * @param type4 The class of the 4th field of the result tuples.
-		 * @param type5 The class of the 5th field of the result tuples.
-		 * @param type6 The class of the 6th field of the result tuples.
-		 * @param type7 The class of the 7th field of the result tuples.
-		 * @param type8 The class of the 8th field of the result tuples.
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
 		 * @return The projected data set.
 		 */
-		public <T1, T2, T3, T4, T5, T6, T7, T8> ProjectOperator<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> types(
-				Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, 
-				Class<T7> type7, Class<T8> type8) {
-			
-			Class<?>[] types = {type1, type2, type3, type4, type5, type6, type7, type8};
+		public <T0, T1, T2, T3, T4, T5, T6, T7> ProjectOperator<T, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7};
 			if(types.length != this.fields.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
 			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
-			TupleTypeInfo<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> tType = new TupleTypeInfo<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>(fTypes);
-			
-			return new ProjectOperator<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>(this.ds, this.fields, tType);
+			TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> tType = new TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(fTypes);
+
+			return new ProjectOperator<T, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(this.ds, this.fields, tType);
 		}
-		
-		// TODO: Do all 22 type methods
-		
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8> ProjectOperator<T, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> tType = new TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(fTypes);
+
+			return new ProjectOperator<T, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> ProjectOperator<T, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> tType = new TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(fTypes);
+
+			return new ProjectOperator<T, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ProjectOperator<T, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> tType = new TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(fTypes);
+
+			return new ProjectOperator<T, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> ProjectOperator<T, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> tType = new TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(fTypes);
+
+			return new ProjectOperator<T, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> ProjectOperator<T, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> tType = new TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(fTypes);
+
+			return new ProjectOperator<T, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> ProjectOperator<T, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> tType = new TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(fTypes);
+
+			return new ProjectOperator<T, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> ProjectOperator<T, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> tType = new TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(fTypes);
+
+			return new ProjectOperator<T, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> ProjectOperator<T, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> tType = new TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(fTypes);
+
+			return new ProjectOperator<T, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> ProjectOperator<T, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> tType = new TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(fTypes);
+
+			return new ProjectOperator<T, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> ProjectOperator<T, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> tType = new TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(fTypes);
+
+			return new ProjectOperator<T, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> ProjectOperator<T, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> tType = new TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(fTypes);
+
+			return new ProjectOperator<T, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @param type19 The class of field '19' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> ProjectOperator<T, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> tType = new TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(fTypes);
+
+			return new ProjectOperator<T, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @param type19 The class of field '19' of the result tuples.
+		 * @param type20 The class of field '20' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> ProjectOperator<T, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> tType = new TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(fTypes);
+
+			return new ProjectOperator<T, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(this.ds, this.fields, tType);
+		}
+
+		/**
+		 * Projects a tuple data set to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @param type19 The class of field '19' of the result tuples.
+		 * @param type20 The class of field '20' of the result tuples.
+		 * @param type21 The class of field '21' of the result tuples.
+		 * @return The projected data set.
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> ProjectOperator<T, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20, Class<T21> type21) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20, type21};
+			if(types.length != this.fields.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
+			TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> tType = new TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(fTypes);
+
+			return new ProjectOperator<T, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(this.ds, this.fields, tType);
+		}
+
+		// END_OF_TUPLE_DEPENDENT_CODE
 		// -----------------------------------------------------------------------------------------
 		
 			

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
@@ -79,7 +79,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple1<T1>> tType = new TupleTypeInfo<Tuple1<T1>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple1<T1>>(this.ds, this.fields, tType);
@@ -100,7 +100,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple2<T1, T2>> tType = new TupleTypeInfo<Tuple2<T1, T2>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple2<T1, T2>>(this.ds, this.fields, tType);
@@ -122,7 +122,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple3<T1, T2, T3>> tType = new TupleTypeInfo<Tuple3<T1, T2, T3>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple3<T1, T2, T3>>(this.ds, this.fields, tType);
@@ -145,7 +145,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple4<T1, T2, T3, T4>> tType = new TupleTypeInfo<Tuple4<T1, T2, T3, T4>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple4<T1, T2, T3, T4>>(this.ds, this.fields, tType);
@@ -169,7 +169,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple5<T1, T2, T3, T4, T5>> tType = new TupleTypeInfo<Tuple5<T1, T2, T3, T4, T5>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple5<T1, T2, T3, T4, T5>>(this.ds, this.fields, tType);
@@ -195,7 +195,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple6<T1, T2, T3, T4, T5, T6>> tType = new TupleTypeInfo<Tuple6<T1, T2, T3, T4, T5, T6>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple6<T1, T2, T3, T4, T5, T6>>(this.ds, this.fields, tType);
@@ -222,7 +222,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple7<T1, T2, T3, T4, T5, T6, T7>> tType = new TupleTypeInfo<Tuple7<T1, T2, T3, T4, T5, T6, T7>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple7<T1, T2, T3, T4, T5, T6, T7>>(this.ds, this.fields, tType);
@@ -251,7 +251,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
 			
-			TypeInformation<?>[] fTypes = extractFieldTypes(fields, ds.getType());
+			TypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());
 			TupleTypeInfo<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> tType = new TupleTypeInfo<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>(fTypes);
 			
 			return new ProjectOperator<T, Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>>(this.ds, this.fields, tType);
@@ -262,15 +262,17 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		// -----------------------------------------------------------------------------------------
 		
 			
-		private TypeInformation<?>[] extractFieldTypes(int[] fields, TypeInformation<?> inType) {
+		private TypeInformation<?>[] extractFieldTypes(int[] fields, Class<?>[] givenTypes, TypeInformation<?> inType) {
 			
 			TupleTypeInfo<?> inTupleType = (TupleTypeInfo<?>) inType;
 			TypeInformation<?>[] fieldTypes = new TypeInformation[fields.length];
 					
 			for(int i=0; i<fields.length; i++) {
-				if(fields[i] > inTupleType.getArity() - 1) {
-					throw new IndexOutOfBoundsException("Projection field not in range of input tuple fields.");
+				
+				if(inTupleType.getTypeAt(fields[i]).getTypeClass() != givenTypes[i]) {
+					throw new IllegalArgumentException("Given types do not match types of input data set.");
 				}
+					
 				fieldTypes[i] = inTupleType.getTypeAt(fields[i]);
 			}
 			

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanProjectOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanProjectOperator.java
@@ -1,0 +1,75 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.operators.translation;
+
+import eu.stratosphere.api.common.functions.AbstractFunction;
+import eu.stratosphere.api.common.functions.GenericMap;
+import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.api.java.tuple.Tuple;
+import eu.stratosphere.api.java.typeutils.TypeInformation;
+
+public class PlanProjectOperator<T, R extends Tuple> 
+	extends PlainMapOperatorBase<GenericMap<T, R>>
+	implements UnaryJavaPlanNode<T, R>
+{
+	private final TypeInformation<T> inType;
+	private final TypeInformation<R> outType;
+	
+	
+	public PlanProjectOperator(int[] fields, String name, TypeInformation<T> inType, TypeInformation<R> outType) {
+		super(new MapProjector<T, R>(fields, outType.createSerializer()), name);
+		this.inType = inType;
+		this.outType = outType;
+	}
+	
+	@Override
+	public TypeInformation<R> getReturnType() {
+		return this.outType;
+	}
+
+	@Override
+	public TypeInformation<T> getInputType() {
+		return this.inType;
+	}
+	
+	
+	// --------------------------------------------------------------------------------------------
+	
+	public static final class MapProjector<T, R extends Tuple> 
+		extends AbstractFunction
+		implements GenericMap<T, R>
+	{
+		private static final long serialVersionUID = 1L;
+		
+		private final int[] fields;
+		private final R outTuple;
+		
+		private MapProjector(int[] fields, TypeSerializer<R> serializer) {
+			this.fields = fields;
+			this.outTuple = serializer.createInstance();
+		}
+
+		// TODO We should use code generation for this.
+		@Override
+		public R map(T inTuple) throws Exception {
+			
+			for(int i=0; i<fields.length; i++) {
+				outTuple.setField(((Tuple)inTuple).getField(fields[i]), i);
+			}
+			return outTuple;
+		}
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanProjectOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanProjectOperator.java
@@ -17,7 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.AbstractFunction;
 import eu.stratosphere.api.common.functions.GenericMap;
 import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
-import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.api.java.tuple.Tuple;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
@@ -30,7 +29,7 @@ public class PlanProjectOperator<T, R extends Tuple>
 	
 	
 	public PlanProjectOperator(int[] fields, String name, TypeInformation<T> inType, TypeInformation<R> outType) {
-		super(new MapProjector<T, R>(fields, outType.createSerializer()), name);
+		super(new MapProjector<T, R>(fields, outType.createSerializer().createInstance()), name);
 		this.inType = inType;
 		this.outType = outType;
 	}
@@ -57,9 +56,9 @@ public class PlanProjectOperator<T, R extends Tuple>
 		private final int[] fields;
 		private final R outTuple;
 		
-		private MapProjector(int[] fields, TypeSerializer<R> serializer) {
+		private MapProjector(int[] fields, R outTupleInstance) {
 			this.fields = fields;
-			this.outTuple = serializer.createInstance();
+			this.outTuple = outTupleInstance;
 		}
 
 		// TODO We should use code generation for this.

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/operator/ProjectionOperatorTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/operator/ProjectionOperatorTest.java
@@ -1,0 +1,278 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.operator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.tuple.Tuple5;
+import eu.stratosphere.api.java.typeutils.BasicTypeInfo;
+import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
+
+public class ProjectionOperatorTest {
+
+	// TUPLE DATA
+	
+	private final List<Tuple5<Integer, Long, String, Long, Integer>> emptyTupleData = 
+			new ArrayList<Tuple5<Integer, Long, String, Long, Integer>>();
+	
+	private final TupleTypeInfo<Tuple5<Integer, Long, String, Long, Integer>> tupleTypeInfo = new 
+			TupleTypeInfo<Tuple5<Integer, Long, String, Long, Integer>>(
+					BasicTypeInfo.INT_TYPE_INFO,
+					BasicTypeInfo.LONG_TYPE_INFO,
+					BasicTypeInfo.STRING_TYPE_INFO,
+					BasicTypeInfo.LONG_TYPE_INFO,
+					BasicTypeInfo.INT_TYPE_INFO
+			);
+	
+	// LONG DATA
+	
+	private final List<Long> emptyLongData = new ArrayList<Long>();
+	
+	@Test
+	public void testFieldsProjection() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			tupleDs.project(0);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: too many fields
+		try {
+			tupleDs.project(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22);
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: index out of bounds of input tuple
+		try {
+			tupleDs.project(0,5,2);
+			Assert.fail();
+		} catch(IndexOutOfBoundsException ioobe) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: not applied to tuple dataset
+		DataSet<Long> longDs = env.fromCollection(emptyLongData, BasicTypeInfo.LONG_TYPE_INFO);
+		try {
+			longDs.project(0);
+			Assert.fail();
+		} catch(UnsupportedOperationException uoe) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+	}
+	
+	@Test
+	public void testFieldMaskProjection() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = 
+				env.fromCollection(emptyTupleData, tupleTypeInfo);
+		
+		// should work
+		try {
+			tupleDs.project("TFTTF");
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should work
+		try {
+			tupleDs.project("tfftf");
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should work
+		try {
+			tupleDs.project("01101");
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should work
+		try {
+			tupleDs.project("101");
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: too many fields
+		try {
+			tupleDs.project("TTTTTTTTTTTTTTTTTTTTTTT");
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: too few fields
+		try {
+			tupleDs.project("");
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: no selected field
+		try {
+			tupleDs.project("FFFFF");
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: illegal character
+		try {
+			tupleDs.project("TFXFT");
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: not applied to tuple dataset
+		DataSet<Long> longDs = env.fromCollection(emptyLongData, BasicTypeInfo.LONG_TYPE_INFO);
+		try {
+			longDs.project("T");
+			Assert.fail();
+		} catch(UnsupportedOperationException uoe) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+	}
+	
+	@Test
+	public void testFieldFlagsProjection() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = 
+				env.fromCollection(emptyTupleData, tupleTypeInfo);
+		
+		// should work
+		try {
+			tupleDs.project(true, true, false, true, false);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should work
+		try {
+			tupleDs.project(false, true);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: too many fields
+		try {
+			tupleDs.project(
+					true, true, true, true, true, true, true, true, true, true, 
+					true, true, true, true, true, true, true, true, true, true,
+					true, true, true);
+			
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: no selected field
+		try {
+			tupleDs.project(false, false, false, false, false);
+			
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: not applied to tuple dataset
+		DataSet<Long> longDs = env.fromCollection(emptyLongData, BasicTypeInfo.LONG_TYPE_INFO);
+		try {
+			longDs.project(false, true);
+			Assert.fail();
+		} catch(UnsupportedOperationException uoe) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+	}
+	
+	@Test
+	public void testProjectionTypes() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> tupleDs = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			tupleDs.project(0).types(Integer.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: too few types
+		try {
+			tupleDs.project(2,1,4).types(String.class, Long.class);
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+		// should not work: given types do not match input types
+		try {
+			tupleDs.project(2,1,4).types(String.class, Long.class, Long.class);
+			Assert.fail();
+		} catch(IllegalArgumentException iae) {
+			// we're good here
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+	}
+	
+}

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/ProjectITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/ProjectITCase.java
@@ -1,0 +1,180 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.test.javaApiOperators;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.api.java.tuple.Tuple5;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.test.javaApiOperators.util.CollectionDataSets;
+import eu.stratosphere.test.util.JavaProgramTestBase;
+
+@RunWith(Parameterized.class)
+public class ProjectITCase extends JavaProgramTestBase {
+	
+	private static int NUM_PROGRAMS = 3; 
+	
+	private int curProgId = config.getInteger("ProgramId", -1);
+	private String resultPath;
+	private String expectedResult;
+	
+	public ProjectITCase(Configuration config) {
+		super(config);	
+	}
+	
+	@Override
+	protected void preSubmit() throws Exception {
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		expectedResult = ProjectProgs.runProgram(curProgId, resultPath);
+	}
+	
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(expectedResult, resultPath);
+	}
+	
+	@Parameters
+	public static Collection<Object[]> getConfigurations() throws FileNotFoundException, IOException {
+
+		LinkedList<Configuration> tConfigs = new LinkedList<Configuration>();
+
+		for(int i=1; i <= NUM_PROGRAMS; i++) {
+			Configuration config = new Configuration();
+			config.setInteger("ProgramId", i);
+			tConfigs.add(config);
+		}
+		
+		return toParameterList(tConfigs);
+	}
+	
+		
+	private static class ProjectProgs {
+		
+		
+		public static String runProgram(int progId, String resultPath) throws Exception {
+			
+			switch(progId) {
+			case 1: {
+				/*
+				 * Projection with tuple fields indexes
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds = CollectionDataSets.get5TupleDataSet(env);
+				DataSet<Tuple3<String, Long, Integer>> projDs = ds.
+						project(3,4,2).types(String.class, Long.class, Integer.class);
+				projDs.writeAsCsv(resultPath);
+				
+				env.execute();
+				return "Hallo,1,0\n" +
+						"Hallo Welt,2,1\n" +
+						"Hallo Welt wie,1,2\n" +
+						"Hallo Welt wie gehts?,2,3\n" +
+						"ABC,2,4\n" +
+						"BCD,3,5\n" +
+						"CDE,2,6\n" +
+						"DEF,1,7\n" +
+						"EFG,1,8\n" +
+						"FGH,2,9\n" +
+						"GHI,1,10\n" +
+						"HIJ,3,11\n" +
+						"IJK,3,12\n" +
+						"JKL,2,13\n" +
+						"KLM,2,14\n";
+				
+			}
+			case 2: {
+				/*
+				 * Projection with field mask
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds = CollectionDataSets.get5TupleDataSet(env);
+				DataSet<Tuple3<Integer, String, Long>> projDs = ds.
+						project("TFFTT").types(Integer.class, String.class, Long.class);
+				projDs.writeAsCsv(resultPath);
+				
+				env.execute();
+				return "1,Hallo,1\n" +
+						"2,Hallo Welt,2\n" +
+						"2,Hallo Welt wie,1\n" +
+						"3,Hallo Welt wie gehts?,2\n" +
+						"3,ABC,2\n" +
+						"3,BCD,3\n" +
+						"4,CDE,2\n" +
+						"4,DEF,1\n" +
+						"4,EFG,1\n" +
+						"4,FGH,2\n" +
+						"5,GHI,1\n" +
+						"5,HIJ,3\n" +
+						"5,IJK,3\n" +
+						"5,JKL,2\n" +
+						"5,KLM,2\n";
+			}
+			case 3: {
+				/*
+				 * Projection with field flags
+				 */
+					
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds = CollectionDataSets.get5TupleDataSet(env);
+				DataSet<Tuple3<Integer, String, Long>> projDs = ds.
+						project(false, false, true, true, true).types(Integer.class, String.class, Long.class);
+				projDs.writeAsCsv(resultPath);
+				
+				env.execute();
+				return "0,Hallo,1\n" +
+						"1,Hallo Welt,2\n" +
+						"2,Hallo Welt wie,1\n" +
+						"3,Hallo Welt wie gehts?,2\n" +
+						"4,ABC,2\n" +
+						"5,BCD,3\n" +
+						"6,CDE,2\n" +
+						"7,DEF,1\n" +
+						"8,EFG,1\n" +
+						"9,FGH,2\n" +
+						"10,GHI,1\n" +
+						"11,HIJ,3\n" +
+						"12,IJK,3\n" +
+						"13,JKL,2\n" +
+						"14,KLM,2\n";
+			}
+			default: 
+				throw new IllegalArgumentException("Invalid program id");
+			}
+			
+		}
+		
+	}
+	
+	
+}


### PR DESCRIPTION
Adds a project operator to the new Java API (Issue #566)
Project works only on Tuple datasets and is used like:

``` java
DataSet<Tuple3<Integer, Double, String>> ds = ...
DataSet<Tuple2<String,Integer>> pds = ds.project(2,0).types(String.class, Integer.class);
DataSet<Tuple1<Double>> pds2 = ds.project("FTF").types(Double.class);
DataSet<Tuple2<Integer, String>> pds3 = ds.project(true, false, true).types(Integer.class, String.class);
```

Also added unit tests and integration tests for the project operator.
