### PR TITLE
Added static method for DecimalTextIntParser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,19 +292,6 @@
 	<reporting>
 		<plugins>
 
-			<plugin>
-				<!-- just define the Java version to be used for compiling and plugins -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-
-
-
 			<!-- execution of Unit Tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -505,7 +492,7 @@
 										</goals>
 									</pluginExecutionFilter>
 									<action>
-										<ignore></ignore>
+										<ignore/>
 									</action>
 								</pluginExecution>
 							</pluginExecutions>

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextIntParser.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextIntParser.java
@@ -75,4 +75,38 @@ public class DecimalTextIntParser extends FieldParser<IntValue> {
 	public IntValue getLastResult() {
 		return this.result;
 	}
+	
+	public static final int parseField(byte[] bytes, int startPos, int length, char delim) {
+		long val = 0;
+		boolean neg = false;
+		
+		
+		if (bytes[startPos] == '-') {
+			neg = true;
+			startPos++;
+			length--;
+			// check for empty field with only the sign
+			if (length == 0 || bytes[startPos] == delim) {
+				throw new NumberFormatException("Orphaned minus sign.");
+			}
+		}
+		
+		for (; length > 0; startPos++, length--) {
+			if (bytes[startPos] == delim) {
+				return neg ? -(int)val : (int)val;
+			}
+			if (bytes[startPos] < 48 || bytes[startPos] > 57) {
+				throw new NumberFormatException();
+			}
+			val *= 10;
+			val += bytes[startPos] - 48;
+			
+			if (val > OVERFLOW_BOUND && (!neg || val > UNDERFLOW_BOUND)) {
+				throw new NumberFormatException("Number format Overlfow/Underflow");
+			}
+		}
+		return neg ? -(int)val : (int)val;
+	}
+
+	
 }

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextIntParser.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextIntParser.java
@@ -102,7 +102,7 @@ public class DecimalTextIntParser extends FieldParser<IntValue> {
 			val += bytes[startPos] - 48;
 			
 			if (val > OVERFLOW_BOUND && (!neg || val > UNDERFLOW_BOUND)) {
-				throw new NumberFormatException("Number format Overlfow/Underflow");
+				throw new NumberFormatException("Number format Overflow/Underflow");
 			}
 		}
 		return (int) (neg ? -val : val);

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextIntParser.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextIntParser.java
@@ -93,7 +93,7 @@ public class DecimalTextIntParser extends FieldParser<IntValue> {
 		
 		for (; length > 0; startPos++, length--) {
 			if (bytes[startPos] == delim) {
-				return neg ? -(int)val : (int)val;
+				return (int) (neg ? -val : val);
 			}
 			if (bytes[startPos] < 48 || bytes[startPos] > 57) {
 				throw new NumberFormatException();
@@ -105,7 +105,7 @@ public class DecimalTextIntParser extends FieldParser<IntValue> {
 				throw new NumberFormatException("Number format Overlfow/Underflow");
 			}
 		}
-		return neg ? -(int)val : (int)val;
+		return (int) (neg ? -val : val);
 	}
 
 	


### PR DESCRIPTION
I added the static method for DecimalTextIntParser (issue #427) the same way is done in DecimalTextLongParser.
I'm planning on adding static methods for the rest of the parsers.
