### PR TITLE
Several changes in the TupleGenerator

### DIFF
--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/relational/BroadcastVariableJoin.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/relational/BroadcastVariableJoin.java
@@ -129,7 +129,7 @@ public class BroadcastVariableJoin {
 
 		@Override
 		public User map(Tuple3<Integer, String, String> value) {
-			return new User( value.T1(), value.T2(), value.T3());
+			return new User( value.f0, value.f1, value.f2);
 		}
 	}
 	

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/relational/RelQuery.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/relational/RelQuery.java
@@ -58,9 +58,9 @@ public class RelQuery {
 			new FilterFunction<Tuple5<Long, String, String, String, String>>() {
 				@Override
 				public boolean filter(Tuple5<Long, String, String, String, String> value) throws Exception {
-					String orderStatus = value.T2();
-					String orderPrio = value.T4();
-					String orderDate = value.T3();
+					String orderStatus = value.f1;
+					String orderPrio = value.f3;
+					String orderDate = value.f2;
 					return orderStatus.equals("F") && orderPrio.startsWith(prioFilter) && 
 							Integer.parseInt(orderDate.substring(0, 4)) > yearFilter;
 				}
@@ -82,7 +82,7 @@ public class RelQuery {
 		public Tuple3<Long, String, Double> join(Tuple5<Long, String, String, String, String> first,
 				Tuple2<Long, Double> second) throws Exception
 		{
-			return new Tuple3<Long, String, Double>(first.T1(), first.T5(), second.T2());
+			return new Tuple3<Long, String, Double>(first.f0, first.f4, second.f1);
 		}
 		
 	}

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/util/EdgeDataTypes.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/triangles/util/EdgeDataTypes.java
@@ -43,8 +43,8 @@ public class EdgeDataTypes {
 		public void setSecondVertex(final Integer vertex2) { this.setField(vertex2, V2); }
 		
 		public void copyVerticesFromTuple2(Tuple2<Integer, Integer> t) {
-			this.setFirstVertex(t.T1());
-			this.setSecondVertex(t.T2());
+			this.setFirstVertex(t.f0);
+			this.setSecondVertex(t.f1);
 		}
 		
 		public void copyVerticesFromEdgeWithDegrees(EdgeWithDegrees ewd) {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvReader.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvReader.java
@@ -18,13 +18,7 @@ import java.util.ArrayList;
 
 import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.api.java.operators.DataSource;
-import eu.stratosphere.api.java.tuple.Tuple;
-import eu.stratosphere.api.java.tuple.Tuple1;
-import eu.stratosphere.api.java.tuple.Tuple2;
-import eu.stratosphere.api.java.tuple.Tuple3;
-import eu.stratosphere.api.java.tuple.Tuple4;
-import eu.stratosphere.api.java.tuple.Tuple5;
-import eu.stratosphere.api.java.tuple.Tuple6;
+import eu.stratosphere.api.java.tuple.*;
 import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
 import eu.stratosphere.core.fs.Path;
 
@@ -157,47 +151,165 @@ public class CsvReader {
 		}
 	}
 	
-	// --------------------------------------------------------------------------------------------
-	
-	public <T1> DataSource<Tuple1<T1>> types(Class<T1> type1) {
-		TupleTypeInfo<Tuple1<T1>> types = TupleTypeInfo.getBasicTupleTypeInfo(type1);
-		CsvInputFormat<Tuple1<T1>> inputFormat = new CsvInputFormat<Tuple1<T1>>(path);
-		configureInputFormat(inputFormat, type1);			
-		return new DataSource<Tuple1<T1>>(executionContext, inputFormat, types);
+	// --------------------------------------------------------------------------------------------	
+	// The following lines are generated.
+	// --------------------------------------------------------------------------------------------	
+	// BEGIN_OF_TUPLE_DEPENDENT_CODE
+	// GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+
+	public <T0> DataSource<Tuple1<T0>> types(Class<T0> type0) {
+		TupleTypeInfo<Tuple1<T0>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0);
+		CsvInputFormat<Tuple1<T0>> inputFormat = new CsvInputFormat<Tuple1<T0>>(path);
+		configureInputFormat(inputFormat, type0);
+		return new DataSource<Tuple1<T0>>(executionContext, inputFormat, types);
 	}
-	
-	public <T1, T2> DataSource<Tuple2<T1, T2>> types(Class<T1> type1, Class<T2> type2) {
-		TupleTypeInfo<Tuple2<T1, T2>> types = TupleTypeInfo.getBasicTupleTypeInfo(type1, type2);
-		CsvInputFormat<Tuple2<T1, T2>> inputFormat = new CsvInputFormat<Tuple2<T1, T2>>(path);
-		configureInputFormat(inputFormat, type1, type2);
-		return new DataSource<Tuple2<T1, T2>>(executionContext, inputFormat, types);
+
+	public <T0, T1> DataSource<Tuple2<T0, T1>> types(Class<T0> type0, Class<T1> type1) {
+		TupleTypeInfo<Tuple2<T0, T1>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1);
+		CsvInputFormat<Tuple2<T0, T1>> inputFormat = new CsvInputFormat<Tuple2<T0, T1>>(path);
+		configureInputFormat(inputFormat, type0, type1);
+		return new DataSource<Tuple2<T0, T1>>(executionContext, inputFormat, types);
 	}
-	
-	public <T1, T2, T3> DataSource<Tuple3<T1, T2, T3>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3) {
-		TupleTypeInfo<Tuple3<T1, T2, T3>> types = TupleTypeInfo.getBasicTupleTypeInfo(type1, type2, type3);
-		CsvInputFormat<Tuple3<T1, T2, T3>> inputFormat = new CsvInputFormat<Tuple3<T1, T2, T3>>(path);
-		configureInputFormat(inputFormat, type1, type2, type3);
-		return new DataSource<Tuple3<T1, T2, T3>>(executionContext, inputFormat, types);
+
+	public <T0, T1, T2> DataSource<Tuple3<T0, T1, T2>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2) {
+		TupleTypeInfo<Tuple3<T0, T1, T2>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2);
+		CsvInputFormat<Tuple3<T0, T1, T2>> inputFormat = new CsvInputFormat<Tuple3<T0, T1, T2>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2);
+		return new DataSource<Tuple3<T0, T1, T2>>(executionContext, inputFormat, types);
 	}
-	
-	public <T1, T2, T3, T4> DataSource<Tuple4<T1, T2, T3, T4>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
-		TupleTypeInfo<Tuple4<T1, T2, T3, T4>> types = TupleTypeInfo.getBasicTupleTypeInfo(type1, type2, type3, type4);
-		CsvInputFormat<Tuple4<T1, T2, T3, T4>> inputFormat = new CsvInputFormat<Tuple4<T1, T2, T3, T4>>(path);
-		configureInputFormat(inputFormat, type1, type2, type3, type4);
-		return new DataSource<Tuple4<T1, T2, T3, T4>>(executionContext, inputFormat, types);
+
+	public <T0, T1, T2, T3> DataSource<Tuple4<T0, T1, T2, T3>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+		TupleTypeInfo<Tuple4<T0, T1, T2, T3>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3);
+		CsvInputFormat<Tuple4<T0, T1, T2, T3>> inputFormat = new CsvInputFormat<Tuple4<T0, T1, T2, T3>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3);
+		return new DataSource<Tuple4<T0, T1, T2, T3>>(executionContext, inputFormat, types);
 	}
-	
-	public <T1, T2, T3, T4, T5> DataSource<Tuple5<T1, T2, T3, T4, T5>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
-		TupleTypeInfo<Tuple5<T1, T2, T3, T4, T5>> types = TupleTypeInfo.getBasicTupleTypeInfo(type1, type2, type3, type4, type5);
-		CsvInputFormat<Tuple5<T1, T2, T3, T4, T5>> inputFormat = new CsvInputFormat<Tuple5<T1, T2, T3, T4, T5>>(path);
-		configureInputFormat(inputFormat, type1, type2, type3, type4, type5);
-		return new DataSource<Tuple5<T1, T2, T3, T4, T5>>(executionContext, inputFormat, types);
+
+	public <T0, T1, T2, T3, T4> DataSource<Tuple5<T0, T1, T2, T3, T4>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+		TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4);
+		CsvInputFormat<Tuple5<T0, T1, T2, T3, T4>> inputFormat = new CsvInputFormat<Tuple5<T0, T1, T2, T3, T4>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4);
+		return new DataSource<Tuple5<T0, T1, T2, T3, T4>>(executionContext, inputFormat, types);
 	}
-	
-	public <T1, T2, T3, T4, T5, T6> DataSource<Tuple6<T1, T2, T3, T4, T5, T6>> types(Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
-		TupleTypeInfo<Tuple6<T1, T2, T3, T4, T5, T6>> types = TupleTypeInfo.getBasicTupleTypeInfo(type1, type2, type3, type4, type5, type6);
-		CsvInputFormat<Tuple6<T1, T2, T3, T4, T5, T6>> inputFormat = new CsvInputFormat<Tuple6<T1, T2, T3, T4, T5, T6>>(path);
-		configureInputFormat(inputFormat, type1, type2, type3, type4, type5, type6);
-		return new DataSource<Tuple6<T1, T2, T3, T4, T5, T6>>(executionContext, inputFormat, types);
+
+	public <T0, T1, T2, T3, T4, T5> DataSource<Tuple6<T0, T1, T2, T3, T4, T5>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+		TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5);
+		CsvInputFormat<Tuple6<T0, T1, T2, T3, T4, T5>> inputFormat = new CsvInputFormat<Tuple6<T0, T1, T2, T3, T4, T5>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5);
+		return new DataSource<Tuple6<T0, T1, T2, T3, T4, T5>>(executionContext, inputFormat, types);
 	}
+
+	public <T0, T1, T2, T3, T4, T5, T6> DataSource<Tuple7<T0, T1, T2, T3, T4, T5, T6>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+		TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6);
+		CsvInputFormat<Tuple7<T0, T1, T2, T3, T4, T5, T6>> inputFormat = new CsvInputFormat<Tuple7<T0, T1, T2, T3, T4, T5, T6>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6);
+		return new DataSource<Tuple7<T0, T1, T2, T3, T4, T5, T6>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7> DataSource<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+		TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7);
+		CsvInputFormat<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> inputFormat = new CsvInputFormat<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7);
+		return new DataSource<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8> DataSource<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+		TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8);
+		CsvInputFormat<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> inputFormat = new CsvInputFormat<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8);
+		return new DataSource<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> DataSource<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+		TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9);
+		CsvInputFormat<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> inputFormat = new CsvInputFormat<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9);
+		return new DataSource<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> DataSource<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+		TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
+		CsvInputFormat<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> inputFormat = new CsvInputFormat<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10);
+		return new DataSource<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> DataSource<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11) {
+		TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11);
+		CsvInputFormat<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> inputFormat = new CsvInputFormat<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11);
+		return new DataSource<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> DataSource<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12) {
+		TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12);
+		CsvInputFormat<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> inputFormat = new CsvInputFormat<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12);
+		return new DataSource<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> DataSource<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13) {
+		TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13);
+		CsvInputFormat<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> inputFormat = new CsvInputFormat<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13);
+		return new DataSource<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> DataSource<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14) {
+		TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14);
+		CsvInputFormat<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> inputFormat = new CsvInputFormat<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14);
+		return new DataSource<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> DataSource<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15) {
+		TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15);
+		CsvInputFormat<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> inputFormat = new CsvInputFormat<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15);
+		return new DataSource<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> DataSource<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16) {
+		TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16);
+		CsvInputFormat<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> inputFormat = new CsvInputFormat<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16);
+		return new DataSource<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> DataSource<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17) {
+		TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17);
+		CsvInputFormat<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> inputFormat = new CsvInputFormat<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17);
+		return new DataSource<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> DataSource<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18) {
+		TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18);
+		CsvInputFormat<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> inputFormat = new CsvInputFormat<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18);
+		return new DataSource<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> DataSource<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19) {
+		TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19);
+		CsvInputFormat<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> inputFormat = new CsvInputFormat<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19);
+		return new DataSource<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> DataSource<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20) {
+		TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20);
+		CsvInputFormat<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> inputFormat = new CsvInputFormat<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20);
+		return new DataSource<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(executionContext, inputFormat, types);
+	}
+
+	public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> DataSource<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20, Class<T21> type21) {
+		TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> types = TupleTypeInfo.getBasicTupleTypeInfo(type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20, type21);
+		CsvInputFormat<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> inputFormat = new CsvInputFormat<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(path);
+		configureInputFormat(inputFormat, type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20, type21);
+		return new DataSource<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(executionContext, inputFormat, types);
+	}
+
+	// END_OF_TUPLE_DEPENDENT_CODE
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/KeyExtractingMapper.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/KeyExtractingMapper.java
@@ -37,8 +37,8 @@ public final class KeyExtractingMapper<T, K> extends MapFunction<T, Tuple2<K, T>
 	public Tuple2<K, T> map(T value) throws Exception {
 		
 		K key = keySelector.getKey(value);
-		tuple.T1(key);
-		tuple.T2(value);
+		tuple.f0 = key;
+		tuple.f1 = value;
 		
 		return tuple;
 	}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanUnwrappingReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanUnwrappingReduceOperator.java
@@ -73,10 +73,10 @@ public class PlanUnwrappingReduceOperator<T, K> extends GroupReduceOperatorBase<
 
 		@Override
 		public void reduce(Iterator<Tuple2<K, T>> values, Collector<T> out) throws Exception {
-			T curr = values.next().T2();
+			T curr = values.next().f1;
 			
 			while (values.hasNext()) {
-				curr = this.wrappedFunction.reduce(curr, values.next().T2());
+				curr = this.wrappedFunction.reduce(curr, values.next().f1);
 			}
 			
 			out.collect(curr);
@@ -87,14 +87,14 @@ public class PlanUnwrappingReduceOperator<T, K> extends GroupReduceOperatorBase<
 			
 			Tuple2<K, T> currentTuple = values.next();
 			
-			T curr = currentTuple.T2();
+			T curr = currentTuple.f1;
 
 			while (values.hasNext()) {
 				currentTuple = values.next();
-				curr = this.wrappedFunction.reduce(curr, currentTuple.T2());
+				curr = this.wrappedFunction.reduce(curr, currentTuple.f1);
 			}
 
-			out.collect(new Tuple2<K, T>(currentTuple.T1(), curr));
+			out.collect(new Tuple2<K, T>(currentTuple.f0, curr));
 		}
 
 	}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/TupleUnwrappingIterator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/TupleUnwrappingIterator.java
@@ -41,7 +41,7 @@ public class TupleUnwrappingIterator<T, K> implements Iterator<T>, java.io.Seria
 
 	@Override
 	public T next() {
-		return iterator.next().T2();
+		return iterator.next().f1;
 	}
 
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple1.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple1.java
@@ -24,32 +24,26 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple1<T1> extends Tuple {
+public class Tuple1<T0> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
+	public T0 f0;
 
 	public Tuple1() {}
 
-	public Tuple1(T1 value1) {
-		this._1 = value1;
+	public Tuple1(T0 value0) {
+		this.f0 = value0;
 	}
 
 	@Override
 	public int getArity() { return 1; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
+			case 0: return (T) this.f0;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -58,11 +52,15 @@ public class Tuple1<T1> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0) {
+		this.f0 = value0;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -70,7 +68,7 @@ public class Tuple1<T1> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
 			+ ")";
 	}
 
@@ -89,7 +87,7 @@ public class Tuple1<T1> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple1.class.getDeclaredField("_1"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple1.class.getDeclaredField("f0"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple10.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple10.java
@@ -24,113 +24,53 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple {
+public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
 
 	public Tuple10() {}
 
-	public Tuple10(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
+	public Tuple10(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
 	}
 
 	@Override
 	public int getArity() { return 10; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -139,38 +79,51 @@ public class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -178,16 +131,16 @@ public class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
 			+ ")";
 	}
 
@@ -206,16 +159,16 @@ public class Tuple10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("_10"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple10.class.getDeclaredField("f9"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple11.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple11.java
@@ -24,122 +24,56 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends Tuple {
+public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
 
 	public Tuple11() {}
 
-	public Tuple11(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
+	public Tuple11(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
 	}
 
 	@Override
 	public int getArity() { return 11; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -148,41 +82,55 @@ public class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends Tuple
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -190,17 +138,17 @@ public class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends Tuple
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
 			+ ")";
 	}
 
@@ -219,17 +167,17 @@ public class Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends Tuple
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("_11"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple11.class.getDeclaredField("f10"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple12.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple12.java
@@ -24,131 +24,59 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> extends Tuple {
+public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
 
 	public Tuple12() {}
 
-	public Tuple12(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
+	public Tuple12(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
 	}
 
 	@Override
 	public int getArity() { return 12; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -157,44 +85,59 @@ public class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> extends 
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -202,18 +145,18 @@ public class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> extends 
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
 			+ ")";
 	}
 
@@ -232,18 +175,18 @@ public class Tuple12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> extends 
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("_12"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple12.class.getDeclaredField("f11"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple13.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple13.java
@@ -24,140 +24,62 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> extends Tuple {
+public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
 
 	public Tuple13() {}
 
-	public Tuple13(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
+	public Tuple13(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
 	}
 
 	@Override
 	public int getArity() { return 13; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -166,47 +88,63 @@ public class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> ext
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -214,19 +152,19 @@ public class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> ext
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
 			+ ")";
 	}
 
@@ -245,19 +183,19 @@ public class Tuple13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> ext
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("_13"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple13.class.getDeclaredField("f12"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple14.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple14.java
@@ -24,149 +24,65 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> extends Tuple {
+public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
 
 	public Tuple14() {}
 
-	public Tuple14(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
+	public Tuple14(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
 	}
 
 	@Override
 	public int getArity() { return 14; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -175,50 +91,67 @@ public class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -226,20 +159,20 @@ public class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
 			+ ")";
 	}
 
@@ -258,20 +191,20 @@ public class Tuple14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("_14"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple14.class.getDeclaredField("f13"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple15.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple15.java
@@ -24,158 +24,68 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> extends Tuple {
+public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
 
 	public Tuple15() {}
 
-	public Tuple15(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
+	public Tuple15(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
 	}
 
 	@Override
 	public int getArity() { return 15; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -184,53 +94,71 @@ public class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -238,21 +166,21 @@ public class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
 			+ ")";
 	}
 
@@ -271,21 +199,21 @@ public class Tuple15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("_15"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple15.class.getDeclaredField("f14"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple16.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple16.java
@@ -24,167 +24,71 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> extends Tuple {
+public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
-	private T16 _16;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
+	public T15 f15;
 
 	public Tuple16() {}
 
-	public Tuple16(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
-		this._16 = value16;
+	public Tuple16(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
 	}
 
 	@Override
 	public int getArity() { return 16; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public T16 T16() {
-		return this._16;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
-	public void T16(T16 value) {
-		this._16 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
-			case 15: return (T) this._16;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
+			case 15: return (T) this.f15;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -193,56 +97,75 @@ public class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			case 15:
-				this._16 = (T16) value;
+				this.f15 = (T15) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -250,22 +173,22 @@ public class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
-			+ ", " + StringUtils.arrayAwareToString(this._16)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
+			+ ", " + StringUtils.arrayAwareToString(this.f15)
 			+ ")";
 	}
 
@@ -284,22 +207,22 @@ public class Tuple16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_15"));
-			offsets[15] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("_16"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f14"));
+			offsets[15] = UNSAFE.objectFieldOffset(Tuple16.class.getDeclaredField("f15"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple17.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple17.java
@@ -24,176 +24,74 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> extends Tuple {
+public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
-	private T16 _16;
-	private T17 _17;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
+	public T15 f15;
+	public T16 f16;
 
 	public Tuple17() {}
 
-	public Tuple17(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
-		this._16 = value16;
-		this._17 = value17;
+	public Tuple17(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
 	}
 
 	@Override
 	public int getArity() { return 17; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public T16 T16() {
-		return this._16;
-	}
-	public T17 T17() {
-		return this._17;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
-	public void T16(T16 value) {
-		this._16 = value;
-	}
-	public void T17(T17 value) {
-		this._17 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
-			case 15: return (T) this._16;
-			case 16: return (T) this._17;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
+			case 15: return (T) this.f15;
+			case 16: return (T) this.f16;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -202,59 +100,79 @@ public class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			case 15:
-				this._16 = (T16) value;
+				this.f15 = (T15) value;
 				break;
 			case 16:
-				this._17 = (T17) value;
+				this.f16 = (T16) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -262,23 +180,23 @@ public class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
-			+ ", " + StringUtils.arrayAwareToString(this._16)
-			+ ", " + StringUtils.arrayAwareToString(this._17)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
+			+ ", " + StringUtils.arrayAwareToString(this.f15)
+			+ ", " + StringUtils.arrayAwareToString(this.f16)
 			+ ")";
 	}
 
@@ -297,23 +215,23 @@ public class Tuple17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_15"));
-			offsets[15] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_16"));
-			offsets[16] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("_17"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f14"));
+			offsets[15] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f15"));
+			offsets[16] = UNSAFE.objectFieldOffset(Tuple17.class.getDeclaredField("f16"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple18.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple18.java
@@ -24,185 +24,77 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> extends Tuple {
+public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
-	private T16 _16;
-	private T17 _17;
-	private T18 _18;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
+	public T15 f15;
+	public T16 f16;
+	public T17 f17;
 
 	public Tuple18() {}
 
-	public Tuple18(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
-		this._16 = value16;
-		this._17 = value17;
-		this._18 = value18;
+	public Tuple18(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
 	}
 
 	@Override
 	public int getArity() { return 18; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public T16 T16() {
-		return this._16;
-	}
-	public T17 T17() {
-		return this._17;
-	}
-	public T18 T18() {
-		return this._18;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
-	public void T16(T16 value) {
-		this._16 = value;
-	}
-	public void T17(T17 value) {
-		this._17 = value;
-	}
-	public void T18(T18 value) {
-		this._18 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
-			case 15: return (T) this._16;
-			case 16: return (T) this._17;
-			case 17: return (T) this._18;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
+			case 15: return (T) this.f15;
+			case 16: return (T) this.f16;
+			case 17: return (T) this.f17;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -211,62 +103,83 @@ public class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			case 15:
-				this._16 = (T16) value;
+				this.f15 = (T15) value;
 				break;
 			case 16:
-				this._17 = (T17) value;
+				this.f16 = (T16) value;
 				break;
 			case 17:
-				this._18 = (T18) value;
+				this.f17 = (T17) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -274,24 +187,24 @@ public class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
-			+ ", " + StringUtils.arrayAwareToString(this._16)
-			+ ", " + StringUtils.arrayAwareToString(this._17)
-			+ ", " + StringUtils.arrayAwareToString(this._18)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
+			+ ", " + StringUtils.arrayAwareToString(this.f15)
+			+ ", " + StringUtils.arrayAwareToString(this.f16)
+			+ ", " + StringUtils.arrayAwareToString(this.f17)
 			+ ")";
 	}
 
@@ -310,24 +223,24 @@ public class Tuple18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_15"));
-			offsets[15] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_16"));
-			offsets[16] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_17"));
-			offsets[17] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("_18"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f14"));
+			offsets[15] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f15"));
+			offsets[16] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f16"));
+			offsets[17] = UNSAFE.objectFieldOffset(Tuple18.class.getDeclaredField("f17"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple19.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple19.java
@@ -24,194 +24,80 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> extends Tuple {
+public class Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
-	private T16 _16;
-	private T17 _17;
-	private T18 _18;
-	private T19 _19;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
+	public T15 f15;
+	public T16 f16;
+	public T17 f17;
+	public T18 f18;
 
 	public Tuple19() {}
 
-	public Tuple19(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
-		this._16 = value16;
-		this._17 = value17;
-		this._18 = value18;
-		this._19 = value19;
+	public Tuple19(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
 	}
 
 	@Override
 	public int getArity() { return 19; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public T16 T16() {
-		return this._16;
-	}
-	public T17 T17() {
-		return this._17;
-	}
-	public T18 T18() {
-		return this._18;
-	}
-	public T19 T19() {
-		return this._19;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
-	public void T16(T16 value) {
-		this._16 = value;
-	}
-	public void T17(T17 value) {
-		this._17 = value;
-	}
-	public void T18(T18 value) {
-		this._18 = value;
-	}
-	public void T19(T19 value) {
-		this._19 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
-			case 15: return (T) this._16;
-			case 16: return (T) this._17;
-			case 17: return (T) this._18;
-			case 18: return (T) this._19;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
+			case 15: return (T) this.f15;
+			case 16: return (T) this.f16;
+			case 17: return (T) this.f17;
+			case 18: return (T) this.f18;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -220,65 +106,87 @@ public class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			case 15:
-				this._16 = (T16) value;
+				this.f15 = (T15) value;
 				break;
 			case 16:
-				this._17 = (T17) value;
+				this.f16 = (T16) value;
 				break;
 			case 17:
-				this._18 = (T18) value;
+				this.f17 = (T17) value;
 				break;
 			case 18:
-				this._19 = (T19) value;
+				this.f18 = (T18) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -286,25 +194,25 @@ public class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
-			+ ", " + StringUtils.arrayAwareToString(this._16)
-			+ ", " + StringUtils.arrayAwareToString(this._17)
-			+ ", " + StringUtils.arrayAwareToString(this._18)
-			+ ", " + StringUtils.arrayAwareToString(this._19)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
+			+ ", " + StringUtils.arrayAwareToString(this.f15)
+			+ ", " + StringUtils.arrayAwareToString(this.f16)
+			+ ", " + StringUtils.arrayAwareToString(this.f17)
+			+ ", " + StringUtils.arrayAwareToString(this.f18)
 			+ ")";
 	}
 
@@ -323,25 +231,25 @@ public class Tuple19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_15"));
-			offsets[15] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_16"));
-			offsets[16] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_17"));
-			offsets[17] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_18"));
-			offsets[18] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("_19"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f14"));
+			offsets[15] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f15"));
+			offsets[16] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f16"));
+			offsets[17] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f17"));
+			offsets[18] = UNSAFE.objectFieldOffset(Tuple19.class.getDeclaredField("f18"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple2.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple2.java
@@ -24,41 +24,29 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple2<T1, T2> extends Tuple {
+public class Tuple2<T0, T1> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
+	public T0 f0;
+	public T1 f1;
 
 	public Tuple2() {}
 
-	public Tuple2(T1 value1, T2 value2) {
-		this._1 = value1;
-		this._2 = value2;
+	public Tuple2(T0 value0, T1 value1) {
+		this.f0 = value0;
+		this.f1 = value1;
 	}
 
 	@Override
 	public int getArity() { return 2; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -67,14 +55,19 @@ public class Tuple2<T1, T2> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1) {
+		this.f0 = value0;
+		this.f1 = value1;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -82,8 +75,8 @@ public class Tuple2<T1, T2> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
 			+ ")";
 	}
 
@@ -102,8 +95,8 @@ public class Tuple2<T1, T2> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple2.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple2.class.getDeclaredField("_2"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple2.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple2.class.getDeclaredField("f1"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple20.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple20.java
@@ -24,203 +24,83 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> extends Tuple {
+public class Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
-	private T16 _16;
-	private T17 _17;
-	private T18 _18;
-	private T19 _19;
-	private T20 _20;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
+	public T15 f15;
+	public T16 f16;
+	public T17 f17;
+	public T18 f18;
+	public T19 f19;
 
 	public Tuple20() {}
 
-	public Tuple20(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
-		this._16 = value16;
-		this._17 = value17;
-		this._18 = value18;
-		this._19 = value19;
-		this._20 = value20;
+	public Tuple20(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
+		this.f19 = value19;
 	}
 
 	@Override
 	public int getArity() { return 20; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public T16 T16() {
-		return this._16;
-	}
-	public T17 T17() {
-		return this._17;
-	}
-	public T18 T18() {
-		return this._18;
-	}
-	public T19 T19() {
-		return this._19;
-	}
-	public T20 T20() {
-		return this._20;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
-	public void T16(T16 value) {
-		this._16 = value;
-	}
-	public void T17(T17 value) {
-		this._17 = value;
-	}
-	public void T18(T18 value) {
-		this._18 = value;
-	}
-	public void T19(T19 value) {
-		this._19 = value;
-	}
-	public void T20(T20 value) {
-		this._20 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
-			case 15: return (T) this._16;
-			case 16: return (T) this._17;
-			case 17: return (T) this._18;
-			case 18: return (T) this._19;
-			case 19: return (T) this._20;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
+			case 15: return (T) this.f15;
+			case 16: return (T) this.f16;
+			case 17: return (T) this.f17;
+			case 18: return (T) this.f18;
+			case 19: return (T) this.f19;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -229,68 +109,91 @@ public class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			case 15:
-				this._16 = (T16) value;
+				this.f15 = (T15) value;
 				break;
 			case 16:
-				this._17 = (T17) value;
+				this.f16 = (T16) value;
 				break;
 			case 17:
-				this._18 = (T18) value;
+				this.f17 = (T17) value;
 				break;
 			case 18:
-				this._19 = (T19) value;
+				this.f18 = (T18) value;
 				break;
 			case 19:
-				this._20 = (T20) value;
+				this.f19 = (T19) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
+		this.f19 = value19;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -298,26 +201,26 @@ public class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
-			+ ", " + StringUtils.arrayAwareToString(this._16)
-			+ ", " + StringUtils.arrayAwareToString(this._17)
-			+ ", " + StringUtils.arrayAwareToString(this._18)
-			+ ", " + StringUtils.arrayAwareToString(this._19)
-			+ ", " + StringUtils.arrayAwareToString(this._20)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
+			+ ", " + StringUtils.arrayAwareToString(this.f15)
+			+ ", " + StringUtils.arrayAwareToString(this.f16)
+			+ ", " + StringUtils.arrayAwareToString(this.f17)
+			+ ", " + StringUtils.arrayAwareToString(this.f18)
+			+ ", " + StringUtils.arrayAwareToString(this.f19)
 			+ ")";
 	}
 
@@ -336,26 +239,26 @@ public class Tuple20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_15"));
-			offsets[15] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_16"));
-			offsets[16] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_17"));
-			offsets[17] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_18"));
-			offsets[18] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_19"));
-			offsets[19] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("_20"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f14"));
+			offsets[15] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f15"));
+			offsets[16] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f16"));
+			offsets[17] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f17"));
+			offsets[18] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f18"));
+			offsets[19] = UNSAFE.objectFieldOffset(Tuple20.class.getDeclaredField("f19"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple21.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple21.java
@@ -24,212 +24,86 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> extends Tuple {
+public class Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
-	private T16 _16;
-	private T17 _17;
-	private T18 _18;
-	private T19 _19;
-	private T20 _20;
-	private T21 _21;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
+	public T15 f15;
+	public T16 f16;
+	public T17 f17;
+	public T18 f18;
+	public T19 f19;
+	public T20 f20;
 
 	public Tuple21() {}
 
-	public Tuple21(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
-		this._16 = value16;
-		this._17 = value17;
-		this._18 = value18;
-		this._19 = value19;
-		this._20 = value20;
-		this._21 = value21;
+	public Tuple21(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
+		this.f19 = value19;
+		this.f20 = value20;
 	}
 
 	@Override
 	public int getArity() { return 21; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public T16 T16() {
-		return this._16;
-	}
-	public T17 T17() {
-		return this._17;
-	}
-	public T18 T18() {
-		return this._18;
-	}
-	public T19 T19() {
-		return this._19;
-	}
-	public T20 T20() {
-		return this._20;
-	}
-	public T21 T21() {
-		return this._21;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
-	public void T16(T16 value) {
-		this._16 = value;
-	}
-	public void T17(T17 value) {
-		this._17 = value;
-	}
-	public void T18(T18 value) {
-		this._18 = value;
-	}
-	public void T19(T19 value) {
-		this._19 = value;
-	}
-	public void T20(T20 value) {
-		this._20 = value;
-	}
-	public void T21(T21 value) {
-		this._21 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
-			case 15: return (T) this._16;
-			case 16: return (T) this._17;
-			case 17: return (T) this._18;
-			case 18: return (T) this._19;
-			case 19: return (T) this._20;
-			case 20: return (T) this._21;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
+			case 15: return (T) this.f15;
+			case 16: return (T) this.f16;
+			case 17: return (T) this.f17;
+			case 18: return (T) this.f18;
+			case 19: return (T) this.f19;
+			case 20: return (T) this.f20;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -238,71 +112,95 @@ public class Tuple21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			case 15:
-				this._16 = (T16) value;
+				this.f15 = (T15) value;
 				break;
 			case 16:
-				this._17 = (T17) value;
+				this.f16 = (T16) value;
 				break;
 			case 17:
-				this._18 = (T18) value;
+				this.f17 = (T17) value;
 				break;
 			case 18:
-				this._19 = (T19) value;
+				this.f18 = (T18) value;
 				break;
 			case 19:
-				this._20 = (T20) value;
+				this.f19 = (T19) value;
 				break;
 			case 20:
-				this._21 = (T21) value;
+				this.f20 = (T20) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
+		this.f19 = value19;
+		this.f20 = value20;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -310,27 +208,27 @@ public class Tuple21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
-			+ ", " + StringUtils.arrayAwareToString(this._16)
-			+ ", " + StringUtils.arrayAwareToString(this._17)
-			+ ", " + StringUtils.arrayAwareToString(this._18)
-			+ ", " + StringUtils.arrayAwareToString(this._19)
-			+ ", " + StringUtils.arrayAwareToString(this._20)
-			+ ", " + StringUtils.arrayAwareToString(this._21)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
+			+ ", " + StringUtils.arrayAwareToString(this.f15)
+			+ ", " + StringUtils.arrayAwareToString(this.f16)
+			+ ", " + StringUtils.arrayAwareToString(this.f17)
+			+ ", " + StringUtils.arrayAwareToString(this.f18)
+			+ ", " + StringUtils.arrayAwareToString(this.f19)
+			+ ", " + StringUtils.arrayAwareToString(this.f20)
 			+ ")";
 	}
 
@@ -349,27 +247,27 @@ public class Tuple21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_15"));
-			offsets[15] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_16"));
-			offsets[16] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_17"));
-			offsets[17] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_18"));
-			offsets[18] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_19"));
-			offsets[19] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_20"));
-			offsets[20] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("_21"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f14"));
+			offsets[15] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f15"));
+			offsets[16] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f16"));
+			offsets[17] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f17"));
+			offsets[18] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f18"));
+			offsets[19] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f19"));
+			offsets[20] = UNSAFE.objectFieldOffset(Tuple21.class.getDeclaredField("f20"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple22.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple22.java
@@ -24,221 +24,89 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> extends Tuple {
+public class Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
-	private T10 _10;
-	private T11 _11;
-	private T12 _12;
-	private T13 _13;
-	private T14 _14;
-	private T15 _15;
-	private T16 _16;
-	private T17 _17;
-	private T18 _18;
-	private T19 _19;
-	private T20 _20;
-	private T21 _21;
-	private T22 _22;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
+	public T9 f9;
+	public T10 f10;
+	public T11 f11;
+	public T12 f12;
+	public T13 f13;
+	public T14 f14;
+	public T15 f15;
+	public T16 f16;
+	public T17 f17;
+	public T18 f18;
+	public T19 f19;
+	public T20 f20;
+	public T21 f21;
 
 	public Tuple22() {}
 
-	public Tuple22(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21, T22 value22) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
-		this._10 = value10;
-		this._11 = value11;
-		this._12 = value12;
-		this._13 = value13;
-		this._14 = value14;
-		this._15 = value15;
-		this._16 = value16;
-		this._17 = value17;
-		this._18 = value18;
-		this._19 = value19;
-		this._20 = value20;
-		this._21 = value21;
-		this._22 = value22;
+	public Tuple22(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
+		this.f19 = value19;
+		this.f20 = value20;
+		this.f21 = value21;
 	}
 
 	@Override
 	public int getArity() { return 22; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public T10 T10() {
-		return this._10;
-	}
-	public T11 T11() {
-		return this._11;
-	}
-	public T12 T12() {
-		return this._12;
-	}
-	public T13 T13() {
-		return this._13;
-	}
-	public T14 T14() {
-		return this._14;
-	}
-	public T15 T15() {
-		return this._15;
-	}
-	public T16 T16() {
-		return this._16;
-	}
-	public T17 T17() {
-		return this._17;
-	}
-	public T18 T18() {
-		return this._18;
-	}
-	public T19 T19() {
-		return this._19;
-	}
-	public T20 T20() {
-		return this._20;
-	}
-	public T21 T21() {
-		return this._21;
-	}
-	public T22 T22() {
-		return this._22;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
-	public void T10(T10 value) {
-		this._10 = value;
-	}
-	public void T11(T11 value) {
-		this._11 = value;
-	}
-	public void T12(T12 value) {
-		this._12 = value;
-	}
-	public void T13(T13 value) {
-		this._13 = value;
-	}
-	public void T14(T14 value) {
-		this._14 = value;
-	}
-	public void T15(T15 value) {
-		this._15 = value;
-	}
-	public void T16(T16 value) {
-		this._16 = value;
-	}
-	public void T17(T17 value) {
-		this._17 = value;
-	}
-	public void T18(T18 value) {
-		this._18 = value;
-	}
-	public void T19(T19 value) {
-		this._19 = value;
-	}
-	public void T20(T20 value) {
-		this._20 = value;
-	}
-	public void T21(T21 value) {
-		this._21 = value;
-	}
-	public void T22(T22 value) {
-		this._22 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
-			case 9: return (T) this._10;
-			case 10: return (T) this._11;
-			case 11: return (T) this._12;
-			case 12: return (T) this._13;
-			case 13: return (T) this._14;
-			case 14: return (T) this._15;
-			case 15: return (T) this._16;
-			case 16: return (T) this._17;
-			case 17: return (T) this._18;
-			case 18: return (T) this._19;
-			case 19: return (T) this._20;
-			case 20: return (T) this._21;
-			case 21: return (T) this._22;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
+			case 9: return (T) this.f9;
+			case 10: return (T) this.f10;
+			case 11: return (T) this.f11;
+			case 12: return (T) this.f12;
+			case 13: return (T) this.f13;
+			case 14: return (T) this.f14;
+			case 15: return (T) this.f15;
+			case 16: return (T) this.f16;
+			case 17: return (T) this.f17;
+			case 18: return (T) this.f18;
+			case 19: return (T) this.f19;
+			case 20: return (T) this.f20;
+			case 21: return (T) this.f21;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -247,74 +115,99 @@ public class Tuple22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			case 9:
-				this._10 = (T10) value;
+				this.f9 = (T9) value;
 				break;
 			case 10:
-				this._11 = (T11) value;
+				this.f10 = (T10) value;
 				break;
 			case 11:
-				this._12 = (T12) value;
+				this.f11 = (T11) value;
 				break;
 			case 12:
-				this._13 = (T13) value;
+				this.f12 = (T12) value;
 				break;
 			case 13:
-				this._14 = (T14) value;
+				this.f13 = (T13) value;
 				break;
 			case 14:
-				this._15 = (T15) value;
+				this.f14 = (T14) value;
 				break;
 			case 15:
-				this._16 = (T16) value;
+				this.f15 = (T15) value;
 				break;
 			case 16:
-				this._17 = (T17) value;
+				this.f16 = (T16) value;
 				break;
 			case 17:
-				this._18 = (T18) value;
+				this.f17 = (T17) value;
 				break;
 			case 18:
-				this._19 = (T19) value;
+				this.f18 = (T18) value;
 				break;
 			case 19:
-				this._20 = (T20) value;
+				this.f19 = (T19) value;
 				break;
 			case 20:
-				this._21 = (T21) value;
+				this.f20 = (T20) value;
 				break;
 			case 21:
-				this._22 = (T22) value;
+				this.f21 = (T21) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+		this.f9 = value9;
+		this.f10 = value10;
+		this.f11 = value11;
+		this.f12 = value12;
+		this.f13 = value13;
+		this.f14 = value14;
+		this.f15 = value15;
+		this.f16 = value16;
+		this.f17 = value17;
+		this.f18 = value18;
+		this.f19 = value19;
+		this.f20 = value20;
+		this.f21 = value21;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -322,28 +215,28 @@ public class Tuple22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
-			+ ", " + StringUtils.arrayAwareToString(this._10)
-			+ ", " + StringUtils.arrayAwareToString(this._11)
-			+ ", " + StringUtils.arrayAwareToString(this._12)
-			+ ", " + StringUtils.arrayAwareToString(this._13)
-			+ ", " + StringUtils.arrayAwareToString(this._14)
-			+ ", " + StringUtils.arrayAwareToString(this._15)
-			+ ", " + StringUtils.arrayAwareToString(this._16)
-			+ ", " + StringUtils.arrayAwareToString(this._17)
-			+ ", " + StringUtils.arrayAwareToString(this._18)
-			+ ", " + StringUtils.arrayAwareToString(this._19)
-			+ ", " + StringUtils.arrayAwareToString(this._20)
-			+ ", " + StringUtils.arrayAwareToString(this._21)
-			+ ", " + StringUtils.arrayAwareToString(this._22)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
+			+ ", " + StringUtils.arrayAwareToString(this.f9)
+			+ ", " + StringUtils.arrayAwareToString(this.f10)
+			+ ", " + StringUtils.arrayAwareToString(this.f11)
+			+ ", " + StringUtils.arrayAwareToString(this.f12)
+			+ ", " + StringUtils.arrayAwareToString(this.f13)
+			+ ", " + StringUtils.arrayAwareToString(this.f14)
+			+ ", " + StringUtils.arrayAwareToString(this.f15)
+			+ ", " + StringUtils.arrayAwareToString(this.f16)
+			+ ", " + StringUtils.arrayAwareToString(this.f17)
+			+ ", " + StringUtils.arrayAwareToString(this.f18)
+			+ ", " + StringUtils.arrayAwareToString(this.f19)
+			+ ", " + StringUtils.arrayAwareToString(this.f20)
+			+ ", " + StringUtils.arrayAwareToString(this.f21)
 			+ ")";
 	}
 
@@ -362,28 +255,28 @@ public class Tuple22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_9"));
-			offsets[9] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_10"));
-			offsets[10] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_11"));
-			offsets[11] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_12"));
-			offsets[12] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_13"));
-			offsets[13] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_14"));
-			offsets[14] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_15"));
-			offsets[15] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_16"));
-			offsets[16] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_17"));
-			offsets[17] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_18"));
-			offsets[18] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_19"));
-			offsets[19] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_20"));
-			offsets[20] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_21"));
-			offsets[21] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("_22"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f8"));
+			offsets[9] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f9"));
+			offsets[10] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f10"));
+			offsets[11] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f11"));
+			offsets[12] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f12"));
+			offsets[13] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f13"));
+			offsets[14] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f14"));
+			offsets[15] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f15"));
+			offsets[16] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f16"));
+			offsets[17] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f17"));
+			offsets[18] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f18"));
+			offsets[19] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f19"));
+			offsets[20] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f20"));
+			offsets[21] = UNSAFE.objectFieldOffset(Tuple22.class.getDeclaredField("f21"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple3.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple3.java
@@ -24,50 +24,32 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple3<T1, T2, T3> extends Tuple {
+public class Tuple3<T0, T1, T2> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
 
 	public Tuple3() {}
 
-	public Tuple3(T1 value1, T2 value2, T3 value3) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
+	public Tuple3(T0 value0, T1 value1, T2 value2) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
 	}
 
 	@Override
 	public int getArity() { return 3; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -76,17 +58,23 @@ public class Tuple3<T1, T2, T3> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -94,9 +82,9 @@ public class Tuple3<T1, T2, T3> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
 			+ ")";
 	}
 
@@ -115,9 +103,9 @@ public class Tuple3<T1, T2, T3> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple3.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple3.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple3.class.getDeclaredField("_3"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple3.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple3.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple3.class.getDeclaredField("f2"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple4.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple4.java
@@ -24,59 +24,35 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple4<T1, T2, T3, T4> extends Tuple {
+public class Tuple4<T0, T1, T2, T3> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
 
 	public Tuple4() {}
 
-	public Tuple4(T1 value1, T2 value2, T3 value3, T4 value4) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
+	public Tuple4(T0 value0, T1 value1, T2 value2, T3 value3) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
 	}
 
 	@Override
 	public int getArity() { return 4; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -85,20 +61,27 @@ public class Tuple4<T1, T2, T3, T4> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -106,10 +89,10 @@ public class Tuple4<T1, T2, T3, T4> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
 			+ ")";
 	}
 
@@ -128,10 +111,10 @@ public class Tuple4<T1, T2, T3, T4> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("_4"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple4.class.getDeclaredField("f3"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple5.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple5.java
@@ -24,68 +24,38 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple5<T1, T2, T3, T4, T5> extends Tuple {
+public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
 
 	public Tuple5() {}
 
-	public Tuple5(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
+	public Tuple5(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
 	}
 
 	@Override
 	public int getArity() { return 5; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -94,23 +64,31 @@ public class Tuple5<T1, T2, T3, T4, T5> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -118,11 +96,11 @@ public class Tuple5<T1, T2, T3, T4, T5> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
 			+ ")";
 	}
 
@@ -141,11 +119,11 @@ public class Tuple5<T1, T2, T3, T4, T5> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("_5"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple5.class.getDeclaredField("f4"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple6.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple6.java
@@ -24,77 +24,41 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple {
+public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
 
 	public Tuple6() {}
 
-	public Tuple6(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
+	public Tuple6(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
 	}
 
 	@Override
 	public int getArity() { return 6; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -103,26 +67,35 @@ public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -130,12 +103,12 @@ public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
 			+ ")";
 	}
 
@@ -154,12 +127,12 @@ public class Tuple6<T1, T2, T3, T4, T5, T6> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("_6"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple6.class.getDeclaredField("f5"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple7.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple7.java
@@ -24,86 +24,44 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple {
+public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
 
 	public Tuple7() {}
 
-	public Tuple7(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
+	public Tuple7(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
 	}
 
 	@Override
 	public int getArity() { return 7; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -112,29 +70,39 @@ public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -142,13 +110,13 @@ public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
 			+ ")";
 	}
 
@@ -167,13 +135,13 @@ public class Tuple7<T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("_7"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple7.class.getDeclaredField("f6"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple8.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple8.java
@@ -24,95 +24,47 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
+public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
 
 	public Tuple8() {}
 
-	public Tuple8(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
+	public Tuple8(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
 	}
 
 	@Override
 	public int getArity() { return 8; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -121,32 +73,43 @@ public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -154,14 +117,14 @@ public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
 			+ ")";
 	}
 
@@ -180,14 +143,14 @@ public class Tuple8<T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("_8"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple8.class.getDeclaredField("f7"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple9.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/Tuple9.java
@@ -24,104 +24,50 @@ package eu.stratosphere.api.java.tuple;
 import eu.stratosphere.util.StringUtils;
 
 @SuppressWarnings({"restriction"})
-public class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
+public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 
 	private static final long serialVersionUID = 1L;
 
-	private T1 _1;
-	private T2 _2;
-	private T3 _3;
-	private T4 _4;
-	private T5 _5;
-	private T6 _6;
-	private T7 _7;
-	private T8 _8;
-	private T9 _9;
+	public T0 f0;
+	public T1 f1;
+	public T2 f2;
+	public T3 f3;
+	public T4 f4;
+	public T5 f5;
+	public T6 f6;
+	public T7 f7;
+	public T8 f8;
 
 	public Tuple9() {}
 
-	public Tuple9(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9) {
-		this._1 = value1;
-		this._2 = value2;
-		this._3 = value3;
-		this._4 = value4;
-		this._5 = value5;
-		this._6 = value6;
-		this._7 = value7;
-		this._8 = value8;
-		this._9 = value9;
+	public Tuple9(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
 	}
 
 	@Override
 	public int getArity() { return 9; }
 
-	public T1 T1() {
-		return this._1;
-	}
-	public T2 T2() {
-		return this._2;
-	}
-	public T3 T3() {
-		return this._3;
-	}
-	public T4 T4() {
-		return this._4;
-	}
-	public T5 T5() {
-		return this._5;
-	}
-	public T6 T6() {
-		return this._6;
-	}
-	public T7 T7() {
-		return this._7;
-	}
-	public T8 T8() {
-		return this._8;
-	}
-	public T9 T9() {
-		return this._9;
-	}
-	public void T1(T1 value) {
-		this._1 = value;
-	}
-	public void T2(T2 value) {
-		this._2 = value;
-	}
-	public void T3(T3 value) {
-		this._3 = value;
-	}
-	public void T4(T4 value) {
-		this._4 = value;
-	}
-	public void T5(T5 value) {
-		this._5 = value;
-	}
-	public void T6(T6 value) {
-		this._6 = value;
-	}
-	public void T7(T7 value) {
-		this._7 = value;
-	}
-	public void T8(T8 value) {
-		this._8 = value;
-	}
-	public void T9(T9 value) {
-		this._9 = value;
-	}
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T getField(int pos) {
 		switch(pos) {
-			case 0: return (T) this._1;
-			case 1: return (T) this._2;
-			case 2: return (T) this._3;
-			case 3: return (T) this._4;
-			case 4: return (T) this._5;
-			case 5: return (T) this._6;
-			case 6: return (T) this._7;
-			case 7: return (T) this._8;
-			case 8: return (T) this._9;
+			case 0: return (T) this.f0;
+			case 1: return (T) this.f1;
+			case 2: return (T) this.f2;
+			case 3: return (T) this.f3;
+			case 4: return (T) this.f4;
+			case 5: return (T) this.f5;
+			case 6: return (T) this.f6;
+			case 7: return (T) this.f7;
+			case 8: return (T) this.f8;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
@@ -130,35 +76,47 @@ public class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 	public <T> void setField(T value, int pos) {
 		switch(pos) {
 			case 0:
-				this._1 = (T1) value;
+				this.f0 = (T0) value;
 				break;
 			case 1:
-				this._2 = (T2) value;
+				this.f1 = (T1) value;
 				break;
 			case 2:
-				this._3 = (T3) value;
+				this.f2 = (T2) value;
 				break;
 			case 3:
-				this._4 = (T4) value;
+				this.f3 = (T3) value;
 				break;
 			case 4:
-				this._5 = (T5) value;
+				this.f4 = (T4) value;
 				break;
 			case 5:
-				this._6 = (T6) value;
+				this.f5 = (T5) value;
 				break;
 			case 6:
-				this._7 = (T7) value;
+				this.f6 = (T6) value;
 				break;
 			case 7:
-				this._8 = (T8) value;
+				this.f7 = (T7) value;
 				break;
 			case 8:
-				this._9 = (T9) value;
+				this.f8 = (T8) value;
 				break;
 			default: throw new IndexOutOfBoundsException(String.valueOf(pos));
 		}
 	}
+	public void setFields(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) {
+		this.f0 = value0;
+		this.f1 = value1;
+		this.f2 = value2;
+		this.f3 = value3;
+		this.f4 = value4;
+		this.f5 = value5;
+		this.f6 = value6;
+		this.f7 = value7;
+		this.f8 = value8;
+	}
+
 
 	// -------------------------------------------------------------------------------------------------
 	// standard utilities
@@ -166,15 +124,15 @@ public class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 
 	@Override
 	public String toString() {
-		return "(" + StringUtils.arrayAwareToString(this._1)
-			+ ", " + StringUtils.arrayAwareToString(this._2)
-			+ ", " + StringUtils.arrayAwareToString(this._3)
-			+ ", " + StringUtils.arrayAwareToString(this._4)
-			+ ", " + StringUtils.arrayAwareToString(this._5)
-			+ ", " + StringUtils.arrayAwareToString(this._6)
-			+ ", " + StringUtils.arrayAwareToString(this._7)
-			+ ", " + StringUtils.arrayAwareToString(this._8)
-			+ ", " + StringUtils.arrayAwareToString(this._9)
+		return "(" + StringUtils.arrayAwareToString(this.f0)
+			+ ", " + StringUtils.arrayAwareToString(this.f1)
+			+ ", " + StringUtils.arrayAwareToString(this.f2)
+			+ ", " + StringUtils.arrayAwareToString(this.f3)
+			+ ", " + StringUtils.arrayAwareToString(this.f4)
+			+ ", " + StringUtils.arrayAwareToString(this.f5)
+			+ ", " + StringUtils.arrayAwareToString(this.f6)
+			+ ", " + StringUtils.arrayAwareToString(this.f7)
+			+ ", " + StringUtils.arrayAwareToString(this.f8)
 			+ ")";
 	}
 
@@ -193,15 +151,15 @@ public class Tuple9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 
 	static {
 		try {
-			offsets[0] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_1"));
-			offsets[1] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_2"));
-			offsets[2] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_3"));
-			offsets[3] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_4"));
-			offsets[4] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_5"));
-			offsets[5] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_6"));
-			offsets[6] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_7"));
-			offsets[7] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_8"));
-			offsets[8] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("_9"));
+			offsets[0] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f0"));
+			offsets[1] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f1"));
+			offsets[2] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f2"));
+			offsets[3] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f3"));
+			offsets[4] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f4"));
+			offsets[5] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f5"));
+			offsets[6] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f6"));
+			offsets[7] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f7"));
+			offsets[8] = UNSAFE.objectFieldOffset(Tuple9.class.getDeclaredField("f8"));
 		} catch (Throwable t) {
 			throw new RuntimeException("Could not initialize fast field accesses for tuple data type.");
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/TupleGenerator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/TupleGenerator.java
@@ -13,32 +13,293 @@
 package eu.stratosphere.api.java.tuple;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Scanner;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 /**
- * Source code generator for tuple classes.
+ * Source code generator for tuple classes and classes which depend on the arity
+ * of tuples.
  */
 public class TupleGenerator {
-	
+
+	// Parameters for tuple classes	
 	private static final String ROOT_DIRECTORY = "./src/main/java";
-	
+
 	private static final String PACKAGE = "eu.stratosphere.api.java.tuple";
-	
+
 	private static final String GEN_TYPE_PREFIX = "T";
+
+	// Parameters for tuple-dependent classes
+	private static final String BEGIN_INDICATOR = "BEGIN_OF_TUPLE_DEPENDENT_CODE";
+
+	private static final String END_INDICATOR = "END_OF_TUPLE_DEPENDENT_CODE";
+
+	// Parameters for CsvReader	
+	private static final String CSV_READER_PACKAGE = "eu.stratosphere.api.java.io";
+
+	private static final String CSV_READER_CLASSNAME = "CsvReader";
 	
+	// Parameters for TupleTypeInfo
+	private static final String TUPLE_TYPE_INFO_PACKAGE = "eu.stratosphere.api.java.typeutils";
+	
+	private static final String TUPLE_TYPE_INFO_CLASSNAME = "TupleTypeInfo";
+	
+	// Parameters for ProjectOperator
+	private static final String PROJECT_OPERATOR_PACKAGE = "eu.stratosphere.api.java.operators";
+	
+	private static final String PROJECT_OPERATOR_CLASSNAME = "ProjectOperator";
+
+	// min. and max. tuple arity	
 	private static final int FIRST = 1;
-	
+
 	private static final int LAST = 22;
-	
-	
+
 	public static void main(String[] args) throws Exception {
 		File root = new File(ROOT_DIRECTORY);
-		File dir = new File(root, PACKAGE.replace('.', '/'));
+
+		createTupleClasses(root);
+
+		modifyCsvReader(root);
+		
+		modifyTupleTypeInfo(root);
+		
+		modifyProjectOperator(root);
+	}
+
+	private static File getPackage(File root, String packageString) {
+		File dir = new File(root, packageString.replace('.', '/'));
 		if (!dir.exists() && dir.isDirectory()) {
 			System.err.println("None existent directory: " + dir.getAbsolutePath());
 			System.exit(1);
 		}
+		return dir;
+	}
+
+	private static void insertCodeIntoFile(String code, File file) throws IOException {
+		String fileContent = Files.toString(file, Charsets.UTF_8);
+		Scanner s = new Scanner(fileContent);
+
+		StringBuilder sb = new StringBuilder();
+		String line = null;
 		
+		boolean indicatorFound = false;
+
+		// add file beginning
+		while (s.hasNextLine() && (line = s.nextLine()) != null) {
+			sb.append(line + "\n");
+			if (line.contains(BEGIN_INDICATOR)) {
+				indicatorFound = true;
+				break;
+			}
+		}
+		
+		if(!indicatorFound) {
+			System.out.println("No indicator found in '" + file + "'. Will skip code generation.");
+			s.close();
+			return;
+		}
+
+		// add generator signature
+		sb.append("\t// GENERATED FROM " + TupleGenerator.class.getName() + ".\n");
+
+		// add tuple dependent code
+		sb.append(code + "\n");
+
+		// skip generated code
+		while (s.hasNextLine() && (line = s.nextLine()) != null) {
+			if (line.contains(END_INDICATOR)) {
+				sb.append(line + "\n");
+				break;
+			}
+		}
+
+		// add file ending
+		while (s.hasNextLine() && (line = s.nextLine()) != null) {
+			sb.append(line + "\n");
+		}
+		s.close();
+		Files.write(sb.toString(), file, Charsets.UTF_8);
+	}
+	
+	private static void modifyProjectOperator(File root) throws IOException {
+		// generate code
+		StringBuilder sb = new StringBuilder();
+		
+		for (int numFields = FIRST; numFields <= LAST; numFields++) {
+
+			// method begin
+			sb.append("\n");
+			
+			// method comment
+			sb.append("\t\t/**\n");
+			sb.append("\t\t * Projects a tuple data set to the previously selected fields. \n");
+			sb.append("\t\t * Requires the classes of the fields of the resulting tuples. \n");
+			sb.append("\t\t * \n");			
+			for (int i = 0; i < numFields; i++) {
+				sb.append("\t\t * @param type" + i + " The class of field '"+i+"' of the result tuples.\n");
+			}
+			sb.append("\t\t * @return The projected data set.\n");
+			sb.append("\t\t */\n");
+			
+			// method signature
+			sb.append("\t\tpublic <");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append("> ProjectOperator<T, Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">> types(");
+			for (int i = 0; i < numFields; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append("Class<");
+				sb.append(GEN_TYPE_PREFIX + i);
+				sb.append("> type" + i);
+			}
+			sb.append(") {\n");
+			
+			// convert type0..1 to types array
+			sb.append("\t\t\tClass<?>[] types = {");
+			for (int i = 0; i < numFields; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append("type" + i);
+			}
+			sb.append("};\n");
+			
+			// check number of types and extract field types
+			sb.append("\t\t\tif(types.length != this.fields.length) {\n");
+			sb.append("\t\t\t\tthrow new IllegalArgumentException(\"Numbers of projected fields and types do not match.\");\n");
+			sb.append("\t\t\t}\n");
+			sb.append("\t\t\t\n");
+			sb.append("\t\t\tTypeInformation<?>[] fTypes = extractFieldTypes(fields, types, ds.getType());\n");
+			
+			// create new tuple type info
+			sb.append("\t\t\tTupleTypeInfo<Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">> tType = new TupleTypeInfo<Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">>(fTypes);\n\n");
+			
+			// create and return new project operator
+			sb.append("\t\t\treturn new ProjectOperator<T, Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">>(this.ds, this.fields, tType);\n");
+			
+			// method end
+			sb.append("\t\t}\n");
+			
+		}
+		
+		// insert code into file
+		File dir = getPackage(root, PROJECT_OPERATOR_PACKAGE);
+		File projectOperatorClass = new File(dir, PROJECT_OPERATOR_CLASSNAME + ".java");
+		insertCodeIntoFile(sb.toString(), projectOperatorClass);
+	}
+	
+	private static void modifyTupleTypeInfo(File root) throws IOException {
+		// generate code
+		StringBuilder sb = new StringBuilder();
+		sb.append("\tprivate static final Class<?>[] CLASSES = new Class<?>[] {\n\t");
+		for (int i = FIRST; i <= LAST; i++) {
+			if (i > FIRST) {
+				sb.append(", ");
+			}
+			sb.append("Tuple" + i + ".class");
+		}
+		sb.append("\n\t};");
+		
+		// insert code into file
+		File dir = getPackage(root, TUPLE_TYPE_INFO_PACKAGE);
+		File tupleTypeInfoClass = new File(dir, TUPLE_TYPE_INFO_CLASSNAME + ".java");
+		insertCodeIntoFile(sb.toString(), tupleTypeInfoClass);
+	}
+
+	private static void modifyCsvReader(File root) throws IOException {
+		// generate code
+		StringBuilder sb = new StringBuilder();
+		for (int numFields = FIRST; numFields <= LAST; numFields++) {
+
+			// method begin
+			sb.append("\n");
+
+			// method signature
+			sb.append("\tpublic <");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append("> DataSource<Tuple" + numFields + "<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">> types(");
+			for (int i = 0; i < numFields; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append("Class<");
+				sb.append(GEN_TYPE_PREFIX + i);
+				sb.append("> type" + i);
+			}
+			sb.append(") {\n");
+
+			// get TupleTypeInfo
+			sb.append("\t\tTupleTypeInfo<Tuple" + numFields + "<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">> types = TupleTypeInfo.getBasicTupleTypeInfo(");
+			for (int i = 0; i < numFields; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append("type" + i);
+			}
+			sb.append(");\n");
+
+			// create csv input format
+			sb.append("\t\tCsvInputFormat<Tuple" + numFields + "<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">> inputFormat = new CsvInputFormat<Tuple" + numFields + "<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">>(path);\n");
+
+			// configure input format
+			sb.append("\t\tconfigureInputFormat(inputFormat, ");
+			for (int i = 0; i < numFields; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append("type" + i);
+			}
+			sb.append(");\n");
+
+			// return
+			sb.append("\t\treturn new DataSource<Tuple" + numFields + "<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">>(executionContext, inputFormat, types);\n");
+
+			// end of method
+			sb.append("\t}\n");
+		}
+
+		// insert code into file
+		File dir = getPackage(root, CSV_READER_PACKAGE);
+		File csvReaderClass = new File(dir, CSV_READER_CLASSNAME + ".java");
+		insertCodeIntoFile(sb.toString(), csvReaderClass);
+	}
+
+	private static void appendTupleTypeGenerics(StringBuilder sb, int numFields) {
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append(GEN_TYPE_PREFIX + i);
+		}
+	}
+
+	private static void createTupleClasses(File root) throws FileNotFoundException {
+		File dir = getPackage(root, PACKAGE);
+
 		for (int i = FIRST; i <= LAST; i++) {
 			File tupleFile = new File(dir, "Tuple" + i + ".java");
 			PrintWriter writer = new PrintWriter(tupleFile);
@@ -47,55 +308,55 @@ public class TupleGenerator {
 			writer.close();
 		}
 	}
-	
-	
+
 	private static void writeTupleClass(PrintWriter w, int numFields) {
 		final String className = "Tuple" + numFields;
-		
+
 		// head 
 		w.print(HEADER);
-		
+
 		// package and imports
 		w.println("package " + PACKAGE + ';');
 		w.println();
 		w.println("import eu.stratosphere.util.StringUtils;");
 		w.println();
-		
+
 		// class declaration
-		w.println("@SuppressWarnings({\"restriction\"})");;
+		w.println("@SuppressWarnings({\"restriction\"})");
+		;
 		w.print("public class " + className + "<");
-		for (int i = 1; i <= numFields; i++) {
-			if (i > 1) {
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
 				w.print(", ");
 			}
 			w.print(GEN_TYPE_PREFIX + i);
 		}
 		w.println("> extends Tuple {");
 		w.println();
-		
+
 		w.println("\tprivate static final long serialVersionUID = 1L;");
 		w.println();
-		
+
 		// fields
-		for (int i = 1; i <= numFields; i++) {
-			w.println("\tprivate " + GEN_TYPE_PREFIX + i + " _" + i + ';');
+		for (int i = 0; i < numFields; i++) {
+			w.println("\tpublic " + GEN_TYPE_PREFIX + i + " f" + i + ';');
 		}
 		w.println();
-		
+
 		// constructors
 		w.println("\tpublic " + className + "() {}");
 		w.println();
 		w.print("\tpublic " + className + "(");
-		for (int i = 1; i <= numFields; i++) {
-			if (i > 1) {
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
 				w.print(", ");
 			}
 			w.print(GEN_TYPE_PREFIX + i + " value" + i);
 		}
 		w.println(") {");
-		for (int i = 1; i <= numFields; i++) {
-			w.println("\t\tthis._" + i + " = value" + i + ';');
-		}		
+		for (int i = 0; i < numFields; i++) {
+			w.println("\t\tthis.f" + i + " = value" + i + ';');
+		}
 		w.println("\t}");
 		w.println();
 
@@ -103,33 +364,19 @@ public class TupleGenerator {
 		w.println("\t@Override");
 		w.println("\tpublic int getArity() { return " + numFields + "; }");
 		w.println();
-		
-		// individual accessors
-		for (int i = 1; i <= numFields; i++) {
-			w.println("\tpublic " + GEN_TYPE_PREFIX + i + " " + GEN_TYPE_PREFIX + i + "() {");
-			w.println("\t\treturn this._" + i + ";");
-			w.println("\t}");
-		}
-		
-		for (int i = 1; i <= numFields; i++) {
-			w.println("\tpublic void " + GEN_TYPE_PREFIX + i + "(" + GEN_TYPE_PREFIX + i + " value) {");
-			w.println("\t\tthis._" + i + " = value;");
-			w.println("\t}");
-		}
-		
-		
+
 		// accessor getter method
 		w.println("\t@Override");
 		w.println("\t@SuppressWarnings(\"unchecked\")");
 		w.println("\tpublic <T> T getField(int pos) {");
 		w.println("\t\tswitch(pos) {");
 		for (int i = 0; i < numFields; i++) {
-			w.println("\t\t\tcase " + i + ": return (T) this._" + (i+1) + ';');
+			w.println("\t\t\tcase " + i + ": return (T) this.f" + i + ';');
 		}
 		w.println("\t\t\tdefault: throw new IndexOutOfBoundsException(String.valueOf(pos));");
 		w.println("\t\t}");
 		w.println("\t}");
-		
+
 		// accessor setter method
 		w.println("\t@Override");
 		w.println("\t@SuppressWarnings(\"unchecked\")");
@@ -137,13 +384,28 @@ public class TupleGenerator {
 		w.println("\t\tswitch(pos) {");
 		for (int i = 0; i < numFields; i++) {
 			w.println("\t\t\tcase " + i + ':');
-			w.println("\t\t\t\tthis._" + (i+1) + " = (" + GEN_TYPE_PREFIX + (i+1) + ") value;");
+			w.println("\t\t\t\tthis.f" + i + " = (" + GEN_TYPE_PREFIX + i + ") value;");
 			w.println("\t\t\t\tbreak;");
 		}
 		w.println("\t\t\tdefault: throw new IndexOutOfBoundsException(String.valueOf(pos));");
 		w.println("\t\t}");
 		w.println("\t}");
-		
+
+		// accessor setter method for all fields
+		w.print("\tpublic void setFields(");
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
+				w.print(", ");
+			}
+			w.print(GEN_TYPE_PREFIX + i + " value" + i);
+		}
+		w.println(") {");
+		for (int i = 0; i < numFields; i++) {
+			w.println("\t\tthis.f" + i + " = value" + i + ';');
+		}
+		w.println("\t}");
+		w.println();
+
 		// standard utilities (toString, equals, hashCode)
 		w.println();
 		w.println("\t// -------------------------------------------------------------------------------------------------");
@@ -152,13 +414,13 @@ public class TupleGenerator {
 		w.println();
 		w.println("\t@Override");
 		w.println("\tpublic String toString() {");
-		w.println("\t\treturn \"(\" + StringUtils.arrayAwareToString(this._1)");
-		for (int i = 2; i <= numFields; i++) {
-			w.println("\t\t\t+ \", \" + StringUtils.arrayAwareToString(this._" + i + ")");
+		w.println("\t\treturn \"(\" + StringUtils.arrayAwareToString(this.f0)");
+		for (int i = 1; i < numFields; i++) {
+			w.println("\t\t\t+ \", \" + StringUtils.arrayAwareToString(this.f" + i + ")");
 		}
 		w.println("\t\t\t+ \")\";");
 		w.println("\t}");
-		
+
 		// unsafe fast field access
 		w.println();
 		w.println("\t// -------------------------------------------------------------------------------------------------");
@@ -176,20 +438,20 @@ public class TupleGenerator {
 		w.println();
 		w.println("\tstatic {");
 		w.println("\t\ttry {");
-		
+
 		for (int i = 0; i < numFields; i++) {
-			w.println("\t\t\toffsets[" + i + "] = UNSAFE.objectFieldOffset(Tuple" + numFields + ".class.getDeclaredField(\"_" + (i+1) + "\"));");
+			w.println("\t\t\toffsets[" + i + "] = UNSAFE.objectFieldOffset(Tuple" + numFields + ".class.getDeclaredField(\"f" + i + "\"));");
 		}
-		
+
 		w.println("\t\t} catch (Throwable t) {");
 		w.println("\t\t\tthrow new RuntimeException(\"Could not initialize fast field accesses for tuple data type.\");");
 		w.println("\t\t}");
 		w.println("\t}");
-		
+
 		// foot
 		w.println("}");
 	}
-	
+
 	private static String HEADER = 
 		"/***********************************************************************************************************************\n" +
 		" *\n" +

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
@@ -164,15 +164,15 @@ public class TupleTypeInfo<T extends Tuple> extends TypeInformation<T> implement
 		return tupleInfo;
 	}
 	
-	// --------------------------------------------------------------------------------------------
-	
+	// --------------------------------------------------------------------------------------------	
+	// The following lines are generated.
+	// --------------------------------------------------------------------------------------------	
+	// BEGIN_OF_TUPLE_DEPENDENT_CODE	
+	// GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
 	private static final Class<?>[] CLASSES = new Class<?>[] {
-		Tuple1.class, Tuple2.class, Tuple3.class, Tuple4.class, Tuple5.class,
-		Tuple6.class, Tuple7.class, Tuple8.class, Tuple9.class, Tuple10.class,
-		Tuple11.class, Tuple12.class, Tuple13.class, Tuple14.class, Tuple15.class,
-		Tuple16.class, Tuple17.class, Tuple18.class, Tuple19.class, Tuple20.class,
-		Tuple21.class, Tuple22.class
+	Tuple1.class, Tuple2.class, Tuple3.class, Tuple4.class, Tuple5.class, Tuple6.class, Tuple7.class, Tuple8.class, Tuple9.class, Tuple10.class, Tuple11.class, Tuple12.class, Tuple13.class, Tuple14.class, Tuple15.class, Tuple16.class, Tuple17.class, Tuple18.class, Tuple19.class, Tuple20.class, Tuple21.class, Tuple22.class
 	};
+	// END_OF_TUPLE_DEPENDENT_CODE
 	
 	
 	private static final <T extends Tuple, K> TypeComparator<T> createSinglefieldComparator(int pos, boolean ascending, TypeInformation<?> info) {

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CsvInputFormatTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CsvInputFormatTest.java
@@ -61,21 +61,21 @@ public class CsvInputFormatTest {
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals("abc", result.T1());
-			assertEquals("def", result.T2());
-			assertEquals("ghijk", result.T3());
+			assertEquals("abc", result.f0);
+			assertEquals("def", result.f1);
+			assertEquals("ghijk", result.f2);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals("abc", result.T1());
-			assertEquals("", result.T2());
-			assertEquals("hhg", result.T3());
+			assertEquals("abc", result.f0);
+			assertEquals("", result.f1);
+			assertEquals("hhg", result.f2);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals("", result.T1());
-			assertEquals("", result.T2());
-			assertEquals("", result.T3());
+			assertEquals("", result.f0);
+			assertEquals("", result.f1);
+			assertEquals("", result.f2);
 			
 			result = format.nextRecord(result);
 			assertNull(result);
@@ -105,21 +105,21 @@ public class CsvInputFormatTest {
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals("abc", result.T1());
-			assertEquals("def", result.T2());
-			assertEquals("ghijk", result.T3());
+			assertEquals("abc", result.f0);
+			assertEquals("def", result.f1);
+			assertEquals("ghijk", result.f2);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals("abc", result.T1());
-			assertEquals("", result.T2());
-			assertEquals("hhg", result.T3());
+			assertEquals("abc", result.f0);
+			assertEquals("", result.f1);
+			assertEquals("hhg", result.f2);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals("", result.T1());
-			assertEquals("", result.T2());
-			assertEquals("", result.T3());
+			assertEquals("", result.f0);
+			assertEquals("", result.f1);
+			assertEquals("", result.f2);
 			
 			result = format.nextRecord(result);
 			assertNull(result);
@@ -148,19 +148,19 @@ public class CsvInputFormatTest {
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(111), result.T1());
-			assertEquals(Integer.valueOf(222), result.T2());
-			assertEquals(Integer.valueOf(333), result.T3());
-			assertEquals(Integer.valueOf(444), result.T4());
-			assertEquals(Integer.valueOf(555), result.T5());
+			assertEquals(Integer.valueOf(111), result.f0);
+			assertEquals(Integer.valueOf(222), result.f1);
+			assertEquals(Integer.valueOf(333), result.f2);
+			assertEquals(Integer.valueOf(444), result.f3);
+			assertEquals(Integer.valueOf(555), result.f4);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(666), result.T1());
-			assertEquals(Integer.valueOf(777), result.T2());
-			assertEquals(Integer.valueOf(888), result.T3());
-			assertEquals(Integer.valueOf(999), result.T4());
-			assertEquals(Integer.valueOf(000), result.T5());
+			assertEquals(Integer.valueOf(666), result.f0);
+			assertEquals(Integer.valueOf(777), result.f1);
+			assertEquals(Integer.valueOf(888), result.f2);
+			assertEquals(Integer.valueOf(999), result.f3);
+			assertEquals(Integer.valueOf(000), result.f4);
 			
 			result = format.nextRecord(result);
 			assertNull(result);
@@ -189,13 +189,13 @@ public class CsvInputFormatTest {
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(111), result.T1());
-			assertEquals(Integer.valueOf(222), result.T2());
+			assertEquals(Integer.valueOf(111), result.f0);
+			assertEquals(Integer.valueOf(222), result.f1);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(666), result.T1());
-			assertEquals(Integer.valueOf(777), result.T2());
+			assertEquals(Integer.valueOf(666), result.f0);
+			assertEquals(Integer.valueOf(777), result.f1);
 			
 			result = format.nextRecord(result);
 			assertNull(result);
@@ -225,15 +225,15 @@ public class CsvInputFormatTest {
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(111), result.T1());
-			assertEquals(Integer.valueOf(444), result.T2());
-			assertEquals(Integer.valueOf(888), result.T3());
+			assertEquals(Integer.valueOf(111), result.f0);
+			assertEquals(Integer.valueOf(444), result.f1);
+			assertEquals(Integer.valueOf(888), result.f2);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(000), result.T1());
-			assertEquals(Integer.valueOf(777), result.T2());
-			assertEquals(Integer.valueOf(333), result.T3());
+			assertEquals(Integer.valueOf(000), result.f0);
+			assertEquals(Integer.valueOf(777), result.f1);
+			assertEquals(Integer.valueOf(333), result.f2);
 			
 			result = format.nextRecord(result);
 			assertNull(result);
@@ -264,15 +264,15 @@ public class CsvInputFormatTest {
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(111), result.T1());
-			assertEquals(Integer.valueOf(444), result.T2());
-			assertEquals(Integer.valueOf(888), result.T3());
+			assertEquals(Integer.valueOf(111), result.f0);
+			assertEquals(Integer.valueOf(444), result.f1);
+			assertEquals(Integer.valueOf(888), result.f2);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(000), result.T1());
-			assertEquals(Integer.valueOf(777), result.T2());
-			assertEquals(Integer.valueOf(333), result.T3());
+			assertEquals(Integer.valueOf(000), result.f0);
+			assertEquals(Integer.valueOf(777), result.f1);
+			assertEquals(Integer.valueOf(333), result.f2);
 			
 			result = format.nextRecord(result);
 			assertNull(result);
@@ -303,15 +303,15 @@ public class CsvInputFormatTest {
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(111), result.T1());
-			assertEquals(Integer.valueOf(444), result.T2());
-			assertEquals(Integer.valueOf(888), result.T3());
+			assertEquals(Integer.valueOf(111), result.f0);
+			assertEquals(Integer.valueOf(444), result.f1);
+			assertEquals(Integer.valueOf(888), result.f2);
 			
 			result = format.nextRecord(result);
 			assertNotNull(result);
-			assertEquals(Integer.valueOf(000), result.T1());
-			assertEquals(Integer.valueOf(777), result.T2());
-			assertEquals(Integer.valueOf(333), result.T3());
+			assertEquals(Integer.valueOf(000), result.f0);
+			assertEquals(Integer.valueOf(777), result.f1);
+			assertEquals(Integer.valueOf(333), result.f2);
 			
 			result = format.nextRecord(result);
 			assertNull(result);
@@ -344,15 +344,15 @@ public class CsvInputFormatTest {
 //			
 //			result = format.nextRecord(result);
 //			assertNotNull(result);
-//			assertEquals(Integer.valueOf(999), result.T1());
-//			assertEquals(Integer.valueOf(222), result.T2());
-//			assertEquals(Integer.valueOf(444), result.T3());
+//			assertEquals(Integer.valueOf(999), result.f0);
+//			assertEquals(Integer.valueOf(222), result.f1);
+//			assertEquals(Integer.valueOf(444), result.f2);
 //			
 //			result = format.nextRecord(result);
 //			assertNotNull(result);
-//			assertEquals(Integer.valueOf(222), result.T1());
-//			assertEquals(Integer.valueOf(999), result.T2());
-//			assertEquals(Integer.valueOf(777), result.T3());
+//			assertEquals(Integer.valueOf(222), result.f0);
+//			assertEquals(Integer.valueOf(999), result.f1);
+//			assertEquals(Integer.valueOf(777), result.f2);
 //			
 //			result = format.nextRecord(result);
 //			assertNull(result);


### PR DESCRIPTION
```
- For Tuple Fields:
    - start with index 0
    - are public (no getters and setters anymore)
    - can be accessed via f0,f1, etc. instead of a method T1(), T2(), etc.
    - setFields() allows for setting all fields at once
- For CsvReader, ProjectOperator, TupleTypeInfo:
    - TupleGenerator generates code for classes which depend on the tuple arity.
    - A special String indicates where to put Tuple dependent code
```

This PR implements #600, #599, #597. The TupleGenerator already supports #617 if the indicator is added.
