### PR TITLE
Add parser for BigDecimal

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/GenericCsvInputFormat.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/GenericCsvInputFormat.java
@@ -108,6 +108,10 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 		this.skipFirstLineAsHeader = skipFirstLine;
 	}
 	
+	public FieldParser<?> getFieldParser(int i) {
+		return this.fieldParsers[i];
+	}
+	
 	// --------------------------------------------------------------------------------------------
 	
 	protected FieldParser<?>[] getFieldParsers() {
@@ -225,6 +229,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 		this.fieldTypes = denseTypeArray;
 		this.fieldIncluded = includedMask;
 	}
+	
 
 	// --------------------------------------------------------------------------------------------
 	//  Runtime methods

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/DecimalValue.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/DecimalValue.java
@@ -1,0 +1,47 @@
+package eu.stratosphere.types;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class DecimalValue implements Value {
+	private static final long serialVersionUID = 1L;
+	
+	private BigDecimal value;
+	private byte[] landingZone;
+	
+	public DecimalValue() {
+	}
+	
+	@Override
+	public void write(DataOutput out) throws IOException {
+		final byte[] bytes = value.unscaledValue().toByteArray();
+		out.writeInt(bytes.length);
+		out.writeInt(value.scale());
+		out.write(bytes);
+	}
+
+	@Override
+	public void read(DataInput in) throws IOException {
+		final int len = in.readInt();
+		final int scale = in.readInt();
+		if(landingZone == null || landingZone.length != len) {
+			// try to avoid at least some serialization.
+			landingZone = new byte[len];
+		}
+		in.readFully(landingZone);
+		value = new BigDecimal(new BigInteger(landingZone), scale);
+	}
+	
+	public BigDecimal getValue() {
+		return value;
+	}
+	
+	public void setValue(BigDecimal d) {
+		this.value = d;
+	}
+	
+	
+}

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextBigDecimalParser.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/parser/DecimalTextBigDecimalParser.java
@@ -1,0 +1,66 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.types.parser;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import eu.stratosphere.types.DecimalValue;
+
+/**
+ * Parses a text field into a {@link DecimalValue}
+ */
+public class DecimalTextBigDecimalParser extends FieldParser<DecimalValue> {
+	
+	private DecimalValue result;
+	
+	// optional fields if the user wants to convert the input to a certain scale (using a rounding mode).
+	private int scale;
+	private RoundingMode rounding = null;
+	
+	public void enforceScale(int scale, RoundingMode rounding) {
+		this.scale = scale;
+		this.rounding = rounding;
+	}
+	
+	@Override
+	public int parseField(byte[] bytes, int startPos, int limit, char delim, DecimalValue reusable) {
+		
+		int i = startPos;
+		final byte delByte = (byte) delim;
+		
+		while (i < limit && bytes[i] != delByte) {
+			i++;
+		}
+		
+		String str = new String(bytes, startPos, i-startPos);
+		BigDecimal bd = new BigDecimal(str);
+		if(rounding != null) {
+			bd = bd.setScale(scale, rounding);
+		}
+		reusable.setValue(bd);
+		this.result = reusable;
+		return (i == limit) ? limit : i+1;
+	}
+	
+	@Override
+	public DecimalValue createValue() {
+		return new DecimalValue();
+	}
+
+	@Override
+	public DecimalValue getLastResult() {
+		return this.result;
+	}
+}

--- a/stratosphere-core/src/main/java/eu/stratosphere/types/parser/FieldParser.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/types/parser/FieldParser.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import eu.stratosphere.types.ByteValue;
+import eu.stratosphere.types.DecimalValue;
 import eu.stratosphere.types.DoubleValue;
 import eu.stratosphere.types.FloatValue;
 import eu.stratosphere.types.IntValue;
@@ -114,5 +115,6 @@ public abstract class FieldParser<T> {
 		PARSERS.put(StringValue.class, VarLengthStringParser.class);
 		PARSERS.put(FloatValue.class, DecimalTextFloatParser.class);
 		PARSERS.put(DoubleValue.class, DecimalTextDoubleParser.class);
+		PARSERS.put(DecimalValue.class, DecimalTextBigDecimalParser.class);
 	}
 }


### PR DESCRIPTION
I [need](https://github.com/rmetzger/stratosphere-sql/issues/17) BigDecimal support the Stratosphere SQL interface.
The pull request adds a `DecimalValue` to Stratosphere, including a parser for the CSVInputFormat and a little test.

I also added a `GenericCsvInputFormat.getFieldParser()` method to allow external configuration of the parser. I will also need this for the [planned `DateValue` type](https://github.com/rmetzger/stratosphere-sql/issues/16) to configure different Date parsers.
