### PR TITLE
Add PojoTypeInformation, PojoComparator and Expressions for Keys

### DIFF
--- a/stratosphere-addons/avro/src/main/java/eu/stratosphere/api/java/io/AvroInputFormat.java
+++ b/stratosphere-addons/avro/src/main/java/eu/stratosphere/api/java/io/AvroInputFormat.java
@@ -17,6 +17,7 @@ package eu.stratosphere.api.java.io;
 
 import java.io.IOException;
 
+import eu.stratosphere.api.java.typeutils.TypeExtractor;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.FileReader;
 import org.apache.avro.file.SeekableInput;
@@ -73,7 +74,7 @@ public class AvroInputFormat<E> extends FileInputFormat<E> implements ResultType
 	
 	@Override
 	public TypeInformation<E> getProducedType() {
-		return TypeInformation.getForClass(this.avroValueType);
+		return TypeExtractor.getForClass(this.avroValueType);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-examples/stratosphere-java-examples/pom.xml
+++ b/stratosphere-examples/stratosphere-java-examples/pom.xml
@@ -301,6 +301,28 @@
 						</configuration>
 					</execution>
 
+					<!-- WordCount -->
+					<execution>
+						<id>WordCountCustomType</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>WordCountCustomType</classifier>
+
+							<archive>
+								<manifestEntries>
+									<program-class>eu.stratosphere.example.java.wordcount.WordCountCustomType</program-class>
+								</manifestEntries>
+							</archive>
+
+							<includes>
+								<include>**/wordcount/*.class</include>
+							</includes>
+						</configuration>
+					</execution>
+
 					<!-- TeraSort -->
 					<execution>
 						<id>TeraSort</id>

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCustomType.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCustomType.java
@@ -16,68 +16,78 @@ package eu.stratosphere.example.java.wordcount;
 
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.LocalEnvironment;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.functions.JoinFunction;
 import eu.stratosphere.api.java.functions.KeySelector;
 import eu.stratosphere.api.java.functions.ReduceFunction;
 import eu.stratosphere.util.Collector;
 
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
 
 @SuppressWarnings("serial")
 public class WordCountCustomType {
-	
-	public static class WC {
-		
-		public String word;
+
+	public static class WCBase {
+		protected String word;
+	}
+
+	public static class WC extends WCBase {
+
 		public int count;
-		
+		public int docId;
+
 		public WC() {}
 
-		public WC(String word, int count) {
+		public WC(String word, int docId, int count) {
 			this.word = word;
 			this.count = count;
+			this.docId = docId;
 		}
-		
+
 		@Override
 		public String toString() {
-			return "(" + word + ", " + count + ")";
+			return "count(" + word + ", " + docId + ", " + count + ")";
+		}
+
+		public String getWord() {
+			return word;
 		}
 	}
-	
-	public static final class Tokenizer extends FlatMapFunction<String, WC> {
-		
-		@Override
-		public void flatMap(String value, Collector<WC> out) {
-			String[] tokens = value.toLowerCase().split("\\W");
-			for (String token : tokens) {
-				out.collect(new WC(token, 1));
-			}
-		}
-	}
-	
-	
+
 	public static void main(String[] args) throws Exception {
-		
+
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setDegreeOfParallelism(4);
-		
-		DataSet<String> text = env.fromElements("To be", "or not to be", "or to be still", "and certainly not to be not at all", "is that the question?");
-		
-		DataSet<WC> tokenized = text.flatMap(new Tokenizer());
 
-		
+		DataSet<String> text = env.fromElements("To be", "or not to be", "or to be still", "and certainly not to be not at all", "is that the question?");
+
+		DataSet<WC> tokenized = text.flatMap(new FlatMapFunction<String, WC>() {
+			@Override
+			public void flatMap(String value, Collector<WC> out) {
+				String[] tokens = value.toLowerCase().split("\\W");
+				int docId = 0;
+				for (String token : tokens) {
+					out.collect(new WC(token, docId, 1));
+					docId = 1 - docId;
+				}
+			}
+		});
+
+
 		DataSet<WC> result = tokenized
-				
-				.groupBy(new KeySelector<WC, String>() { public String getKey(WC v) { return v.word; } })
-				
+				.groupBy("word", "docId")
 				.reduce(new ReduceFunction<WC>() {
 					public WC reduce(WC value1, WC value2) {
-						return new WC(value1.word, value1.count + value2.count);
+						return new WC(value1.word, value1.docId, value1.count + value2.count);
 					}
 				});
-		
-		
+
 		result.print();
-		
+
 		env.execute();
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -123,9 +123,9 @@ public abstract class DataSet<T> {
 		return new Grouping<T>(this, new Keys.SelectorFunctionKeys<T, K>(keyExtractor, getType()));
 	}
 	
-//	public Grouping<T> groupBy(String fieldExpression) {
-//		return new Grouping<T>(this, new Keys.ExpressionKeys<T>(fieldExpression, getType()));
-//	}
+	public Grouping<T> groupBy(String... fieldExpression) {
+		return new Grouping<T>(this, new Keys.ExpressionKeys<T>(fieldExpression, getType()));
+	}
 	
 	public Grouping<T> groupBy(int... fields) {
 		return new Grouping<T>(this, new Keys.FieldPositionKeys<T>(fields, getType(), false));

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -180,7 +180,7 @@ public abstract class ExecutionEnvironment {
 		
 		X firstValue = data.iterator().next();
 		
-		return fromCollection(data, TypeInformation.getForObject(firstValue));
+		return fromCollection(data, TypeExtractor.getForObject(firstValue));
 	}
 	
 	
@@ -191,7 +191,7 @@ public abstract class ExecutionEnvironment {
 	}
 	
 	public <X> DataSet<X> fromCollection(Iterator<X> data, Class<X> type) {
-		return fromCollection(data, TypeInformation.getForClass(type));
+		return fromCollection(data, TypeExtractor.getForClass(type));
 	}
 	
 	public <X> DataSet<X> fromCollection(Iterator<X> data, TypeInformation<X> type) {
@@ -217,12 +217,12 @@ public abstract class ExecutionEnvironment {
 			throw new IllegalArgumentException("The number of elements must not be zero.");
 		}
 		
-		return fromCollection(Arrays.asList(data), TypeInformation.getForObject(data[0]));
+		return fromCollection(Arrays.asList(data), TypeExtractor.getForObject(data[0]));
 	}
 	
 	
 	public <X> DataSet<X> fromParallelCollection(SplittableIterator<X> iterator, Class<X> type) {
-		return fromParallelCollection(iterator, TypeInformation.getForClass(type));
+		return fromParallelCollection(iterator, TypeExtractor.getForClass(type));
 	}
 	
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CoGroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CoGroupOperator.java
@@ -147,7 +147,7 @@ public class CoGroupOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OU
 			return new CoGroupOperatorSetsPredicate(new Keys.SelectorFunctionKeys<I1, K>(keyExtractor, input1.getType()));
 		}
 		
-		public CoGroupOperatorSetsPredicate where(String keyExpression) {
+		public CoGroupOperatorSetsPredicate where(String... keyExpression) {
 			return new CoGroupOperatorSetsPredicate(new Keys.ExpressionKeys<I1>(keyExpression, input1.getType()));
 		}
 	
@@ -178,7 +178,7 @@ public class CoGroupOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OU
 				return createCoGroupOperator(new Keys.SelectorFunctionKeys<I2, K>(keyExtractor, input2.getType()));
 			}
 			
-			public CoGroupOperatorWithoutFunction equalTo(String keyExpression) {
+			public CoGroupOperatorWithoutFunction equalTo(String... keyExpression) {
 				return createCoGroupOperator(new Keys.ExpressionKeys<I2>(keyExpression, input2.getType()));
 			}
 			

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/JoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/JoinOperator.java
@@ -169,9 +169,12 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 						getInput1Type(), getInput2Type(), getResultType(), name);
 				
 			}
-			else if (super.keys1 instanceof Keys.FieldPositionKeys 
+			else if ((super.keys1 instanceof Keys.FieldPositionKeys
 						&& super.keys2 instanceof Keys.FieldPositionKeys 
-						&& super.keys1.areCompatibale(super.keys2)
+						&& super.keys1.areCompatibale(super.keys2)) ||
+					(super.keys1 instanceof Keys.ExpressionKeys
+							&& super.keys2 instanceof Keys.ExpressionKeys
+							&& super.keys1.areCompatibale(super.keys2))
 					) {
 				
 				int[] logicalKeyPositions1 = super.keys1.computeLogicalKeyPositions();
@@ -336,7 +339,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			return new KeyedJoinOperatorSetsPredicate<K>(new Keys.SelectorFunctionKeys<I1, K>(keyExtractor, input1.getType()));
 		}
 		
-		public JoinOperatorSetsPredicate where(String keyExpression) {
+		public JoinOperatorSetsPredicate where(String... keyExpression) {
 			return new JoinOperatorSetsPredicate(new Keys.ExpressionKeys<I1>(keyExpression, input1.getType()));
 		}
 	
@@ -362,7 +365,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 				return createJoinOperator(new Keys.FieldPositionKeys<I2>(fields, input2.getType()));
 			}
 
-			public DefaultJoin<I1, I2> equalTo(String keyExpression) {
+			public DefaultJoin<I1, I2> equalTo(String... keyExpression) {
 				return createJoinOperator(new Keys.ExpressionKeys<I2>(keyExpression, input2.getType()));
 			}
 			

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/Keys.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/Keys.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 
 import eu.stratosphere.api.common.InvalidProgramException;
 import eu.stratosphere.api.java.functions.KeySelector;
+import eu.stratosphere.api.java.typeutils.PojoTypeInfo;
 import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
 import eu.stratosphere.api.java.typeutils.TypeExtractor;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -151,22 +152,60 @@ public abstract class Keys<T> {
 	
 	public static class ExpressionKeys<T> extends Keys<T> {
 
-		public ExpressionKeys(String expression, TypeInformation<T> type) {
+		private int[] logicalPositions;
+
+		private final TypeInformation<?>[] types;
+
+		private PojoTypeInfo<?> type;
+
+		public ExpressionKeys(String[] expressions, TypeInformation<T> type) {
+			if (!(type instanceof PojoTypeInfo<?>)) {
+				throw new UnsupportedOperationException("Key expressions can only be used on POJOs." + " " +
+						"These may not have a writeObject or a readObject method.");
+			}
+			PojoTypeInfo<?> pojoType = (PojoTypeInfo<?>) type;
+			this.type = pojoType;
+			logicalPositions = pojoType.getLogicalPositions(expressions);
+			types = pojoType.getTypes(expressions);
+
+			for (int i = 0; i < logicalPositions.length; i++) {
+				if (logicalPositions[i] < 0) {
+					throw new UnsupportedOperationException("Logical position of expression '"
+							+ expressions[i] + "' could not be determined.");
+				}
+			}
+
 		}
 
 		@Override
 		public int getNumberOfKeyFields() {
-			throw new UnsupportedOperationException("Expression keys not yet implemented");
+			return logicalPositions.length;
 		}
 
 		@Override
 		public boolean areCompatibale(Keys<?> other) {
-			throw new UnsupportedOperationException("Expression keys not yet implemented");
+
+			if (other instanceof ExpressionKeys) {
+				ExpressionKeys<?> oKey = (ExpressionKeys<?>) other;
+
+				if(oKey.types.length != this.types.length) {
+					return false;
+				}
+				for(int i=0; i<this.types.length; i++) {
+					if(!this.types[i].equals(oKey.types[i])) {
+						return false;
+					}
+				}
+				return true;
+
+			} else {
+				return false;
+			}
 		}
 
 		@Override
 		public int[] computeLogicalKeyPositions() {
-			throw new UnsupportedOperationException("Expression keys not yet implemented");
+			return logicalPositions;
 		}
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
@@ -85,7 +85,8 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 			
 			return translateSelectorFunctionReducer(selectorKeys, function, getInputType(), name);
 		}
-		else if (grouper.getKeys() instanceof Keys.FieldPositionKeys) {
+		else if (grouper.getKeys() instanceof Keys.FieldPositionKeys ||
+				grouper.getKeys() instanceof Keys.ExpressionKeys) {
 			int[] logicalKeyPositions = grouper.getKeys().computeLogicalKeyPositions();
 			PlanReduceOperator<IN> reduceOp = new PlanReduceOperator<IN>(function, logicalKeyPositions, name, getInputType());
 			

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/BasicTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/BasicTypeInfo.java
@@ -111,6 +111,11 @@ public class BasicTypeInfo<T> extends TypeInformation<T> implements AtomicType<T
 	public String toString() {
 		return clazz.getSimpleName();
 	}
+
+	@Override
+	public boolean isPrimitiveProduct() {
+		return true;
+	}
 	
 	// --------------------------------------------------------------------------------------------
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoField.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoField.java
@@ -14,33 +14,19 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.typeutils;
 
-import org.apache.commons.lang3.Validate;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.TypeInfo;
 
-import eu.stratosphere.api.java.tuple.Tuple;
-import eu.stratosphere.api.common.InvalidProgramException;
-import eu.stratosphere.api.common.typeutils.TypeSerializer;
-import eu.stratosphere.types.Value;
+import java.lang.reflect.Field;
 
+/**
+*
+*/
+class PojoField {
+	public Field field;
+	public TypeInformation<?> type;
 
-public abstract class TypeInformation<T> {
-	
-	public abstract boolean isBasicType();
-
-	public abstract boolean isTupleType();
-	
-	public abstract int getArity();
-	
-	public abstract Class<T> getTypeClass();
-	
-	public abstract boolean isKeyType();
-	
-	public abstract TypeSerializer<T> createSerializer();
-	
-	protected static final Log LOG = LogFactory.getLog(TypeInformation.class);
-
-	public boolean isPrimitiveProduct() {
-		return false;
+	public PojoField(Field field, TypeInformation<?> type) {
+		this.field = field;
+		this.type = type;
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/PojoTypeInfo.java
@@ -1,0 +1,173 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.typeutils;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import eu.stratosphere.api.common.typeutils.TypeComparator;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.api.java.typeutils.runtime.AvroSerializer;
+import eu.stratosphere.api.java.typeutils.runtime.PojoComparator;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+
+/**
+ *
+ */
+public class PojoTypeInfo<T> extends TypeInformation<T> implements CompositeType<T> {
+
+	private final Class<T> typeClass;
+
+	private PojoField[] fields;
+
+	public PojoTypeInfo(Class<T> typeClass, List<PojoField> fields) {
+		this.typeClass = typeClass;
+		List<PojoField> tempFields = new ArrayList<PojoField>(fields);
+		Collections.sort(tempFields, new Comparator<PojoField>() {
+			@Override
+			public int compare(PojoField o1, PojoField o2) {
+				return o1.field.getName().compareTo(o2.field.getName());
+			}
+		});
+		this.fields = tempFields.toArray(new PojoField[tempFields.size()]);
+	}
+	
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 1;
+	}
+
+	@Override
+	public Class<T> getTypeClass() {
+		return typeClass;
+	}
+
+	@Override
+	public boolean isPrimitiveProduct() {
+		for (PojoField field : fields) {
+			if (!field.type.isPrimitiveProduct()) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	@Override
+	public boolean isKeyType() {
+		return Comparable.class.isAssignableFrom(typeClass);
+	}
+
+	@Override
+	public TypeSerializer<T> createSerializer() {
+		return new AvroSerializer<T>(this.typeClass);
+	}
+
+	@Override
+	public String toString() {
+		List<String> fieldStrings = new ArrayList<String>();
+		for (PojoField field : fields) {
+			fieldStrings.add(field.field.getName() + ": " + field.type.toString());
+		}
+		return "PojoType<" + typeClass.getCanonicalName()
+				+ ", isPrimitiveProduct=" + isPrimitiveProduct()
+				+ ", fields = [" + Joiner.on(", ").join(fieldStrings) + "]"
+				+ ">";
+	}
+
+	public int getLogicalPosition(String fieldExpression) {
+		for (int i = 0; i < fields.length; i++) {
+			if (fields[i].field.getName().equals(fieldExpression)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	public int[] getLogicalPositions(String[] fieldExpression) {
+		int[] result = new int[fieldExpression.length];
+		for (int i = 0; i < fieldExpression.length; i++) {
+			result[i] = getLogicalPosition(fieldExpression[i]);
+		}
+		return result;
+	}
+
+	public TypeInformation<?> getType(String fieldExpression) {
+		for (int i = 0; i < fields.length; i++) {
+			if (fields[i].field.getName().equals(fieldExpression)) {
+				return fields[i].type;
+			}
+		}
+		return null;
+	}
+
+	public TypeInformation<?>[] getTypes(String[] fieldExpression) {
+		TypeInformation<?>[] result = new TypeInformation<?>[fieldExpression.length];
+		for (int i = 0; i < fieldExpression.length; i++) {
+			result[i] = getType(fieldExpression[i]);
+		}
+		return result;
+	}
+
+	@Override
+	public TypeComparator<T> createComparator(int[] logicalKeyFields, boolean[] orders) {
+		// sanity checks
+		if (logicalKeyFields == null || orders == null || logicalKeyFields.length != orders.length ||
+				logicalKeyFields.length > fields.length)
+		{
+			throw new IllegalArgumentException();
+		}
+
+//		if (logicalKeyFields.length == 1) {
+//			return createSinglefieldComparator(logicalKeyFields[0], orders[0], types[logicalKeyFields[0]]);
+//		}
+
+		// create the comparators for the individual fields
+		TypeComparator<?>[] fieldComparators = new TypeComparator<?>[logicalKeyFields.length];
+		Field[] keyFields = new Field[logicalKeyFields.length];
+
+		for (int i = 0; i < logicalKeyFields.length; i++) {
+			int field = logicalKeyFields[i];
+
+			if (field < 0 || field >= fields.length) {
+				throw new IllegalArgumentException("The field position " + field + " is out of range [0," + fields.length + ")");
+			}
+			if (fields[field].type.isKeyType() && fields[field].type instanceof AtomicType) {
+				fieldComparators[i] = ((AtomicType<?>) fields[field].type).createComparator(orders[i]);
+				keyFields[i] = fields[field].field;
+				keyFields[i].setAccessible(true);
+			} else {
+				throw new IllegalArgumentException("The field at position " + field + " (" + fields[field].type + ") is no atomic key type.");
+			}
+		}
+
+		return new PojoComparator<T>(logicalKeyFields, keyFields, fieldComparators);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/PojoComparator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/PojoComparator.java
@@ -1,0 +1,346 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.typeutils.runtime;
+
+import eu.stratosphere.api.common.typeutils.TypeComparator;
+import eu.stratosphere.api.java.tuple.Tuple;
+import eu.stratosphere.core.memory.DataInputView;
+import eu.stratosphere.core.memory.DataOutputView;
+import eu.stratosphere.core.memory.MemorySegment;
+import eu.stratosphere.types.KeyFieldOutOfBoundsException;
+import eu.stratosphere.types.NullKeyFieldException;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+
+
+public final class PojoComparator<T> extends TypeComparator<T> implements java.io.Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+
+	private final int[] keyPositions;
+
+	private transient Field[] keyFields;
+
+	private final TypeComparator<Object>[] comparators;
+
+	private final int[] normalizedKeyLengths;
+
+	private final int numLeadingNormalizableKeys;
+
+	private final int normalizableKeyPrefixLen;
+
+	private final boolean invertNormKey;
+
+
+	@SuppressWarnings("unchecked")
+	public PojoComparator(int[] keyPositions, Field[] keyFields, TypeComparator<?>[] comparators) {
+		this.keyPositions = keyPositions;
+		this.keyFields = keyFields;
+		this.comparators = (TypeComparator<Object>[]) comparators;
+
+		// set up auxiliary fields for normalized key support
+		this.normalizedKeyLengths = new int[keyPositions.length];
+		int nKeys = 0;
+		int nKeyLen = 0;
+		boolean inverted = false;
+
+		for (int i = 0; i < this.comparators.length; i++) {
+			TypeComparator<?> k = this.comparators[i];
+
+			// as long as the leading keys support normalized keys, we can build up the composite key
+			if (k.supportsNormalizedKey()) {
+				if (i == 0) {
+					// the first comparator decides whether we need to invert the key direction
+					inverted = k.invertNormalizedKey();
+				}
+				else if (k.invertNormalizedKey() != inverted) {
+					// if a successor does not agree on the invertion direction, it cannot be part of the normalized key
+					break;
+				}
+
+				nKeys++;
+				final int len = k.getNormalizeKeyLen();
+				if (len < 0) {
+					throw new RuntimeException("Comparator " + k.getClass().getName() + " specifies an invalid length for the normalized key: " + len);
+				}
+				this.normalizedKeyLengths[i] = len;
+				nKeyLen += this.normalizedKeyLengths[i];
+
+				if (nKeyLen < 0) {
+					// overflow, which means we are out of budget for normalized key space anyways
+					nKeyLen = Integer.MAX_VALUE;
+					break;
+				}
+			}
+			else break;
+		}
+		this.numLeadingNormalizableKeys = nKeys;
+		this.normalizableKeyPrefixLen = nKeyLen;
+		this.invertNormKey = inverted;
+	}
+
+	@SuppressWarnings("unchecked")
+	private PojoComparator(PojoComparator<T> toClone) {
+		this.keyPositions = toClone.keyPositions;
+		this.keyFields = toClone.keyFields;
+		this.comparators = new TypeComparator[toClone.comparators.length];
+		
+		for (int i = 0; i < toClone.comparators.length; i++) {
+			this.comparators[i] = toClone.comparators[i].duplicate();
+		}
+		
+		this.normalizedKeyLengths = toClone.normalizedKeyLengths;
+		this.numLeadingNormalizableKeys = toClone.numLeadingNormalizableKeys;
+		this.normalizableKeyPrefixLen = toClone.normalizableKeyPrefixLen;
+		this.invertNormKey = toClone.invertNormKey;
+	}
+
+	private void writeObject(ObjectOutputStream out)
+			throws IOException, ClassNotFoundException {
+		out.defaultWriteObject();
+		out.writeInt(keyFields.length);
+		for (Field field: keyFields) {
+			out.writeObject(field.getDeclaringClass());
+			out.writeUTF(field.getName());
+		}
+	}
+
+	private void readObject(ObjectInputStream in)
+			throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		int numKeyFields = in.readInt();
+		keyFields = new Field[numKeyFields];
+		for (int i = 0; i < numKeyFields; i++) {
+			Class<?> clazz = (Class<?>)in.readObject();
+			String fieldName = in.readUTF();
+			keyFields[i] = null;
+			// try superclasses as well
+			while (clazz != null) {
+				try {
+					keyFields[i] = clazz.getDeclaredField(fieldName);
+					keyFields[i].setAccessible(true);
+					break;
+				} catch (NoSuchFieldException e) {
+					clazz = clazz.getSuperclass();
+				}
+			}
+			if (keyFields[i] == null) {
+				throw new RuntimeException("Class resolved at TaskManager is not compatible with class read during Plan setup."
+						+ " (" + fieldName + ")");
+			}
+		}
+	}
+	
+	public int[] getKeyPositions() {
+		return this.keyPositions;
+	}
+
+	public Field[] getKeyFields() {
+		return this.keyFields;
+	}
+	
+	public TypeComparator<Object>[] getComparators() {
+		return this.comparators;
+	}
+	
+	@Override
+	public int hash(T value) {
+		int i = 0;
+		try {
+			int code = 0;
+			for (; i < this.keyPositions.length; i++) {
+				code ^= this.comparators[i].hash(this.keyFields[i].get(value));
+				code *= HASH_SALT[i & 0x1F]; // salt code with (i % HASH_SALT.length)-th salt component
+			}
+			return code;
+		}
+		catch (NullPointerException npex) {
+			throw new NullKeyFieldException(this.keyPositions[i]);
+		}
+		catch (IllegalAccessException iaex) {
+			throw new RuntimeException("This should not happen since we call setAccesssible(true) in PojoTypeInfo.");
+		}
+		catch (IndexOutOfBoundsException iobex) {
+			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+		}
+	}
+
+	@Override
+	public void setReference(T toCompare) {
+		int i = 0;
+		try {
+			for (; i < this.keyPositions.length; i++) {
+				this.comparators[i].setReference(this.keyFields[i].get(toCompare));
+			}
+		}
+		catch (NullPointerException npex) {
+			throw new NullKeyFieldException(this.keyPositions[i]);
+		}
+		catch (IllegalAccessException iaex) {
+			throw new RuntimeException("This should not happen since we call setAccesssible(true) in PojoTypeInfo.");
+		}
+		catch (IndexOutOfBoundsException iobex) {
+			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+		}
+	}
+
+	@Override
+	public boolean equalToReference(T candidate) {
+		int i = 0;
+		try {
+			for (; i < this.keyPositions.length; i++) {
+				if (!this.comparators[i].equalToReference(this.keyFields[i].get(candidate))) {
+					return false;
+				}
+			}
+			return true;
+		}
+		catch (NullPointerException npex) {
+			throw new NullKeyFieldException(this.keyPositions[i]);
+		}
+		catch (IllegalAccessException iaex) {
+			throw new RuntimeException("This should not happen since we call setAccesssible(true) in PojoTypeInfo.");
+		}
+		catch (IndexOutOfBoundsException iobex) {
+			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+		}
+	}
+
+	@Override
+	public int compareToReference(TypeComparator<T> referencedComparator) {
+		PojoComparator<T> other = (PojoComparator<T>) referencedComparator;
+		
+		int i = 0;
+		try {
+			for (; i < this.keyPositions.length; i++) {
+				int cmp = this.comparators[i].compareToReference(other.comparators[i]);
+				if (cmp != 0) {
+					return cmp;
+				}
+			}
+			return 0;
+		}
+		catch (NullPointerException npex) {
+			throw new NullKeyFieldException(this.keyPositions[i]);
+		}
+		catch (IndexOutOfBoundsException iobex) {
+			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+		}
+	}
+
+	@Override
+	public int compare(DataInputView firstSource, DataInputView secondSource) throws IOException {
+		int i = 0;
+		try {
+			for (; i < this.keyPositions.length; i++) {
+				int cmp = this.comparators[i].compare(firstSource, secondSource);
+				if (cmp != 0) {
+					return cmp;
+				}
+			}
+			return 0;
+		}
+		catch (NullPointerException npex) {
+			throw new NullKeyFieldException(this.keyPositions[i]);
+		}
+		catch (IndexOutOfBoundsException iobex) {
+			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+		}
+	}
+
+	@Override
+	public boolean supportsNormalizedKey() {
+		return this.numLeadingNormalizableKeys > 0;
+	}
+
+	@Override
+	public int getNormalizeKeyLen() {
+		return this.normalizableKeyPrefixLen;
+	}
+
+	@Override
+	public boolean isNormalizedKeyPrefixOnly(int keyBytes) {
+		return this.numLeadingNormalizableKeys < this.keyPositions.length ||
+				this.normalizableKeyPrefixLen == Integer.MAX_VALUE ||
+				this.normalizableKeyPrefixLen > keyBytes;
+	}
+
+	@Override
+	public void putNormalizedKey(T value, MemorySegment target, int offset, int numBytes) {
+		int i = 0;
+		try {
+			for (; i < this.numLeadingNormalizableKeys & numBytes > 0; i++)
+			{
+				int len = this.normalizedKeyLengths[i]; 
+				len = numBytes >= len ? len : numBytes;
+				this.comparators[i].putNormalizedKey(this.keyFields[i].get(value), target, offset, len);
+				numBytes -= len;
+				offset += len;
+			}
+		}
+		catch (IllegalAccessException iaex) {
+			throw new RuntimeException("This should not happen since we call setAccesssible(true) in PojoTypeInfo.");
+		}
+		catch (NullPointerException npex) {
+			throw new NullKeyFieldException(this.keyPositions[i]);
+		}
+	}
+
+	@Override
+	public boolean invertNormalizedKey() {
+		return this.invertNormKey;
+	}
+	
+	
+	@Override
+	public boolean supportsSerializationWithKeyNormalization() {
+		return false;
+	}
+	
+	@Override
+	public void writeWithKeyNormalization(T record, DataOutputView target) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public T readWithKeyDenormalization(T reuse, DataInputView source) throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public PojoComparator<T> duplicate() {
+		return new PojoComparator<T>(this);
+	}
+	
+	// --------------------------------------------------------------------------------------------
+	
+	/**
+	 * A sequence of prime numbers to be used for salting the computed hash values.
+	 * Based on some empirical evidence, we are using a 32-element subsequence of the  
+	 * OEIS sequence #A068652 (numbers such that every cyclic permutation is a prime).
+	 * 
+	 * @see: http://en.wikipedia.org/wiki/List_of_prime_numbers
+	 * @see: http://oeis.org/A068652
+	 */
+	private static final int[] HASH_SALT = new int[] { 
+		73   , 79   , 97   , 113  , 131  , 197  , 199  , 311   , 
+		337  , 373  , 719  , 733  , 919  , 971  , 991  , 1193  , 
+		1931 , 3119 , 3779 , 7793 , 7937 , 9311 , 9377 , 11939 , 
+		19391, 19937, 37199, 39119, 71993, 91193, 93719, 93911 };
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/PojoPairComparator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/PojoPairComparator.java
@@ -1,0 +1,148 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.typeutils.runtime;
+
+import eu.stratosphere.api.common.typeutils.TypeComparator;
+import eu.stratosphere.api.common.typeutils.TypePairComparator;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+
+
+public class PojoPairComparator<T1, T2> extends TypePairComparator<T1, T2> implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int[] keyPositions1, keyPositions2;
+	private transient Field[] keyFields1, keyFields2;
+	private final TypeComparator<Object>[] comparators1;
+	private final TypeComparator<Object>[] comparators2;
+
+	@SuppressWarnings("unchecked")
+	public PojoPairComparator(int[] keyPositions1, Field[] keyFields1, int[] keyPositions2, Field[] keyFields2, TypeComparator<Object>[] comparators1, TypeComparator<Object>[] comparators2) {
+		
+		if(keyPositions1.length != keyPositions2.length
+			|| keyPositions1.length != comparators1.length
+			|| keyPositions2.length != comparators2.length) {
+			
+			throw new IllegalArgumentException("Number of key fields and comparators differ.");
+		}
+		
+		int numKeys = keyPositions1.length;
+		
+		this.keyPositions1 = keyPositions1;
+		this.keyPositions2 = keyPositions2;
+		this.keyFields1 = keyFields1;
+		this.keyFields2 = keyFields2;
+		this.comparators1 = new TypeComparator[numKeys];
+		this.comparators2 = new TypeComparator[numKeys];
+		
+		for(int i = 0; i < numKeys; i++) {
+			this.comparators1[i] = comparators1[i].duplicate();
+			this.comparators2[i] = comparators2[i].duplicate();
+		}
+	}
+
+	private void writeObject(ObjectOutputStream out)
+			throws IOException, ClassNotFoundException {
+		out.defaultWriteObject();
+		out.writeInt(keyFields1.length);
+		for (Field field: keyFields1) {
+			out.writeObject(field.getDeclaringClass());
+			out.writeUTF(field.getName());
+		}
+		out.writeInt(keyFields2.length);
+		for (Field field: keyFields2) {
+			out.writeObject(field.getDeclaringClass());
+			out.writeUTF(field.getName());
+		}
+	}
+
+	private void readObject(ObjectInputStream in)
+			throws IOException, ClassNotFoundException {
+		in.defaultReadObject();
+		int numKeyFields = in.readInt();
+		keyFields1 = new Field[numKeyFields];
+		for (int i = 0; i < numKeyFields; i++) {
+			Class<?> clazz = (Class<?>)in.readObject();
+			String fieldName = in.readUTF();
+			try {
+				keyFields1[i] = clazz.getField(fieldName);
+				keyFields1[i].setAccessible(true);
+			} catch (NoSuchFieldException e) {
+				throw new RuntimeException("Class resolved at TaskManager is not compatible with class read during Plan setup.");
+			}
+		}
+		numKeyFields = in.readInt();
+		keyFields2 = new Field[numKeyFields];
+		for (int i = 0; i < numKeyFields; i++) {
+			Class<?> clazz = (Class<?>)in.readObject();
+			String fieldName = in.readUTF();
+			try {
+				keyFields2[i] = clazz.getField(fieldName);
+				keyFields2[i].setAccessible(true);
+			} catch (NoSuchFieldException e) {
+				throw new RuntimeException("Class resolved at TaskManager is not compatible with class read during Plan setup.");
+			}
+		}
+	}
+	
+	@Override
+	public void setReference(T1 reference) {
+		for(int i=0; i < this.comparators1.length; i++) {
+			try {
+				this.comparators1[i].setReference(keyFields1[i].get(reference));
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException("This should not happen since we call setAccesssible(true) in PojoTypeInfo.");
+			}
+		}
+	}
+
+	@Override
+	public boolean equalToReference(T2 candidate) {
+		for(int i=0; i < this.comparators1.length; i++) {
+			try {
+				if(!this.comparators1[i].equalToReference(keyFields2[i].get(candidate))) {
+					return false;
+				}
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException("Class resolved at TaskManager is not compatible with class read during Plan setup.");
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public int compareToReference(T2 candidate) {
+		for(int i=0; i < this.comparators1.length; i++) {
+			try {
+				this.comparators2[i].setReference(keyFields2[i].get(candidate));
+			} catch (IllegalAccessException e) {
+				throw new RuntimeException("Class resolved at TaskManager is not compatible with class read during Plan setup.");
+			}
+			int res = this.comparators1[i].compareToReference(this.comparators2[i]);
+			if(res != 0) {
+				return res;
+			}
+		}
+		return 0;
+	}
+
+	
+	
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/RuntimePairComparatorFactory.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/RuntimePairComparatorFactory.java
@@ -40,6 +40,17 @@ public final class RuntimePairComparatorFactory<T1, T2> implements TypePairCompa
 					tupleComp1.getComparators(), tupleComp2.getComparators());
 		}
 
+		if((comparator1 instanceof PojoComparator) && (comparator2 instanceof PojoComparator)) {
+
+			PojoComparator<?> pojoComp1 = ((PojoComparator<?>)comparator1);
+			PojoComparator<?> pojoComp2 = ((PojoComparator<?>)comparator2);
+
+			return (TypePairComparator<T1, T2>) new PojoPairComparator<Tuple, Tuple>(
+					pojoComp1.getKeyPositions(), pojoComp1.getKeyFields(),
+					pojoComp2.getKeyPositions(), pojoComp2.getKeyFields(),
+					pojoComp1.getComparators(), pojoComp2.getComparators());
+		}
+
 		if((comparator1 instanceof TupleSingleFieldComparator) && (comparator2 instanceof TupleSingleFieldComparator)) {
 
 			TupleSingleFieldComparator<?,? extends Object> tupleComp1 = ((TupleSingleFieldComparator<?,? extends Object>)comparator1);
@@ -68,6 +79,16 @@ public final class RuntimePairComparatorFactory<T1, T2> implements TypePairCompa
 			return (TypePairComparator<T2, T1>) new TuplePairComparator<Tuple, Tuple>(
 					tupleComp2.getKeyPositions(), tupleComp1.getKeyPositions(),
 					tupleComp2.getComparators(), tupleComp1.getComparators());
+		}
+		if((comparator1 instanceof PojoComparator) && (comparator2 instanceof PojoComparator)) {
+
+			PojoComparator<?> pojoComp1 = ((PojoComparator<?>)comparator1);
+			PojoComparator<?> pojoComp2 = ((PojoComparator<?>)comparator2);
+
+			return (TypePairComparator<T2, T1>) new PojoPairComparator<Tuple, Tuple>(
+					pojoComp2.getKeyPositions(), pojoComp2.getKeyFields(),
+					pojoComp1.getKeyPositions(), pojoComp1.getKeyFields(),
+					pojoComp2.getComparators(), pojoComp1.getComparators());
 		}
 		if((comparator1 instanceof TupleSingleFieldComparator) && (comparator2 instanceof TupleSingleFieldComparator)) {
 


### PR DESCRIPTION
This enables code like:

``` java
class WC {
    public String word;
    public int count;
}
...
DataSet<WC> result = tokenized
        .groupBy("word")
        .reduce(new ReduceFunction<WC>() {
            public WC reduce(WC value1, WC value2) {
                return new WC(value1.word, value1.count + value2.count);
            }
        });
```
