### PR TITLE
added annotation support for new java api

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
@@ -15,8 +15,14 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCoGrouper;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CoGroupOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CoGroupFunction;
+import eu.stratosphere.api.java.functions.GroupReduceFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCogroupOperator<IN1, IN2, OUT> 
@@ -35,6 +41,10 @@ public class PlanCogroupOperator<IN1, IN2, OUT>
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
+		
+		UserCodeWrapper<CoGroupFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CoGroupFunction<IN1, IN2, OUT>>(udf);
+        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        setSemanticProperties(sp);
 	}
 
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
@@ -15,8 +15,14 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCrosser;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CrossFunction;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCrossOperator<IN1, IN2, OUT> 
@@ -38,6 +44,9 @@ public class PlanCrossOperator<IN1, IN2, OUT>
 		this.inType2 = inType2;
 		this.outType = outType;
 		
+		UserCodeWrapper<CrossFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CrossFunction<IN1, IN2, OUT>>(udf);
+        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        setSemanticProperties(sp);	
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -15,8 +15,12 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericFlatMap;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -34,6 +38,10 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
+		
+		UserCodeWrapper<FlatMapFunction<T, O>> tmp = new UserCodeObjectWrapper<FlatMapFunction<T,O>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);		
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -38,6 +43,10 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 		
 		this.inType = inputType;
 		this.outType = outputType;
+		
+		UserCodeWrapper<GroupReduceFunction<IN, OUT>> tmp = new UserCodeObjectWrapper<GroupReduceFunction<IN, OUT>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);
 	}
 	
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericJoiner;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.CrossFunction;
 import eu.stratosphere.api.java.functions.JoinFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanJoinOperator<IN1, IN2, OUT> 
@@ -35,6 +40,10 @@ public class PlanJoinOperator<IN1, IN2, OUT>
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
+		
+		UserCodeWrapper<JoinFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<JoinFunction<IN1, IN2, OUT>>(udf);
+        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        setSemanticProperties(sp);
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericMap;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -35,6 +40,10 @@ public class PlanMapOperator<T, O> extends PlainMapOperatorBase<GenericMap<T, O>
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
+		
+		UserCodeWrapper<MapFunction<T, O>> tmp = new UserCodeObjectWrapper<MapFunction<T,O>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);	
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.ReduceFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -32,6 +37,9 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type) {
 		super(udf, logicalGroupingFields, name);
 		this.type = type;
+		UserCodeWrapper<ReduceFunction<T>> tmp = new UserCodeObjectWrapper<ReduceFunction<T>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);	
 	}
 	
 	


### PR DESCRIPTION
The operators now read the annotations and wrap them in semanticproperties. This implementation should work fine for operator implementation which use tuples. 
