### PR TITLE
JDBC In-Outputformat for new API

### DIFF
--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormat.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormat.java
@@ -1,0 +1,336 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.io.jdbc;
+
+import eu.stratosphere.api.common.io.InputFormat;
+import eu.stratosphere.api.common.io.statistics.BaseStatistics;
+import eu.stratosphere.api.java.tuple.Tuple;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.core.io.GenericInputSplit;
+import eu.stratosphere.core.io.InputSplit;
+import eu.stratosphere.types.NullValue;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * InputFormat to read data from a database and generate tuples.
+ * The InputFormat has to be configured using the supplied InputFormatBuilder.
+ * 
+ * @param <OUT>
+ * @see Tuple
+ * @see DriverManager
+ */
+public class JDBCInputFormat<OUT extends Tuple> implements InputFormat<OUT, InputSplit> {
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("unused")
+    private static final Log LOG = LogFactory.getLog(JDBCInputFormat.class);
+
+    private String username;
+    private String password;
+    private String drivername;
+    private String dbURL;
+    private String query;
+
+    private transient Connection dbConn;
+    private transient Statement statement;
+    private transient ResultSet resultSet;
+    private transient ResultSetMetaData resultSetMetaData;
+
+    public JDBCInputFormat() {
+    }
+
+    @Override
+    public void configure(Configuration parameters) {
+    }
+
+    /**
+     * Connects to the source database and executes the query.
+     *
+     * @param ignored
+     * @throws IOException
+     */
+    @Override
+    public void open(InputSplit ignored) throws IOException {
+        try {
+            establishConnection();
+            statement = dbConn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+            resultSet = statement.executeQuery(query);
+            resultSetMetaData = resultSet.getMetaData();
+        } catch (SQLException se) {
+            close();
+            throw new IllegalArgumentException("open() failed." + se.getMessage(), se);
+        } catch (ClassNotFoundException cnfe) {
+            throw new IllegalArgumentException("JDBC-Class not found. - " + cnfe.getMessage(), cnfe);
+        }
+    }
+
+    private void establishConnection() throws SQLException, ClassNotFoundException {
+        Class.forName(drivername);
+        if (username == null) {
+            dbConn = DriverManager.getConnection(dbURL);
+        } else {
+            dbConn = DriverManager.getConnection(dbURL, username, password);
+        }
+    }
+
+    /**
+     * Closes all resources used.
+     *
+     * @throws IOException Indicates that a resource could not be closed.
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            resultSet.close();
+        } catch (SQLException se) {
+            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        }
+        try {
+            statement.close();
+        } catch (SQLException se) {
+            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        }
+        try {
+            dbConn.close();
+        } catch (SQLException se) {
+            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        }
+    }
+
+    /**
+     * Checks whether all data has been read.
+     *
+     * @return boolean value indication whether all data has been read.
+     * @throws IOException
+     */
+    @Override
+    public boolean reachedEnd() throws IOException {
+        try {
+            if (resultSet.isLast()) {
+                close();
+                return true;
+            }
+            return false;
+        } catch (SQLException se) {
+            throw new IOException("Couldn't evaluate reachedEnd() - " + se.getMessage(), se);
+        }
+    }
+
+    /**
+     * Stores the next resultSet row in a tuple
+     *
+     * @param tuple
+     * @return tuple containing next row
+     * @throws java.io.IOException
+     */
+    @Override
+    public OUT nextRecord(OUT tuple) throws IOException {
+        try {
+            resultSet.next();
+            int column_count = resultSetMetaData.getColumnCount();
+
+            for (int pos = 0; pos < column_count; pos++) {
+                int type = resultSetMetaData.getColumnType(pos + 1);
+                addValue(pos, type, tuple);
+            }
+            return tuple;
+        } catch (SQLException se) {
+            close();
+            throw new IOException("Couldn't read data - " + se.getMessage(), se);
+        } catch (NullPointerException npe) {
+            close();
+            throw new IOException("Couldn't access resultSet", npe);
+        }
+    }
+
+    /**
+     * Enters data value from the current resultSet into a Record.
+     *
+     * @param pos Tuple position to be set.
+     * @param type SQL type of the resultSet value.
+     * @param reuse Target Record.
+     */
+    private void addValue(int pos, int type, OUT reuse) throws SQLException {
+        switch (type) {
+            case java.sql.Types.NULL:
+                reuse.setField(NullValue.getInstance(), pos);
+                break;
+            case java.sql.Types.BOOLEAN:
+                reuse.setField(resultSet.getBoolean(pos + 1), pos);
+                break;
+            case java.sql.Types.BIT:
+                reuse.setField(resultSet.getBoolean(pos + 1), pos);
+                break;
+            case java.sql.Types.CHAR:
+                reuse.setField(resultSet.getString(pos + 1), pos);
+                break;
+            case java.sql.Types.NCHAR:
+                reuse.setField(resultSet.getString(pos + 1), pos);
+                break;
+            case java.sql.Types.VARCHAR:
+                reuse.setField(resultSet.getString(pos + 1), pos);
+                break;
+            case java.sql.Types.LONGVARCHAR:
+                reuse.setField(resultSet.getString(pos + 1), pos);
+                break;
+            case java.sql.Types.LONGNVARCHAR:
+                reuse.setField(resultSet.getString(pos + 1), pos);
+                break;
+            case java.sql.Types.TINYINT:
+                reuse.setField(resultSet.getShort(pos + 1), pos);
+                break;
+            case java.sql.Types.SMALLINT:
+                reuse.setField(resultSet.getShort(pos + 1), pos);
+                break;
+            case java.sql.Types.BIGINT:
+                reuse.setField(resultSet.getLong(pos + 1), pos);
+                break;
+            case java.sql.Types.INTEGER:
+                reuse.setField(resultSet.getInt(pos + 1), pos);
+                break;
+            case java.sql.Types.FLOAT:
+                reuse.setField(resultSet.getDouble(pos + 1), pos);
+                break;
+            case java.sql.Types.REAL:
+                reuse.setField(resultSet.getFloat(pos + 1), pos);
+                break;
+            case java.sql.Types.DOUBLE:
+                reuse.setField(resultSet.getDouble(pos + 1), pos);
+                break;
+            case java.sql.Types.DECIMAL:
+                reuse.setField(resultSet.getBigDecimal(pos + 1).doubleValue(), pos);
+                break;
+            case java.sql.Types.NUMERIC:
+                reuse.setField(resultSet.getBigDecimal(pos + 1).doubleValue(), pos);
+                break;
+            case java.sql.Types.DATE:
+                reuse.setField(resultSet.getDate(pos + 1).toString(), pos);
+                break;
+            case java.sql.Types.TIME:
+                reuse.setField(resultSet.getTime(pos + 1).getTime(), pos);
+                break;
+            case java.sql.Types.TIMESTAMP:
+                reuse.setField(resultSet.getTimestamp(pos + 1).toString(), pos);
+                break;
+            case java.sql.Types.SQLXML:
+                reuse.setField(resultSet.getSQLXML(pos + 1).toString(), pos);
+                break;
+            default:
+                throw new SQLException("Unsupported sql-type [" + type + "] on column [" + pos + "]");
+
+            // case java.sql.Types.BINARY:
+            // case java.sql.Types.VARBINARY:
+            // case java.sql.Types.LONGVARBINARY:
+            // case java.sql.Types.ARRAY:
+            // case java.sql.Types.JAVA_OBJECT:
+            // case java.sql.Types.BLOB:
+            // case java.sql.Types.CLOB:
+            // case java.sql.Types.NCLOB:
+            // case java.sql.Types.DATALINK:
+            // case java.sql.Types.DISTINCT:
+            // case java.sql.Types.OTHER:
+            // case java.sql.Types.REF:
+            // case java.sql.Types.ROWID:
+            // case java.sql.Types.STRUCT:
+        }
+    }
+
+    @Override
+    public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
+        return cachedStatistics;
+    }
+
+    @Override
+    public InputSplit[] createInputSplits(int minNumSplits) throws IOException {
+        GenericInputSplit[] split = {
+            new GenericInputSplit(0, 1)
+        };
+        return split;
+    }
+
+    @Override
+    public Class<? extends InputSplit> getInputSplitType() {
+        return GenericInputSplit.class;
+    }
+
+    /**
+     * A builder used to set parameters to the output format's configuration in a fluent way.
+     * @return builder
+     */
+    public static JDBCInputFormatBuilder buildJDBCInputFormat() {
+        return new JDBCInputFormatBuilder();
+    }
+
+    public static class JDBCInputFormatBuilder {
+        private final JDBCInputFormat format;
+
+        public JDBCInputFormatBuilder() {
+            this.format = new JDBCInputFormat();
+        }
+
+        public JDBCInputFormatBuilder setUsername(String username) {
+            format.username = username;
+            return this;
+        }
+
+        public JDBCInputFormatBuilder setPassword(String password) {
+            format.password = password;
+            return this;
+        }
+
+        public JDBCInputFormatBuilder setDrivername(String drivername) {
+            format.drivername = drivername;
+            return this;
+        }
+
+        public JDBCInputFormatBuilder setDBUrl(String dbURL) {
+            format.dbURL = dbURL;
+            return this;
+        }
+
+        public JDBCInputFormatBuilder setQuery(String query) {
+            format.query = query;
+            return this;
+        }
+
+        public JDBCInputFormat finish() {
+            if (format.username == null) {
+                LOG.info("Username was not supplied separately.");
+            }
+            if (format.password == null) {
+                LOG.info("Password was not supplied separately.");
+            }
+            if (format.dbURL == null) {
+                throw new IllegalArgumentException("No dababase URL supplied.");
+            }
+            if (format.query == null) {
+                throw new IllegalArgumentException("No query suplied");
+            }
+            if (format.drivername == null) {
+                throw new IllegalArgumentException("No driver supplied");
+            }
+            return format;
+        }
+    }
+
+}

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormat.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormat.java
@@ -104,16 +104,19 @@ public class JDBCInputFormat<OUT extends Tuple> implements InputFormat<OUT, Inpu
             resultSet.close();
         } catch (SQLException se) {
             LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        } catch (NullPointerException npe) {
         }
         try {
             statement.close();
         } catch (SQLException se) {
             LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        } catch (NullPointerException npe) {
         }
         try {
             dbConn.close();
         } catch (SQLException se) {
             LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        } catch (NullPointerException npe) {
         }
     }
 
@@ -165,6 +168,7 @@ public class JDBCInputFormat<OUT extends Tuple> implements InputFormat<OUT, Inpu
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
         columnTypes = new int[resultSetMetaData.getColumnCount()];
         if (tuple.getArity() != columnTypes.length) {
+            close();
             throw new IOException("Tuple size does not match columncount");
         }
         for (int pos = 0; pos < columnTypes.length; pos++) {
@@ -248,7 +252,7 @@ public class JDBCInputFormat<OUT extends Tuple> implements InputFormat<OUT, Inpu
                 default:
                     throw new SQLException("Unsupported sql-type [" + columnTypes[pos] + "] on column [" + pos + "]");
 
-            // case java.sql.Types.BINARY:
+                // case java.sql.Types.BINARY:
                 // case java.sql.Types.VARBINARY:
                 // case java.sql.Types.LONGVARBINARY:
                 // case java.sql.Types.ARRAY:

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormat.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormat.java
@@ -40,312 +40,312 @@ import org.apache.commons.logging.LogFactory;
  * @see DriverManager
  */
 public class JDBCInputFormat<OUT extends Tuple> implements InputFormat<OUT, InputSplit> {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unused")
-    private static final Log LOG = LogFactory.getLog(JDBCInputFormat.class);
+	@SuppressWarnings("unused")
+	private static final Log LOG = LogFactory.getLog(JDBCInputFormat.class);
 
-    private String username;
-    private String password;
-    private String drivername;
-    private String dbURL;
-    private String query;
+	private String username;
+	private String password;
+	private String drivername;
+	private String dbURL;
+	private String query;
 
-    private transient Connection dbConn;
-    private transient Statement statement;
-    private transient ResultSet resultSet;
+	private transient Connection dbConn;
+	private transient Statement statement;
+	private transient ResultSet resultSet;
 
-    private int[] columnTypes = null;
+	private int[] columnTypes = null;
 
-    public JDBCInputFormat() {
-    }
+	public JDBCInputFormat() {
+	}
 
-    @Override
-    public void configure(Configuration parameters) {
-    }
+	@Override
+	public void configure(Configuration parameters) {
+	}
 
-    /**
-     * Connects to the source database and executes the query.
-     *
-     * @param ignored
-     * @throws IOException
-     */
-    @Override
-    public void open(InputSplit ignored) throws IOException {
-        try {
-            establishConnection();
-            statement = dbConn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-            resultSet = statement.executeQuery(query);
-        } catch (SQLException se) {
-            close();
-            throw new IllegalArgumentException("open() failed." + se.getMessage(), se);
-        } catch (ClassNotFoundException cnfe) {
-            throw new IllegalArgumentException("JDBC-Class not found. - " + cnfe.getMessage(), cnfe);
-        }
-    }
+	/**
+	 * Connects to the source database and executes the query.
+	 *
+	 * @param ignored
+	 * @throws IOException
+	 */
+	@Override
+	public void open(InputSplit ignored) throws IOException {
+		try {
+			establishConnection();
+			statement = dbConn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			resultSet = statement.executeQuery(query);
+		} catch (SQLException se) {
+			close();
+			throw new IllegalArgumentException("open() failed." + se.getMessage(), se);
+		} catch (ClassNotFoundException cnfe) {
+			throw new IllegalArgumentException("JDBC-Class not found. - " + cnfe.getMessage(), cnfe);
+		}
+	}
 
-    private void establishConnection() throws SQLException, ClassNotFoundException {
-        Class.forName(drivername);
-        if (username == null) {
-            dbConn = DriverManager.getConnection(dbURL);
-        } else {
-            dbConn = DriverManager.getConnection(dbURL, username, password);
-        }
-    }
+	private void establishConnection() throws SQLException, ClassNotFoundException {
+		Class.forName(drivername);
+		if (username == null) {
+			dbConn = DriverManager.getConnection(dbURL);
+		} else {
+			dbConn = DriverManager.getConnection(dbURL, username, password);
+		}
+	}
 
-    /**
-     * Closes all resources used.
-     *
-     * @throws IOException Indicates that a resource could not be closed.
-     */
-    @Override
-    public void close() throws IOException {
-        try {
-            resultSet.close();
-        } catch (SQLException se) {
-            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-        } catch (NullPointerException npe) {
-        }
-        try {
-            statement.close();
-        } catch (SQLException se) {
-            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-        } catch (NullPointerException npe) {
-        }
-        try {
-            dbConn.close();
-        } catch (SQLException se) {
-            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-        } catch (NullPointerException npe) {
-        }
-    }
+	/**
+	 * Closes all resources used.
+	 *
+	 * @throws IOException Indicates that a resource could not be closed.
+	 */
+	@Override
+	public void close() throws IOException {
+		try {
+			resultSet.close();
+		} catch (SQLException se) {
+			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+		} catch (NullPointerException npe) {
+		}
+		try {
+			statement.close();
+		} catch (SQLException se) {
+			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+		} catch (NullPointerException npe) {
+		}
+		try {
+			dbConn.close();
+		} catch (SQLException se) {
+			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+		} catch (NullPointerException npe) {
+		}
+	}
 
-    /**
-     * Checks whether all data has been read.
-     *
-     * @return boolean value indication whether all data has been read.
-     * @throws IOException
-     */
-    @Override
-    public boolean reachedEnd() throws IOException {
-        try {
-            if (resultSet.isLast()) {
-                close();
-                return true;
-            }
-            return false;
-        } catch (SQLException se) {
-            throw new IOException("Couldn't evaluate reachedEnd() - " + se.getMessage(), se);
-        }
-    }
+	/**
+	 * Checks whether all data has been read.
+	 *
+	 * @return boolean value indication whether all data has been read.
+	 * @throws IOException
+	 */
+	@Override
+	public boolean reachedEnd() throws IOException {
+		try {
+			if (resultSet.isLast()) {
+				close();
+				return true;
+			}
+			return false;
+		} catch (SQLException se) {
+			throw new IOException("Couldn't evaluate reachedEnd() - " + se.getMessage(), se);
+		}
+	}
 
-    /**
-     * Stores the next resultSet row in a tuple
-     *
-     * @param tuple
-     * @return tuple containing next row
-     * @throws java.io.IOException
-     */
-    @Override
-    public OUT nextRecord(OUT tuple) throws IOException {
-        try {
-            resultSet.next();
-            if (columnTypes == null) {
-                extractTypes(tuple);
-            }
-            addValue(tuple);
-            return tuple;
-        } catch (SQLException se) {
-            close();
-            throw new IOException("Couldn't read data - " + se.getMessage(), se);
-        } catch (NullPointerException npe) {
-            close();
-            throw new IOException("Couldn't access resultSet", npe);
-        }
-    }
+	/**
+	 * Stores the next resultSet row in a tuple
+	 *
+	 * @param tuple
+	 * @return tuple containing next row
+	 * @throws java.io.IOException
+	 */
+	@Override
+	public OUT nextRecord(OUT tuple) throws IOException {
+		try {
+			resultSet.next();
+			if (columnTypes == null) {
+				extractTypes(tuple);
+			}
+			addValue(tuple);
+			return tuple;
+		} catch (SQLException se) {
+			close();
+			throw new IOException("Couldn't read data - " + se.getMessage(), se);
+		} catch (NullPointerException npe) {
+			close();
+			throw new IOException("Couldn't access resultSet", npe);
+		}
+	}
 
-    private void extractTypes(OUT tuple) throws SQLException, IOException {
-        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
-        columnTypes = new int[resultSetMetaData.getColumnCount()];
-        if (tuple.getArity() != columnTypes.length) {
-            close();
-            throw new IOException("Tuple size does not match columncount");
-        }
-        for (int pos = 0; pos < columnTypes.length; pos++) {
-            columnTypes[pos] = resultSetMetaData.getColumnType(pos + 1);
-        }
-    }
+	private void extractTypes(OUT tuple) throws SQLException, IOException {
+		ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+		columnTypes = new int[resultSetMetaData.getColumnCount()];
+		if (tuple.getArity() != columnTypes.length) {
+			close();
+			throw new IOException("Tuple size does not match columncount");
+		}
+		for (int pos = 0; pos < columnTypes.length; pos++) {
+			columnTypes[pos] = resultSetMetaData.getColumnType(pos + 1);
+		}
+	}
 
-    /**
-     * Enters data value from the current resultSet into a Record.
-     *
-     * @param pos Tuple position to be set.
-     * @param type SQL type of the resultSet value.
-     * @param reuse Target Record.
-     */
-    private void addValue(OUT reuse) throws SQLException {
-        for (int pos = 0; pos < columnTypes.length; pos++) {
-            switch (columnTypes[pos]) {
-                case java.sql.Types.NULL:
-                    reuse.setField(NullValue.getInstance(), pos);
-                    break;
-                case java.sql.Types.BOOLEAN:
-                    reuse.setField(resultSet.getBoolean(pos + 1), pos);
-                    break;
-                case java.sql.Types.BIT:
-                    reuse.setField(resultSet.getBoolean(pos + 1), pos);
-                    break;
-                case java.sql.Types.CHAR:
-                    reuse.setField(resultSet.getString(pos + 1), pos);
-                    break;
-                case java.sql.Types.NCHAR:
-                    reuse.setField(resultSet.getString(pos + 1), pos);
-                    break;
-                case java.sql.Types.VARCHAR:
-                    reuse.setField(resultSet.getString(pos + 1), pos);
-                    break;
-                case java.sql.Types.LONGVARCHAR:
-                    reuse.setField(resultSet.getString(pos + 1), pos);
-                    break;
-                case java.sql.Types.LONGNVARCHAR:
-                    reuse.setField(resultSet.getString(pos + 1), pos);
-                    break;
-                case java.sql.Types.TINYINT:
-                    reuse.setField(resultSet.getShort(pos + 1), pos);
-                    break;
-                case java.sql.Types.SMALLINT:
-                    reuse.setField(resultSet.getShort(pos + 1), pos);
-                    break;
-                case java.sql.Types.BIGINT:
-                    reuse.setField(resultSet.getLong(pos + 1), pos);
-                    break;
-                case java.sql.Types.INTEGER:
-                    reuse.setField(resultSet.getInt(pos + 1), pos);
-                    break;
-                case java.sql.Types.FLOAT:
-                    reuse.setField(resultSet.getDouble(pos + 1), pos);
-                    break;
-                case java.sql.Types.REAL:
-                    reuse.setField(resultSet.getFloat(pos + 1), pos);
-                    break;
-                case java.sql.Types.DOUBLE:
-                    reuse.setField(resultSet.getDouble(pos + 1), pos);
-                    break;
-                case java.sql.Types.DECIMAL:
-                    reuse.setField(resultSet.getBigDecimal(pos + 1).doubleValue(), pos);
-                    break;
-                case java.sql.Types.NUMERIC:
-                    reuse.setField(resultSet.getBigDecimal(pos + 1).doubleValue(), pos);
-                    break;
-                case java.sql.Types.DATE:
-                    reuse.setField(resultSet.getDate(pos + 1).toString(), pos);
-                    break;
-                case java.sql.Types.TIME:
-                    reuse.setField(resultSet.getTime(pos + 1).getTime(), pos);
-                    break;
-                case java.sql.Types.TIMESTAMP:
-                    reuse.setField(resultSet.getTimestamp(pos + 1).toString(), pos);
-                    break;
-                case java.sql.Types.SQLXML:
-                    reuse.setField(resultSet.getSQLXML(pos + 1).toString(), pos);
-                    break;
-                default:
-                    throw new SQLException("Unsupported sql-type [" + columnTypes[pos] + "] on column [" + pos + "]");
+	/**
+	 * Enters data value from the current resultSet into a Record.
+	 *
+	 * @param pos Tuple position to be set.
+	 * @param type SQL type of the resultSet value.
+	 * @param reuse Target Record.
+	 */
+	private void addValue(OUT reuse) throws SQLException {
+		for (int pos = 0; pos < columnTypes.length; pos++) {
+			switch (columnTypes[pos]) {
+				case java.sql.Types.NULL:
+					reuse.setField(NullValue.getInstance(), pos);
+					break;
+				case java.sql.Types.BOOLEAN:
+					reuse.setField(resultSet.getBoolean(pos + 1), pos);
+					break;
+				case java.sql.Types.BIT:
+					reuse.setField(resultSet.getBoolean(pos + 1), pos);
+					break;
+				case java.sql.Types.CHAR:
+					reuse.setField(resultSet.getString(pos + 1), pos);
+					break;
+				case java.sql.Types.NCHAR:
+					reuse.setField(resultSet.getString(pos + 1), pos);
+					break;
+				case java.sql.Types.VARCHAR:
+					reuse.setField(resultSet.getString(pos + 1), pos);
+					break;
+				case java.sql.Types.LONGVARCHAR:
+					reuse.setField(resultSet.getString(pos + 1), pos);
+					break;
+				case java.sql.Types.LONGNVARCHAR:
+					reuse.setField(resultSet.getString(pos + 1), pos);
+					break;
+				case java.sql.Types.TINYINT:
+					reuse.setField(resultSet.getShort(pos + 1), pos);
+					break;
+				case java.sql.Types.SMALLINT:
+					reuse.setField(resultSet.getShort(pos + 1), pos);
+					break;
+				case java.sql.Types.BIGINT:
+					reuse.setField(resultSet.getLong(pos + 1), pos);
+					break;
+				case java.sql.Types.INTEGER:
+					reuse.setField(resultSet.getInt(pos + 1), pos);
+					break;
+				case java.sql.Types.FLOAT:
+					reuse.setField(resultSet.getDouble(pos + 1), pos);
+					break;
+				case java.sql.Types.REAL:
+					reuse.setField(resultSet.getFloat(pos + 1), pos);
+					break;
+				case java.sql.Types.DOUBLE:
+					reuse.setField(resultSet.getDouble(pos + 1), pos);
+					break;
+				case java.sql.Types.DECIMAL:
+					reuse.setField(resultSet.getBigDecimal(pos + 1).doubleValue(), pos);
+					break;
+				case java.sql.Types.NUMERIC:
+					reuse.setField(resultSet.getBigDecimal(pos + 1).doubleValue(), pos);
+					break;
+				case java.sql.Types.DATE:
+					reuse.setField(resultSet.getDate(pos + 1).toString(), pos);
+					break;
+				case java.sql.Types.TIME:
+					reuse.setField(resultSet.getTime(pos + 1).getTime(), pos);
+					break;
+				case java.sql.Types.TIMESTAMP:
+					reuse.setField(resultSet.getTimestamp(pos + 1).toString(), pos);
+					break;
+				case java.sql.Types.SQLXML:
+					reuse.setField(resultSet.getSQLXML(pos + 1).toString(), pos);
+					break;
+				default:
+					throw new SQLException("Unsupported sql-type [" + columnTypes[pos] + "] on column [" + pos + "]");
 
                 // case java.sql.Types.BINARY:
-                // case java.sql.Types.VARBINARY:
-                // case java.sql.Types.LONGVARBINARY:
-                // case java.sql.Types.ARRAY:
-                // case java.sql.Types.JAVA_OBJECT:
-                // case java.sql.Types.BLOB:
-                // case java.sql.Types.CLOB:
-                // case java.sql.Types.NCLOB:
-                // case java.sql.Types.DATALINK:
-                // case java.sql.Types.DISTINCT:
-                // case java.sql.Types.OTHER:
-                // case java.sql.Types.REF:
-                // case java.sql.Types.ROWID:
-                // case java.sql.Types.STRUCT:
-            }
-        }
-    }
+				// case java.sql.Types.VARBINARY:
+				// case java.sql.Types.LONGVARBINARY:
+				// case java.sql.Types.ARRAY:
+				// case java.sql.Types.JAVA_OBJECT:
+				// case java.sql.Types.BLOB:
+				// case java.sql.Types.CLOB:
+				// case java.sql.Types.NCLOB:
+				// case java.sql.Types.DATALINK:
+				// case java.sql.Types.DISTINCT:
+				// case java.sql.Types.OTHER:
+				// case java.sql.Types.REF:
+				// case java.sql.Types.ROWID:
+				// case java.sql.Types.STRUCT:
+			}
+		}
+	}
 
-    @Override
-    public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
-        return cachedStatistics;
-    }
+	@Override
+	public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
+		return cachedStatistics;
+	}
 
-    @Override
-    public InputSplit[] createInputSplits(int minNumSplits) throws IOException {
-        GenericInputSplit[] split = {
-            new GenericInputSplit(0, 1)
-        };
-        return split;
-    }
+	@Override
+	public InputSplit[] createInputSplits(int minNumSplits) throws IOException {
+		GenericInputSplit[] split = {
+			new GenericInputSplit(0, 1)
+		};
+		return split;
+	}
 
-    @Override
-    public Class<? extends InputSplit> getInputSplitType() {
-        return GenericInputSplit.class;
-    }
+	@Override
+	public Class<? extends InputSplit> getInputSplitType() {
+		return GenericInputSplit.class;
+	}
 
-    /**
-     * A builder used to set parameters to the output format's configuration in a fluent way.
-     * @return builder
-     */
-    public static JDBCInputFormatBuilder buildJDBCInputFormat() {
-        return new JDBCInputFormatBuilder();
-    }
+	/**
+	 * A builder used to set parameters to the output format's configuration in a fluent way.
+	 * @return builder
+	 */
+	public static JDBCInputFormatBuilder buildJDBCInputFormat() {
+		return new JDBCInputFormatBuilder();
+	}
 
-    public static class JDBCInputFormatBuilder {
-        private final JDBCInputFormat format;
+	public static class JDBCInputFormatBuilder {
+		private final JDBCInputFormat format;
 
-        public JDBCInputFormatBuilder() {
-            this.format = new JDBCInputFormat();
-        }
+		public JDBCInputFormatBuilder() {
+			this.format = new JDBCInputFormat();
+		}
 
-        public JDBCInputFormatBuilder setUsername(String username) {
-            format.username = username;
-            return this;
-        }
+		public JDBCInputFormatBuilder setUsername(String username) {
+			format.username = username;
+			return this;
+		}
 
-        public JDBCInputFormatBuilder setPassword(String password) {
-            format.password = password;
-            return this;
-        }
+		public JDBCInputFormatBuilder setPassword(String password) {
+			format.password = password;
+			return this;
+		}
 
-        public JDBCInputFormatBuilder setDrivername(String drivername) {
-            format.drivername = drivername;
-            return this;
-        }
+		public JDBCInputFormatBuilder setDrivername(String drivername) {
+			format.drivername = drivername;
+			return this;
+		}
 
-        public JDBCInputFormatBuilder setDBUrl(String dbURL) {
-            format.dbURL = dbURL;
-            return this;
-        }
+		public JDBCInputFormatBuilder setDBUrl(String dbURL) {
+			format.dbURL = dbURL;
+			return this;
+		}
 
-        public JDBCInputFormatBuilder setQuery(String query) {
-            format.query = query;
-            return this;
-        }
+		public JDBCInputFormatBuilder setQuery(String query) {
+			format.query = query;
+			return this;
+		}
 
-        public JDBCInputFormat finish() {
-            if (format.username == null) {
-                LOG.info("Username was not supplied separately.");
-            }
-            if (format.password == null) {
-                LOG.info("Password was not supplied separately.");
-            }
-            if (format.dbURL == null) {
-                throw new IllegalArgumentException("No dababase URL supplied.");
-            }
-            if (format.query == null) {
-                throw new IllegalArgumentException("No query suplied");
-            }
-            if (format.drivername == null) {
-                throw new IllegalArgumentException("No driver supplied");
-            }
-            return format;
-        }
-    }
+		public JDBCInputFormat finish() {
+			if (format.username == null) {
+				LOG.info("Username was not supplied separately.");
+			}
+			if (format.password == null) {
+				LOG.info("Password was not supplied separately.");
+			}
+			if (format.dbURL == null) {
+				throw new IllegalArgumentException("No dababase URL supplied.");
+			}
+			if (format.query == null) {
+				throw new IllegalArgumentException("No query suplied");
+			}
+			if (format.drivername == null) {
+				throw new IllegalArgumentException("No driver supplied");
+			}
+			return format;
+		}
+	}
 
 }

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
@@ -138,7 +138,7 @@ public class JDBCOutputFormat<OUT extends Tuple> implements OutputFormat<OUT> {
 	private void extractTypes(OUT tuple) {
 		types = new SupportedTypes[tuple.getArity()];
 		for (int x = 0; x < tuple.getArity(); x++) {
-			types[x] = SupportedTypes.valueOf(tuple.getField(x).getClass().getSimpleName());
+			types[x] = SupportedTypes.valueOf(tuple.getField(x).getClass().getSimpleName().toUpperCase());
 		}
 	}
 

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
@@ -112,6 +112,10 @@ public class JDBCOutputFormat<OUT extends Tuple> implements OutputFormat<OUT> {
     @Override
     public void writeRecord(OUT tuple) throws IOException {
         try {
+            if (query.split("\\?,").length != tuple.getArity()) {
+                close();
+                throw new IOException("Tuple size does not match columncount");
+            }
             if (types == null) {
                 extractTypes(tuple);
             }
@@ -181,16 +185,19 @@ public class JDBCOutputFormat<OUT extends Tuple> implements OutputFormat<OUT> {
             batchCount = 0;
         } catch (SQLException se) {
             throw new IllegalArgumentException("close() failed", se);
+        } catch (NullPointerException se) {
         }
         try {
             upload.close();
         } catch (SQLException se) {
             LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        } catch (NullPointerException npe) {
         }
         try {
             dbConn.close();
         } catch (SQLException se) {
             LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        } catch (NullPointerException npe) {
         }
     }
 

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
@@ -34,236 +34,236 @@ import org.apache.commons.logging.LogFactory;
  * @see DriverManager
  */
 public class JDBCOutputFormat<OUT extends Tuple> implements OutputFormat<OUT> {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unused")
-    private static final Log LOG = LogFactory.getLog(JDBCOutputFormat.class);
+	@SuppressWarnings("unused")
+	private static final Log LOG = LogFactory.getLog(JDBCOutputFormat.class);
 
-    private String username;
-    private String password;
-    private String drivername;
-    private String dbURL;
-    private String query;
-    private int batchInterval = 5000;
+	private String username;
+	private String password;
+	private String drivername;
+	private String dbURL;
+	private String query;
+	private int batchInterval = 5000;
 
-    private Connection dbConn;
-    private PreparedStatement upload;
+	private Connection dbConn;
+	private PreparedStatement upload;
 
-    private supportedTypes[] types = null;
+	private SupportedTypes[] types = null;
 
-    private int batchCount = 0;
+	private int batchCount = 0;
 
-    public JDBCOutputFormat() {
-    }
+	public JDBCOutputFormat() {
+	}
 
-    @Override
-    public void configure(Configuration parameters) {
-    }
+	@Override
+	public void configure(Configuration parameters) {
+	}
 
-    /**
-     * Connects to the target database and initializes the prepared statement.
-     *
-     * @param taskNumber The number of the parallel instance.
-     * @throws IOException Thrown, if the output could not be opened due to an
-     * I/O problem.
-     */
-    @Override
-    public void open(int taskNumber, int numTasks) throws IOException {
-        try {
-            establishConnection();
-            upload = dbConn.prepareStatement(query);
-        } catch (SQLException sqe) {
-            close();
-            throw new IllegalArgumentException("open() failed:\t!", sqe);
-        } catch (ClassNotFoundException cnfe) {
-            close();
-            throw new IllegalArgumentException("JDBC-Class not found:\t", cnfe);
-        }
-    }
+	/**
+	 * Connects to the target database and initializes the prepared statement.
+	 *
+	 * @param taskNumber The number of the parallel instance.
+	 * @throws IOException Thrown, if the output could not be opened due to an
+	 * I/O problem.
+	 */
+	@Override
+	public void open(int taskNumber, int numTasks) throws IOException {
+		try {
+			establishConnection();
+			upload = dbConn.prepareStatement(query);
+		} catch (SQLException sqe) {
+			close();
+			throw new IllegalArgumentException("open() failed:\t!", sqe);
+		} catch (ClassNotFoundException cnfe) {
+			close();
+			throw new IllegalArgumentException("JDBC-Class not found:\t", cnfe);
+		}
+	}
 
-    private void establishConnection() throws SQLException, ClassNotFoundException {
-        Class.forName(drivername);
-        if (username == null) {
-            dbConn = DriverManager.getConnection(dbURL);
-        } else {
-            dbConn = DriverManager.getConnection(dbURL, username, password);
-        }
-    }
+	private void establishConnection() throws SQLException, ClassNotFoundException {
+		Class.forName(drivername);
+		if (username == null) {
+			dbConn = DriverManager.getConnection(dbURL);
+		} else {
+			dbConn = DriverManager.getConnection(dbURL, username, password);
+		}
+	}
 
-    private enum supportedTypes {
-        Boolean,
-        Byte,
-        Short,
-        Integer,
-        Long,
-        String,
-        Float,
-        Double
-    }
+	private enum SupportedTypes {
+		BOOLEAN,
+		BYTE,
+		SHORT,
+		INTEGER,
+		LONG,
+		STRING,
+		FLOAT,
+		DOUBLE
+	}
 
-    /**
-     * Adds a record to the prepared statement.
-     * <p>
-     * When this method is called, the output format is guaranteed to be opened.
-     *
-     * @param tuple The records to add to the output.
-     * @throws IOException Thrown, if the records could not be added due to an I/O problem.
-     */
-    @Override
-    public void writeRecord(OUT tuple) throws IOException {
-        try {
-            if (query.split("\\?,").length != tuple.getArity()) {
-                close();
-                throw new IOException("Tuple size does not match columncount");
-            }
-            if (types == null) {
-                extractTypes(tuple);
-            }
-            addValues(tuple);
-            upload.addBatch();
-            batchCount++;
-            if (batchCount >= batchInterval) {
-                upload.executeBatch();
-                batchCount = 0;
-            }
-        } catch (SQLException sqe) {
-            close();
-            throw new IllegalArgumentException("writeRecord() failed", sqe);
-        } catch (IllegalArgumentException iae) {
-            close();
-            throw new IllegalArgumentException("writeRecord() failed", iae);
-        }
-    }
+	/**
+	 * Adds a record to the prepared statement.
+	 * <p>
+	 * When this method is called, the output format is guaranteed to be opened.
+	 *
+	 * @param tuple The records to add to the output.
+	 * @throws IOException Thrown, if the records could not be added due to an I/O problem.
+	 */
+	@Override
+	public void writeRecord(OUT tuple) throws IOException {
+		try {
+			if (query.split("\\?,").length != tuple.getArity()) {
+				close();
+				throw new IOException("Tuple size does not match columncount");
+			}
+			if (types == null) {
+				extractTypes(tuple);
+			}
+			addValues(tuple);
+			upload.addBatch();
+			batchCount++;
+			if (batchCount >= batchInterval) {
+				upload.executeBatch();
+				batchCount = 0;
+			}
+		} catch (SQLException sqe) {
+			close();
+			throw new IllegalArgumentException("writeRecord() failed", sqe);
+		} catch (IllegalArgumentException iae) {
+			close();
+			throw new IllegalArgumentException("writeRecord() failed", iae);
+		}
+	}
 
-    private void extractTypes(OUT tuple) {
-        types = new supportedTypes[tuple.getArity()];
-        for (int x = 0; x < tuple.getArity(); x++) {
-            types[x] = supportedTypes.valueOf(tuple.getField(x).getClass().getSimpleName());
-        }
-    }
+	private void extractTypes(OUT tuple) {
+		types = new SupportedTypes[tuple.getArity()];
+		for (int x = 0; x < tuple.getArity(); x++) {
+			types[x] = SupportedTypes.valueOf(tuple.getField(x).getClass().getSimpleName());
+		}
+	}
 
-    private void addValues(OUT tuple) throws SQLException {
-        for (int index = 0; index < tuple.getArity(); index++) {
-            switch (types[index]) {
-                case Boolean:
-                    upload.setBoolean(index + 1, (Boolean) tuple.getField(index));
-                    break;
-                case Byte:
-                    upload.setByte(index + 1, (Byte) tuple.getField(index));
-                    break;
-                case Short:
-                    upload.setShort(index + 1, (Short) tuple.getField(index));
-                    break;
-                case Integer:
-                    upload.setInt(index + 1, (Integer) tuple.getField(index));
-                    break;
-                case Long:
-                    upload.setLong(index + 1, (Long) tuple.getField(index));
-                    break;
-                case String:
-                    upload.setString(index + 1, (String) tuple.getField(index));
-                    break;
-                case Float:
-                    upload.setFloat(index + 1, (Float) tuple.getField(index));
-                    break;
-                case Double:
-                    upload.setDouble(index + 1, (Double) tuple.getField(index));
-                    break;
-            }
-        }
-    }
+	private void addValues(OUT tuple) throws SQLException {
+		for (int index = 0; index < tuple.getArity(); index++) {
+			switch (types[index]) {
+				case BOOLEAN:
+					upload.setBoolean(index + 1, (Boolean) tuple.getField(index));
+					break;
+				case BYTE:
+					upload.setByte(index + 1, (Byte) tuple.getField(index));
+					break;
+				case SHORT:
+					upload.setShort(index + 1, (Short) tuple.getField(index));
+					break;
+				case INTEGER:
+					upload.setInt(index + 1, (Integer) tuple.getField(index));
+					break;
+				case LONG:
+					upload.setLong(index + 1, (Long) tuple.getField(index));
+					break;
+				case STRING:
+					upload.setString(index + 1, (String) tuple.getField(index));
+					break;
+				case FLOAT:
+					upload.setFloat(index + 1, (Float) tuple.getField(index));
+					break;
+				case DOUBLE:
+					upload.setDouble(index + 1, (Double) tuple.getField(index));
+					break;
+			}
+		}
+	}
 
-    /**
-     * Executes prepared statement and closes all resources of this instance.
-     *
-     * @throws IOException Thrown, if the input could not be closed properly.
-     */
-    @Override
-    public void close() throws IOException {
-        try {
-            upload.executeBatch();
-            batchCount = 0;
-        } catch (SQLException se) {
-            throw new IllegalArgumentException("close() failed", se);
-        } catch (NullPointerException se) {
-        }
-        try {
-            upload.close();
-        } catch (SQLException se) {
-            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-        } catch (NullPointerException npe) {
-        }
-        try {
-            dbConn.close();
-        } catch (SQLException se) {
-            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
-        } catch (NullPointerException npe) {
-        }
-    }
+	/**
+	 * Executes prepared statement and closes all resources of this instance.
+	 *
+	 * @throws IOException Thrown, if the input could not be closed properly.
+	 */
+	@Override
+	public void close() throws IOException {
+		try {
+			upload.executeBatch();
+			batchCount = 0;
+		} catch (SQLException se) {
+			throw new IllegalArgumentException("close() failed", se);
+		} catch (NullPointerException se) {
+		}
+		try {
+			upload.close();
+		} catch (SQLException se) {
+			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+		} catch (NullPointerException npe) {
+		}
+		try {
+			dbConn.close();
+		} catch (SQLException se) {
+			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+		} catch (NullPointerException npe) {
+		}
+	}
 
-    public static JDBCOutputFormatBuilder buildJDBCOutputFormat() {
-        return new JDBCOutputFormatBuilder();
-    }
+	public static JDBCOutputFormatBuilder buildJDBCOutputFormat() {
+		return new JDBCOutputFormatBuilder();
+	}
 
-    public static class JDBCOutputFormatBuilder {
-        private final JDBCOutputFormat format;
+	public static class JDBCOutputFormatBuilder {
+		private final JDBCOutputFormat format;
 
-        protected JDBCOutputFormatBuilder() {
-            this.format = new JDBCOutputFormat();
-        }
+		protected JDBCOutputFormatBuilder() {
+			this.format = new JDBCOutputFormat();
+		}
 
-        public JDBCOutputFormatBuilder setUsername(String username) {
-            format.username = username;
-            return this;
-        }
+		public JDBCOutputFormatBuilder setUsername(String username) {
+			format.username = username;
+			return this;
+		}
 
-        public JDBCOutputFormatBuilder setPassword(String password) {
-            format.password = password;
-            return this;
-        }
+		public JDBCOutputFormatBuilder setPassword(String password) {
+			format.password = password;
+			return this;
+		}
 
-        public JDBCOutputFormatBuilder setDrivername(String drivername) {
-            format.drivername = drivername;
-            return this;
-        }
+		public JDBCOutputFormatBuilder setDrivername(String drivername) {
+			format.drivername = drivername;
+			return this;
+		}
 
-        public JDBCOutputFormatBuilder setDBUrl(String dbURL) {
-            format.dbURL = dbURL;
-            return this;
-        }
+		public JDBCOutputFormatBuilder setDBUrl(String dbURL) {
+			format.dbURL = dbURL;
+			return this;
+		}
 
-        public JDBCOutputFormatBuilder setQuery(String query) {
-            format.query = query;
-            return this;
-        }
+		public JDBCOutputFormatBuilder setQuery(String query) {
+			format.query = query;
+			return this;
+		}
 
-        public JDBCOutputFormatBuilder setBatchInterval(int batchInterval) {
-            format.batchInterval = batchInterval;
-            return this;
-        }
+		public JDBCOutputFormatBuilder setBatchInterval(int batchInterval) {
+			format.batchInterval = batchInterval;
+			return this;
+		}
 
-        /**
-         Finalizes the configuration and checks validity.
-         @return Configured JDBCOutputFormat
-         */
-        public JDBCOutputFormat finish() {
-            if (format.username == null) {
-                LOG.info("Username was not supplied separately.");
-            }
-            if (format.password == null) {
-                LOG.info("Password was not supplied separately.");
-            }
-            if (format.dbURL == null) {
-                throw new IllegalArgumentException("No dababase URL supplied.");
-            }
-            if (format.query == null) {
-                throw new IllegalArgumentException("No query suplied");
-            }
-            if (format.drivername == null) {
-                throw new IllegalArgumentException("No driver supplied");
-            }
-            return format;
-        }
-    }
+		/**
+		 Finalizes the configuration and checks validity.
+		 @return Configured JDBCOutputFormat
+		 */
+		public JDBCOutputFormat finish() {
+			if (format.username == null) {
+				LOG.info("Username was not supplied separately.");
+			}
+			if (format.password == null) {
+				LOG.info("Password was not supplied separately.");
+			}
+			if (format.dbURL == null) {
+				throw new IllegalArgumentException("No dababase URL supplied.");
+			}
+			if (format.query == null) {
+				throw new IllegalArgumentException("No query suplied");
+			}
+			if (format.drivername == null) {
+				throw new IllegalArgumentException("No driver supplied");
+			}
+			return format;
+		}
+	}
 
 }

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormat.java
@@ -1,0 +1,258 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.io.jdbc;
+
+import eu.stratosphere.api.common.io.OutputFormat;
+import eu.stratosphere.api.java.tuple.Tuple;
+import eu.stratosphere.configuration.Configuration;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * OutputFormat to write tuples into a database.
+ * The OutputFormat has to be configured using the supplied OutputFormatBuilder.
+ * 
+ * @param <OUT>
+ * @see Tuple
+ * @see DriverManager
+ */
+public class JDBCOutputFormat<OUT extends Tuple> implements OutputFormat<OUT> {
+    private static final long serialVersionUID = 1L;
+
+    @SuppressWarnings("unused")
+    private static final Log LOG = LogFactory.getLog(JDBCOutputFormat.class);
+
+    private String username;
+    private String password;
+    private String drivername;
+    private String dbURL;
+    private String query;
+    private int batchInterval = 5000;
+
+    private Connection dbConn;
+    private PreparedStatement upload;
+
+    private int batchCount = 0;
+
+    public JDBCOutputFormat() {
+    }
+
+    @Override
+    public void configure(Configuration parameters) {
+    }
+    
+    /**
+     * Connects to the target database and initializes the prepared statement.
+     *
+     * @param taskNumber The number of the parallel instance.
+     * @throws IOException Thrown, if the output could not be opened due to an
+     * I/O problem.
+     */
+    @Override
+    public void open(int taskNumber, int numTasks) throws IOException {
+        try {
+            establishConnection();
+            upload = dbConn.prepareStatement(query);
+        } catch (SQLException sqe) {
+            close();
+            throw new IllegalArgumentException("open() failed:\t!", sqe);
+        } catch (ClassNotFoundException cnfe) {
+            close();
+            throw new IllegalArgumentException("JDBC-Class not found:\t", cnfe);
+        }
+    }
+
+    private void establishConnection() throws SQLException, ClassNotFoundException {
+        Class.forName(drivername);
+        if (username == null) {
+            dbConn = DriverManager.getConnection(dbURL);
+        } else {
+            dbConn = DriverManager.getConnection(dbURL, username, password);
+        }
+    }
+
+    private enum supportedTypes {
+        Boolean,
+        Byte,
+        Short,
+        Integer,
+        Long,
+        String,
+        Float,
+        Double
+    }
+    
+    /**
+     * Adds a record to the prepared statement.
+     * <p>
+     * When this method is called, the output format is guaranteed to be opened.
+     *
+     * @param tuple The records to add to the output.
+     * @throws IOException Thrown, if the records could not be added due to an I/O problem.
+     */
+    @Override
+    public void writeRecord(OUT tuple) throws IOException {
+        try {
+            for (int x = 0; x < tuple.getArity(); x++) {
+                addValue(x, tuple);
+            }
+            upload.addBatch();
+            batchCount++;
+            if (batchCount >= batchInterval) {
+                upload.executeBatch();
+                batchCount = 0;
+            }
+        } catch (SQLException sqe) {
+            close();
+            throw new IllegalArgumentException("writeRecord() failed", sqe);
+        } catch (IllegalArgumentException iae) {
+            close();
+            throw new IllegalArgumentException("writeRecord() failed", iae);
+        }
+    }
+
+    private void addValue(int index, OUT tuple) throws SQLException {
+        supportedTypes type;
+        try {
+            type = supportedTypes.valueOf(tuple.getField(index).getClass().getSimpleName());
+        } catch (IllegalArgumentException iae) {
+            throw new IllegalArgumentException("PactType not supported", iae);
+        }
+        switch (type) {
+            case Boolean:
+                upload.setBoolean(index + 1, (Boolean) tuple.getField(index));
+                break;
+            case Byte:
+                upload.setByte(index + 1, (Byte) tuple.getField(index));
+                break;
+            case Short:
+                upload.setShort(index + 1, (Short) tuple.getField(index));
+                break;
+            case Integer:
+                upload.setInt(index + 1, (Integer) tuple.getField(index));
+                break;
+            case Long:
+                upload.setLong(index + 1, (Long) tuple.getField(index));
+                break;
+            case String:
+                upload.setString(index + 1, (String) tuple.getField(index));
+                break;
+            case Float:
+                upload.setFloat(index + 1, (Float) tuple.getField(index));
+                break;
+            case Double:
+                upload.setDouble(index + 1, (Double) tuple.getField(index));
+                break;
+        }
+    }
+
+    /**
+     * Executes prepared statement and closes all resources of this instance.
+     *
+     * @throws IOException Thrown, if the input could not be closed properly.
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            upload.executeBatch();
+            batchCount = 0;
+        } catch (SQLException se) {
+            throw new IllegalArgumentException("close() failed", se);
+        }
+        try {
+            upload.close();
+        } catch (SQLException se) {
+            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        }
+        try {
+            dbConn.close();
+        } catch (SQLException se) {
+            LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+        }
+    }
+    
+
+    public static JDBCOutputFormatBuilder buildJDBCOutputFormat() {
+        return new JDBCOutputFormatBuilder();
+    }
+
+    public static class JDBCOutputFormatBuilder {
+        private final JDBCOutputFormat format;
+
+        protected JDBCOutputFormatBuilder() {
+            this.format = new JDBCOutputFormat();
+        }
+
+        public JDBCOutputFormatBuilder setUsername(String username) {
+            format.username = username;
+            return this;
+        }
+
+        public JDBCOutputFormatBuilder setPassword(String password) {
+            format.password = password;
+            return this;
+        }
+
+        public JDBCOutputFormatBuilder setDrivername(String drivername) {
+            format.drivername = drivername;
+            return this;
+        }
+
+        public JDBCOutputFormatBuilder setDBUrl(String dbURL) {
+            format.dbURL = dbURL;
+            return this;
+        }
+
+        public JDBCOutputFormatBuilder setQuery(String query) {
+            format.query = query;
+            return this;
+        }
+
+
+        public JDBCOutputFormatBuilder setBatchInterval(int batchInterval) {
+            format.batchInterval = batchInterval;
+            return this;
+        }
+
+        /**
+         Finalizes the configuration and checks validity.
+         @return Configured JDBCOutputFormat
+         */
+        public JDBCOutputFormat finish() {
+            if (format.username == null) {
+                LOG.info("Username was not supplied separately.");
+            }
+            if (format.password == null) {
+                LOG.info("Password was not supplied separately.");
+            }
+            if (format.dbURL == null) {
+                throw new IllegalArgumentException("No dababase URL supplied.");
+            }
+            if (format.query == null) {
+                throw new IllegalArgumentException("No query suplied");
+            }
+            if (format.drivername == null) {
+                throw new IllegalArgumentException("No driver supplied");
+            }
+            return format;
+        }
+    }
+
+}

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/example/JDBCExample.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/example/JDBCExample.java
@@ -1,0 +1,95 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.io.jdbc.example;
+
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.io.jdbc.JDBCInputFormat;
+import eu.stratosphere.api.java.io.jdbc.JDBCOutputFormat;
+import eu.stratosphere.api.java.tuple.Tuple5;
+import static eu.stratosphere.api.java.typeutils.BasicTypeInfo.DOUBLE_TYPE_INFO;
+import static eu.stratosphere.api.java.typeutils.BasicTypeInfo.INT_TYPE_INFO;
+import static eu.stratosphere.api.java.typeutils.BasicTypeInfo.STRING_TYPE_INFO;
+import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+public class JDBCExample {
+
+    public static void main(String[] args) throws Exception {
+        prepareTestDb();
+
+        ExecutionEnvironment environment = ExecutionEnvironment.getExecutionEnvironment();
+        DataSet<Tuple5> source
+                = environment.createInput(JDBCInputFormat.buildJDBCInputFormat()
+                        .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+                        .setDBUrl("jdbc:derby:memory:ebookshop")
+                        .setQuery("select * from books")
+                        .finish(),
+                        new TupleTypeInfo(Tuple5.class, INT_TYPE_INFO, STRING_TYPE_INFO, STRING_TYPE_INFO, DOUBLE_TYPE_INFO, INT_TYPE_INFO)
+                );
+
+        source.output(JDBCOutputFormat.buildJDBCOutputFormat()
+                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+                .setDBUrl("jdbc:derby:memory:ebookshop")
+                .setQuery("insert into newbooks (id,title,author,price,qty) values (?,?,?,?,?)")
+                .finish());
+        environment.execute();
+    }
+
+    private static void prepareTestDb() throws Exception {
+        String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+        Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+        Connection conn = DriverManager.getConnection(dbURL);
+
+        StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE books (");
+        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+        sqlQueryBuilder.append("PRIMARY KEY (id))");
+
+        Statement stat = conn.createStatement();
+        stat.executeUpdate(sqlQueryBuilder.toString());
+        stat.close();
+
+        sqlQueryBuilder = new StringBuilder("CREATE TABLE newbooks (");
+        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+        sqlQueryBuilder.append("PRIMARY KEY (id))");
+
+        stat = conn.createStatement();
+        stat.executeUpdate(sqlQueryBuilder.toString());
+        stat.close();
+
+        sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+        sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
+        sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
+        sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
+        sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
+        sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
+
+        stat = conn.createStatement();
+        stat.execute(sqlQueryBuilder.toString());
+        stat.close();
+
+        conn.close();
+    }
+}

--- a/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/example/JDBCExample.java
+++ b/stratosphere-addons/jdbc/src/main/java/eu/stratosphere/api/java/io/jdbc/example/JDBCExample.java
@@ -29,67 +29,67 @@ import java.sql.Statement;
 
 public class JDBCExample {
 
-    public static void main(String[] args) throws Exception {
-        prepareTestDb();
+	public static void main(String[] args) throws Exception {
+		prepareTestDb();
 
-        ExecutionEnvironment environment = ExecutionEnvironment.getExecutionEnvironment();
-        DataSet<Tuple5> source
-                = environment.createInput(JDBCInputFormat.buildJDBCInputFormat()
-                        .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                        .setDBUrl("jdbc:derby:memory:ebookshop")
-                        .setQuery("select * from books")
-                        .finish(),
-                        new TupleTypeInfo(Tuple5.class, INT_TYPE_INFO, STRING_TYPE_INFO, STRING_TYPE_INFO, DOUBLE_TYPE_INFO, INT_TYPE_INFO)
-                );
+		ExecutionEnvironment environment = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5> source
+				= environment.createInput(JDBCInputFormat.buildJDBCInputFormat()
+						.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+						.setDBUrl("jdbc:derby:memory:ebookshop")
+						.setQuery("select * from books")
+						.finish(),
+						new TupleTypeInfo(Tuple5.class, INT_TYPE_INFO, STRING_TYPE_INFO, STRING_TYPE_INFO, DOUBLE_TYPE_INFO, INT_TYPE_INFO)
+				);
 
-        source.output(JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("insert into newbooks (id,title,author,price,qty) values (?,?,?,?,?)")
-                .finish());
-        environment.execute();
-    }
+		source.output(JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("insert into newbooks (id,title,author,price,qty) values (?,?,?,?,?)")
+				.finish());
+		environment.execute();
+	}
 
-    private static void prepareTestDb() throws Exception {
-        String dbURL = "jdbc:derby:memory:ebookshop;create=true";
-        Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-        Connection conn = DriverManager.getConnection(dbURL);
+	private static void prepareTestDb() throws Exception {
+		String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+		Connection conn = DriverManager.getConnection(dbURL);
 
-        StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE books (");
-        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
-        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
-        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
-        sqlQueryBuilder.append("PRIMARY KEY (id))");
+		StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE books (");
+		sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+		sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+		sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+		sqlQueryBuilder.append("PRIMARY KEY (id))");
 
-        Statement stat = conn.createStatement();
-        stat.executeUpdate(sqlQueryBuilder.toString());
-        stat.close();
+		Statement stat = conn.createStatement();
+		stat.executeUpdate(sqlQueryBuilder.toString());
+		stat.close();
 
-        sqlQueryBuilder = new StringBuilder("CREATE TABLE newbooks (");
-        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
-        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
-        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
-        sqlQueryBuilder.append("PRIMARY KEY (id))");
+		sqlQueryBuilder = new StringBuilder("CREATE TABLE newbooks (");
+		sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+		sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+		sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+		sqlQueryBuilder.append("PRIMARY KEY (id))");
 
-        stat = conn.createStatement();
-        stat.executeUpdate(sqlQueryBuilder.toString());
-        stat.close();
+		stat = conn.createStatement();
+		stat.executeUpdate(sqlQueryBuilder.toString());
+		stat.close();
 
-        sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
-        sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
-        sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
-        sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
-        sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
-        sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
+		sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+		sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
+		sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
+		sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
+		sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
+		sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
 
-        stat = conn.createStatement();
-        stat.execute(sqlQueryBuilder.toString());
-        stat.close();
+		stat = conn.createStatement();
+		stat.execute(sqlQueryBuilder.toString());
+		stat.close();
 
-        conn.close();
-    }
+		conn.close();
+	}
 }

--- a/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -1,0 +1,142 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.io.jdbc;
+
+import eu.stratosphere.api.java.tuple.Tuple5;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import eu.stratosphere.configuration.Configuration;
+import org.junit.AfterClass;
+
+public class JDBCInputFormatTest {
+    JDBCInputFormat jdbcInputFormat;
+    Configuration config;
+    static Connection conn;
+    static final Object[][] dbData = {
+        {new Integer(1001), ("Java for dummies"), ("Tan Ah Teck"), new Double(11.11), new Integer(11)},
+        {new Integer(1002), ("More Java for dummies"), ("Tan Ah Teck"), new Double(22.22), new Integer(22)},
+        {new Integer(1003), ("More Java for more dummies"), ("Mohammad Ali"), new Double(33.33), new Integer(33)},
+        {new Integer(1004), ("A Cup of Java"), ("Kumar"), new Double(44.44), new Integer(44)},
+        {new Integer(1005), ("A Teaspoon of Java"), ("Kevin Jones"), new Double(55.55), new Integer(55)}};
+
+    @BeforeClass
+    public static void setUpClass() {
+        try {
+            prepareDerbyDatabase();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    private static void prepareDerbyDatabase() throws ClassNotFoundException, SQLException {
+        System.setProperty("derby.stream.error.field", "eu.stratosphere.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
+        String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+        Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+        conn = DriverManager.getConnection(dbURL);
+        createTable();
+        insertDataToSQLTable();
+        conn.close();
+    }
+
+    private static void createTable() throws SQLException {
+        StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE books (");
+        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+        sqlQueryBuilder.append("PRIMARY KEY (id))");
+
+        Statement stat = conn.createStatement();
+        stat.executeUpdate(sqlQueryBuilder.toString());
+        stat.close();
+    }
+
+    private static void insertDataToSQLTable() throws SQLException {
+        StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+        sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
+        sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
+        sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
+        sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
+        sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
+
+        Statement stat = conn.createStatement();
+        stat.execute(sqlQueryBuilder.toString());
+        stat.close();
+    }
+
+    @AfterClass
+    public static void tearDownClass(){
+        cleanUpDerbyDatabases();
+    }
+    
+    private static void cleanUpDerbyDatabases() {
+    	 try {
+             String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+             Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+             
+             conn = DriverManager.getConnection(dbURL);
+             Statement stat = conn.createStatement();
+             stat.executeUpdate("DROP TABLE books");
+             stat.close();
+             conn.close();
+         } catch (Exception e) {
+        	 e.printStackTrace();
+             Assert.fail();
+         } 
+    }
+    
+    @After
+    public void tearDown() {
+        jdbcInputFormat = null;
+    }
+
+    @Test
+    public void testJDBCInputFormat() throws IOException {
+        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+                .setDBUrl("jdbc:derby:memory:ebookshop")
+                .setQuery("select * from books")
+                .finish();
+        jdbcInputFormat.open(null);
+        Tuple5 tuple = new Tuple5();
+        int recordCount = 0;
+        while (!jdbcInputFormat.reachedEnd()) {
+            jdbcInputFormat.nextRecord(tuple);
+            Assert.assertEquals("Field 0 should be int", Integer.class, tuple.getField(0).getClass());
+            Assert.assertEquals("Field 1 should be String", String.class, tuple.getField(1).getClass());
+            Assert.assertEquals("Field 2 should be String", String.class, tuple.getField(2).getClass());
+            Assert.assertEquals("Field 3 should be float", Double.class, tuple.getField(3).getClass());
+            Assert.assertEquals("Field 4 should be int", Integer.class, tuple.getField(4).getClass());
+
+            for (int x = 0; x < 5; x++) {
+                Assert.assertEquals(dbData[recordCount][x], tuple.getField(x));
+            }
+            recordCount++;
+        }
+        Assert.assertEquals(5, recordCount);
+    }
+
+}

--- a/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -28,162 +28,162 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class JDBCInputFormatTest {
-    JDBCInputFormat jdbcInputFormat;
+	JDBCInputFormat jdbcInputFormat;
 
-    static Connection conn;
+	static Connection conn;
 
-    static final Object[][] dbData = {
-        {1001, ("Java for dummies"), ("Tan Ah Teck"), 11.11, 11},
-        {1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22},
-        {1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33},
-        {1004, ("A Cup of Java"), ("Kumar"), 44.44, 44},
-        {1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55}};
+	static final Object[][] dbData = {
+		{1001, ("Java for dummies"), ("Tan Ah Teck"), 11.11, 11},
+		{1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22},
+		{1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33},
+		{1004, ("A Cup of Java"), ("Kumar"), 44.44, 44},
+		{1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55}};
 
-    @BeforeClass
-    public static void setUpClass() {
-        try {
-            prepareDerbyDatabase();
-        } catch (Exception e) {
-            Assert.fail();
-        }
-    }
+	@BeforeClass
+	public static void setUpClass() {
+		try {
+			prepareDerbyDatabase();
+		} catch (Exception e) {
+			Assert.fail();
+		}
+	}
 
-    private static void prepareDerbyDatabase() throws ClassNotFoundException, SQLException {
-        System.setProperty("derby.stream.error.field", "eu.stratosphere.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
-        String dbURL = "jdbc:derby:memory:ebookshop;create=true";
-        Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-        conn = DriverManager.getConnection(dbURL);
-        createTable();
-        insertDataToSQLTable();
-        conn.close();
-    }
+	private static void prepareDerbyDatabase() throws ClassNotFoundException, SQLException {
+		System.setProperty("derby.stream.error.field", "eu.stratosphere.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
+		String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+		conn = DriverManager.getConnection(dbURL);
+		createTable();
+		insertDataToSQLTable();
+		conn.close();
+	}
 
-    private static void createTable() throws SQLException {
-        StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE books (");
-        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
-        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
-        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
-        sqlQueryBuilder.append("PRIMARY KEY (id))");
+	private static void createTable() throws SQLException {
+		StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE books (");
+		sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+		sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+		sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+		sqlQueryBuilder.append("PRIMARY KEY (id))");
 
-        Statement stat = conn.createStatement();
-        stat.executeUpdate(sqlQueryBuilder.toString());
-        stat.close();
-    }
+		Statement stat = conn.createStatement();
+		stat.executeUpdate(sqlQueryBuilder.toString());
+		stat.close();
+	}
 
-    private static void insertDataToSQLTable() throws SQLException {
-        StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
-        sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
-        sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
-        sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
-        sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
-        sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
+	private static void insertDataToSQLTable() throws SQLException {
+		StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+		sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
+		sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
+		sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
+		sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
+		sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
 
-        Statement stat = conn.createStatement();
-        stat.execute(sqlQueryBuilder.toString());
-        stat.close();
-    }
+		Statement stat = conn.createStatement();
+		stat.execute(sqlQueryBuilder.toString());
+		stat.close();
+	}
 
-    @AfterClass
-    public static void tearDownClass() {
-        cleanUpDerbyDatabases();
-    }
+	@AfterClass
+	public static void tearDownClass() {
+		cleanUpDerbyDatabases();
+	}
 
-    private static void cleanUpDerbyDatabases() {
-        try {
-            String dbURL = "jdbc:derby:memory:ebookshop;create=true";
-            Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+	private static void cleanUpDerbyDatabases() {
+		try {
+			String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+			Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
 
-            conn = DriverManager.getConnection(dbURL);
-            Statement stat = conn.createStatement();
-            stat.executeUpdate("DROP TABLE books");
-            stat.close();
-            conn.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail();
-        }
-    }
+			conn = DriverManager.getConnection(dbURL);
+			Statement stat = conn.createStatement();
+			stat.executeUpdate("DROP TABLE books");
+			stat.close();
+			conn.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail();
+		}
+	}
 
-    @After
-    public void tearDown() {
-        jdbcInputFormat = null;
-    }
+	@After
+	public void tearDown() {
+		jdbcInputFormat = null;
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidDriver() throws IOException {
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername("org.apache.derby.jdbc.idontexist")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("select * from books")
-                .finish();
-        jdbcInputFormat.open(null);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidDriver() throws IOException {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername("org.apache.derby.jdbc.idontexist")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("select * from books")
+				.finish();
+		jdbcInputFormat.open(null);
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidURL() throws IOException {
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
-                .setQuery("select * from books")
-                .finish();
-        jdbcInputFormat.open(null);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidURL() throws IOException {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
+				.setQuery("select * from books")
+				.finish();
+		jdbcInputFormat.open(null);
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidQuery() throws IOException {
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("iamnotsql")
-                .finish();
-        jdbcInputFormat.open(null);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidQuery() throws IOException {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("iamnotsql")
+				.finish();
+		jdbcInputFormat.open(null);
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIncompleteConfiguration() throws IOException {
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setQuery("select * from books")
-                .finish();
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testIncompleteConfiguration() throws IOException {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setQuery("select * from books")
+				.finish();
+	}
 
-    @Test(expected = IOException.class)
-    public void testIncompatibleTuple() throws IOException {
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("select * from books")
-                .finish();
-        jdbcInputFormat.open(null);
-        jdbcInputFormat.nextRecord(new Tuple2());
-    }
+	@Test(expected = IOException.class)
+	public void testIncompatibleTuple() throws IOException {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("select * from books")
+				.finish();
+		jdbcInputFormat.open(null);
+		jdbcInputFormat.nextRecord(new Tuple2());
+	}
 
-    @Test
-    public void testJDBCInputFormat() throws IOException {
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("select * from books")
-                .finish();
-        jdbcInputFormat.open(null);
-        Tuple5 tuple = new Tuple5();
-        int recordCount = 0;
-        while (!jdbcInputFormat.reachedEnd()) {
-            jdbcInputFormat.nextRecord(tuple);
-            Assert.assertEquals("Field 0 should be int", Integer.class, tuple.getField(0).getClass());
-            Assert.assertEquals("Field 1 should be String", String.class, tuple.getField(1).getClass());
-            Assert.assertEquals("Field 2 should be String", String.class, tuple.getField(2).getClass());
-            Assert.assertEquals("Field 3 should be float", Double.class, tuple.getField(3).getClass());
-            Assert.assertEquals("Field 4 should be int", Integer.class, tuple.getField(4).getClass());
+	@Test
+	public void testJDBCInputFormat() throws IOException {
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("select * from books")
+				.finish();
+		jdbcInputFormat.open(null);
+		Tuple5 tuple = new Tuple5();
+		int recordCount = 0;
+		while (!jdbcInputFormat.reachedEnd()) {
+			jdbcInputFormat.nextRecord(tuple);
+			Assert.assertEquals("Field 0 should be int", Integer.class, tuple.getField(0).getClass());
+			Assert.assertEquals("Field 1 should be String", String.class, tuple.getField(1).getClass());
+			Assert.assertEquals("Field 2 should be String", String.class, tuple.getField(2).getClass());
+			Assert.assertEquals("Field 3 should be float", Double.class, tuple.getField(3).getClass());
+			Assert.assertEquals("Field 4 should be int", Integer.class, tuple.getField(4).getClass());
 
-            for (int x = 0; x < 5; x++) {
-                Assert.assertEquals(dbData[recordCount][x], tuple.getField(x));
-            }
-            recordCount++;
-        }
-        Assert.assertEquals(5, recordCount);
-    }
+			for (int x = 0; x < 5; x++) {
+				Assert.assertEquals(dbData[recordCount][x], tuple.getField(x));
+			}
+			recordCount++;
+		}
+		Assert.assertEquals(5, recordCount);
+	}
 
 }

--- a/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormatTest.java
+++ b/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormatTest.java
@@ -28,225 +28,225 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class JDBCOutputFormatTest {
-    private JDBCInputFormat jdbcInputFormat;
-    private JDBCOutputFormat jdbcOutputFormat;
+	private JDBCInputFormat jdbcInputFormat;
+	private JDBCOutputFormat jdbcOutputFormat;
 
-    private static Connection conn;
+	private static Connection conn;
 
-    static final Object[][] dbData = {
-        {1001, ("Java for dummies"), ("Tan Ah Teck"), 11.11, 11},
-        {1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22},
-        {1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33},
-        {1004, ("A Cup of Java"), ("Kumar"), 44.44, 44},
-        {1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55}};
+	static final Object[][] dbData = {
+		{1001, ("Java for dummies"), ("Tan Ah Teck"), 11.11, 11},
+		{1002, ("More Java for dummies"), ("Tan Ah Teck"), 22.22, 22},
+		{1003, ("More Java for more dummies"), ("Mohammad Ali"), 33.33, 33},
+		{1004, ("A Cup of Java"), ("Kumar"), 44.44, 44},
+		{1005, ("A Teaspoon of Java"), ("Kevin Jones"), 55.55, 55}};
 
-    @BeforeClass
-    public static void setUpClass() throws SQLException {
-        try {
-            System.setProperty("derby.stream.error.field", "eu.stratosphere.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
-            prepareDerbyDatabase();
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            Assert.fail();
-        }
-    }
+	@BeforeClass
+	public static void setUpClass() throws SQLException {
+		try {
+			System.setProperty("derby.stream.error.field", "eu.stratosphere.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
+			prepareDerbyDatabase();
+		} catch (ClassNotFoundException e) {
+			e.printStackTrace();
+			Assert.fail();
+		}
+	}
 
-    private static void prepareDerbyDatabase() throws ClassNotFoundException, SQLException {
-        String dbURL = "jdbc:derby:memory:ebookshop;create=true";
-        Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-        conn = DriverManager.getConnection(dbURL);
-        createTable("books");
-        createTable("newbooks");
-        insertDataToSQLTables();
-        conn.close();
-    }
+	private static void prepareDerbyDatabase() throws ClassNotFoundException, SQLException {
+		String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+		Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+		conn = DriverManager.getConnection(dbURL);
+		createTable("books");
+		createTable("newbooks");
+		insertDataToSQLTables();
+		conn.close();
+	}
 
-    private static void createTable(String tableName) throws SQLException {
-        StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE ");
-        sqlQueryBuilder.append(tableName);
-        sqlQueryBuilder.append(" (");
-        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
-        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
-        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
-        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
-        sqlQueryBuilder.append("PRIMARY KEY (id))");
+	private static void createTable(String tableName) throws SQLException {
+		StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE ");
+		sqlQueryBuilder.append(tableName);
+		sqlQueryBuilder.append(" (");
+		sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+		sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+		sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+		sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+		sqlQueryBuilder.append("PRIMARY KEY (id))");
 
-        Statement stat = conn.createStatement();
-        stat.executeUpdate(sqlQueryBuilder.toString());
-        stat.close();
-    }
+		Statement stat = conn.createStatement();
+		stat.executeUpdate(sqlQueryBuilder.toString());
+		stat.close();
+	}
 
-    private static void insertDataToSQLTables() throws SQLException {
-        StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
-        sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
-        sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
-        sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
-        sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
-        sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
+	private static void insertDataToSQLTables() throws SQLException {
+		StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+		sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
+		sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
+		sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
+		sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
+		sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
 
-        Statement stat = conn.createStatement();
-        stat.execute(sqlQueryBuilder.toString());
-        stat.close();
-    }
+		Statement stat = conn.createStatement();
+		stat.execute(sqlQueryBuilder.toString());
+		stat.close();
+	}
 
-    @AfterClass
-    public static void tearDownClass() {
-        cleanUpDerbyDatabases();
-    }
+	@AfterClass
+	public static void tearDownClass() {
+		cleanUpDerbyDatabases();
+	}
 
-    private static void cleanUpDerbyDatabases() {
-        try {
-            String dbURL = "jdbc:derby:memory:ebookshop;create=true";
-            Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+	private static void cleanUpDerbyDatabases() {
+		try {
+			String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+			Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
 
-            conn = DriverManager.getConnection(dbURL);
-            Statement stat = conn.createStatement();
-            stat.executeUpdate("DROP TABLE books");
-            stat.executeUpdate("DROP TABLE newbooks");
-            stat.close();
-            conn.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail();
-        }
-    }
+			conn = DriverManager.getConnection(dbURL);
+			Statement stat = conn.createStatement();
+			stat.executeUpdate("DROP TABLE books");
+			stat.executeUpdate("DROP TABLE newbooks");
+			stat.close();
+			conn.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail();
+		}
+	}
 
-    @After
-    public void tearDown() {
-        jdbcOutputFormat = null;
-    }
+	@After
+	public void tearDown() {
+		jdbcOutputFormat = null;
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidDriver() throws IOException {
-        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDrivername("org.apache.derby.jdbc.idontexist")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
-                .finish();
-        jdbcOutputFormat.open(0, 1);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidDriver() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDrivername("org.apache.derby.jdbc.idontexist")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
+				.finish();
+		jdbcOutputFormat.open(0, 1);
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidURL() throws IOException {
-        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
-                .setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
-                .finish();
-        jdbcOutputFormat.open(0, 1);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidURL() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
+				.setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
+				.finish();
+		jdbcOutputFormat.open(0, 1);
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidQuery() throws IOException {
-        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("iamnotsql")
-                .finish();
-        jdbcOutputFormat.open(0, 1);
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidQuery() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("iamnotsql")
+				.finish();
+		jdbcOutputFormat.open(0, 1);
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIncompleteConfiguration() throws IOException {
-        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
-                .finish();
-    }
+	@Test(expected = IllegalArgumentException.class)
+	public void testIncompleteConfiguration() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
+				.finish();
+	}
 
-    @Test(expected = IOException.class)
-    public void testIncompatibleTuple() throws IOException {
-        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
-                .finish();
-        jdbcOutputFormat.open(0, 1);
+	@Test(expected = IOException.class)
+	public void testIncompatibleTuple() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
+				.finish();
+		jdbcOutputFormat.open(0, 1);
 
-        Tuple3 tuple3 = new Tuple3();
-        tuple3.setField(4, 0);
-        tuple3.setField("hi", 1);
-        tuple3.setField(4.4, 2);
+		Tuple3 tuple3 = new Tuple3();
+		tuple3.setField(4, 0);
+		tuple3.setField("hi", 1);
+		tuple3.setField(4.4, 2);
 
-        jdbcOutputFormat.writeRecord(tuple3);
-        jdbcOutputFormat.close();
-    }
+		jdbcOutputFormat.writeRecord(tuple3);
+		jdbcOutputFormat.close();
+	}
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIncompatibleTypes() throws IOException {
-        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
-                .setDBUrl("jdbc:derby:memory:ebookshop")
-                .setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
-                .finish();
-        jdbcOutputFormat.open(0, 1);
+	@Test(expected = IllegalArgumentException.class)
+	public void testIncompatibleTypes() throws IOException {
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+				.setDBUrl("jdbc:derby:memory:ebookshop")
+				.setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
+				.finish();
+		jdbcOutputFormat.open(0, 1);
 
-        Tuple5 tuple5 = new Tuple5();
-        tuple5.setField(4, 0);
-        tuple5.setField("hello", 1);
-        tuple5.setField("world", 2);
-        tuple5.setField(0.99, 3);
-        tuple5.setField("imthewrongtype", 4);
+		Tuple5 tuple5 = new Tuple5();
+		tuple5.setField(4, 0);
+		tuple5.setField("hello", 1);
+		tuple5.setField("world", 2);
+		tuple5.setField(0.99, 3);
+		tuple5.setField("imthewrongtype", 4);
 
-        jdbcOutputFormat.writeRecord(tuple5);
-        jdbcOutputFormat.close();
-    }
+		jdbcOutputFormat.writeRecord(tuple5);
+		jdbcOutputFormat.close();
+	}
 
-    @Test
-    public void testJDBCOutputFormat() throws IOException {
-        String sourceTable = "books";
-        String targetTable = "newbooks";
-        String driverPath = "org.apache.derby.jdbc.EmbeddedDriver";
-        String dbUrl = "jdbc:derby:memory:ebookshop";
+	@Test
+	public void testJDBCOutputFormat() throws IOException {
+		String sourceTable = "books";
+		String targetTable = "newbooks";
+		String driverPath = "org.apache.derby.jdbc.EmbeddedDriver";
+		String dbUrl = "jdbc:derby:memory:ebookshop";
 
-        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
-                .setDBUrl(dbUrl)
-                .setDrivername(driverPath)
-                .setQuery("insert into " + targetTable + " (id, title, author, price, qty) values (?,?,?,?,?)")
-                .finish();
-        jdbcOutputFormat.open(0, 1);
+		jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+				.setDBUrl(dbUrl)
+				.setDrivername(driverPath)
+				.setQuery("insert into " + targetTable + " (id, title, author, price, qty) values (?,?,?,?,?)")
+				.finish();
+		jdbcOutputFormat.open(0, 1);
 
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername(driverPath)
-                .setDBUrl(dbUrl)
-                .setQuery("select * from " + sourceTable)
-                .finish();
-        jdbcInputFormat.open(null);
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername(driverPath)
+				.setDBUrl(dbUrl)
+				.setQuery("select * from " + sourceTable)
+				.finish();
+		jdbcInputFormat.open(null);
 
-        Tuple5 tuple = new Tuple5();
-        while (!jdbcInputFormat.reachedEnd()) {
-            jdbcInputFormat.nextRecord(tuple);
-            jdbcOutputFormat.writeRecord(tuple);
-        }
+		Tuple5 tuple = new Tuple5();
+		while (!jdbcInputFormat.reachedEnd()) {
+			jdbcInputFormat.nextRecord(tuple);
+			jdbcOutputFormat.writeRecord(tuple);
+		}
 
-        jdbcOutputFormat.close();
-        jdbcInputFormat.close();
+		jdbcOutputFormat.close();
+		jdbcInputFormat.close();
 
-        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
-                .setDrivername(driverPath)
-                .setDBUrl(dbUrl)
-                .setQuery("select * from " + targetTable)
-                .finish();
-        jdbcInputFormat.open(null);
+		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+				.setDrivername(driverPath)
+				.setDBUrl(dbUrl)
+				.setQuery("select * from " + targetTable)
+				.finish();
+		jdbcInputFormat.open(null);
 
-        int recordCount = 0;
-        while (!jdbcInputFormat.reachedEnd()) {
-            jdbcInputFormat.nextRecord(tuple);
-            Assert.assertEquals("Field 0 should be int", Integer.class, tuple.getField(0).getClass());
-            Assert.assertEquals("Field 1 should be String", String.class, tuple.getField(1).getClass());
-            Assert.assertEquals("Field 2 should be String", String.class, tuple.getField(2).getClass());
-            Assert.assertEquals("Field 3 should be float", Double.class, tuple.getField(3).getClass());
-            Assert.assertEquals("Field 4 should be int", Integer.class, tuple.getField(4).getClass());
+		int recordCount = 0;
+		while (!jdbcInputFormat.reachedEnd()) {
+			jdbcInputFormat.nextRecord(tuple);
+			Assert.assertEquals("Field 0 should be int", Integer.class, tuple.getField(0).getClass());
+			Assert.assertEquals("Field 1 should be String", String.class, tuple.getField(1).getClass());
+			Assert.assertEquals("Field 2 should be String", String.class, tuple.getField(2).getClass());
+			Assert.assertEquals("Field 3 should be float", Double.class, tuple.getField(3).getClass());
+			Assert.assertEquals("Field 4 should be int", Integer.class, tuple.getField(4).getClass());
 
-            for (int x = 0; x < 5; x++) {
-                Assert.assertEquals(dbData[recordCount][x], tuple.getField(x));
-            }
+			for (int x = 0; x < 5; x++) {
+				Assert.assertEquals(dbData[recordCount][x], tuple.getField(x));
+			}
 
-            recordCount++;
-        }
-        Assert.assertEquals(5, recordCount);
+			recordCount++;
+		}
+		Assert.assertEquals(5, recordCount);
 
-        jdbcInputFormat.close();
-    }
+		jdbcInputFormat.close();
+	}
 }

--- a/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormatTest.java
+++ b/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormatTest.java
@@ -1,0 +1,179 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.io.jdbc;
+
+import eu.stratosphere.api.java.tuple.Tuple5;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JDBCOutputFormatTest {
+    private JDBCInputFormat jdbcInputFormat;
+    private JDBCOutputFormat jdbcOutputFormat;
+
+    private static Connection conn;
+
+    static final Object[][] dbData = {
+        {new Integer(1001), ("Java for dummies"), ("Tan Ah Teck"), new Double(11.11), new Integer(11)},
+        {new Integer(1002), ("More Java for dummies"), ("Tan Ah Teck"), new Double(22.22), new Integer(22)},
+        {new Integer(1003), ("More Java for more dummies"), ("Mohammad Ali"), new Double(33.33), new Integer(33)},
+        {new Integer(1004), ("A Cup of Java"), ("Kumar"), new Double(44.44), new Integer(44)},
+        {new Integer(1005), ("A Teaspoon of Java"), ("Kevin Jones"), new Double(55.55), new Integer(55)}};
+
+    @BeforeClass
+    public static void setUpClass() throws SQLException {
+        try {
+            System.setProperty("derby.stream.error.field", "eu.stratosphere.api.java.record.io.jdbc.DevNullLogStream.DEV_NULL");
+            prepareDerbyDatabase();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    private static void prepareDerbyDatabase() throws ClassNotFoundException, SQLException {
+        String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+        Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+        conn = DriverManager.getConnection(dbURL);
+        createTable("books");
+        createTable("newbooks");
+        insertDataToSQLTables();
+        conn.close();
+    }
+
+    private static void createTable(String tableName) throws SQLException {
+        StringBuilder sqlQueryBuilder = new StringBuilder("CREATE TABLE ");
+        sqlQueryBuilder.append(tableName);
+        sqlQueryBuilder.append(" (");
+        sqlQueryBuilder.append("id INT NOT NULL DEFAULT 0,");
+        sqlQueryBuilder.append("title VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("author VARCHAR(50) DEFAULT NULL,");
+        sqlQueryBuilder.append("price FLOAT DEFAULT NULL,");
+        sqlQueryBuilder.append("qty INT DEFAULT NULL,");
+        sqlQueryBuilder.append("PRIMARY KEY (id))");
+
+        Statement stat = conn.createStatement();
+        stat.executeUpdate(sqlQueryBuilder.toString());
+        stat.close();
+    }
+
+    private static void insertDataToSQLTables() throws SQLException {
+        StringBuilder sqlQueryBuilder = new StringBuilder("INSERT INTO books (id, title, author, price, qty) VALUES ");
+        sqlQueryBuilder.append("(1001, 'Java for dummies', 'Tan Ah Teck', 11.11, 11),");
+        sqlQueryBuilder.append("(1002, 'More Java for dummies', 'Tan Ah Teck', 22.22, 22),");
+        sqlQueryBuilder.append("(1003, 'More Java for more dummies', 'Mohammad Ali', 33.33, 33),");
+        sqlQueryBuilder.append("(1004, 'A Cup of Java', 'Kumar', 44.44, 44),");
+        sqlQueryBuilder.append("(1005, 'A Teaspoon of Java', 'Kevin Jones', 55.55, 55)");
+
+        Statement stat = conn.createStatement();
+        stat.execute(sqlQueryBuilder.toString());
+        stat.close();
+    }
+    
+    @AfterClass
+    public static void tearDownClass(){
+        cleanUpDerbyDatabases();
+    }
+    
+    private static void cleanUpDerbyDatabases() {
+    	 try {
+             String dbURL = "jdbc:derby:memory:ebookshop;create=true";
+             Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+             
+             conn = DriverManager.getConnection(dbURL);
+             Statement stat = conn.createStatement();
+             stat.executeUpdate("DROP TABLE books");
+             stat.executeUpdate("DROP TABLE newbooks");
+             stat.close();
+             conn.close();
+         } catch (Exception e) {
+        	 e.printStackTrace();
+             Assert.fail();
+         } 
+    }
+
+    @After
+    public void tearDown() {
+        jdbcOutputFormat = null;
+    }
+
+    @Test
+    public void testJDBCOutputFormat() throws IOException {
+        String sourceTable = "books";
+        String targetTable = "newbooks";
+        String driverPath = "org.apache.derby.jdbc.EmbeddedDriver";
+        String dbUrl = "jdbc:derby:memory:ebookshop";
+
+
+        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+                .setDBUrl(dbUrl)
+                .setDrivername(driverPath)
+                .setQuery("insert into " + targetTable + " (id, title, author, price, qty) values (?,?,?,?,?)")
+                .finish();
+        jdbcOutputFormat.open(0, 1);
+
+        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+                .setDrivername(driverPath)
+                .setDBUrl(dbUrl)
+                .setQuery("select * from " + sourceTable)
+                .finish();
+        jdbcInputFormat.open(null);
+
+        Tuple5 tuple = new Tuple5();
+        while (!jdbcInputFormat.reachedEnd()) {
+            jdbcInputFormat.nextRecord(tuple);
+            jdbcOutputFormat.writeRecord(tuple);
+        }
+
+        jdbcOutputFormat.close();
+        jdbcInputFormat.close();
+
+        jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
+                .setDrivername(driverPath)
+                .setDBUrl(dbUrl)
+                .setQuery("select * from " + targetTable)
+                .finish();
+        jdbcInputFormat.open(null);
+
+        int recordCount = 0;
+        while (!jdbcInputFormat.reachedEnd()) {
+            jdbcInputFormat.nextRecord(tuple);
+            Assert.assertEquals("Field 0 should be int", Integer.class, tuple.getField(0).getClass());
+            Assert.assertEquals("Field 1 should be String", String.class, tuple.getField(1).getClass());
+            Assert.assertEquals("Field 2 should be String", String.class, tuple.getField(2).getClass());
+            Assert.assertEquals("Field 3 should be float", Double.class, tuple.getField(3).getClass());
+            Assert.assertEquals("Field 4 should be int", Integer.class, tuple.getField(4).getClass());
+
+
+            for (int x = 0; x < 5; x++) {
+                Assert.assertEquals(dbData[recordCount][x], tuple.getField(x));
+            }
+
+            recordCount++;
+        }
+        Assert.assertEquals(5, recordCount);
+
+        jdbcInputFormat.close();
+    }
+}

--- a/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormatTest.java
+++ b/stratosphere-addons/jdbc/src/test/java/eu/stratosphere/api/java/io/jdbc/JDBCOutputFormatTest.java
@@ -156,7 +156,7 @@ public class JDBCOutputFormatTest {
     }
 
     @Test(expected = IOException.class)
-    public void testIncompatibleTypes() throws IOException {
+    public void testIncompatibleTuple() throws IOException {
         jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
                 .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
                 .setDBUrl("jdbc:derby:memory:ebookshop")
@@ -170,6 +170,26 @@ public class JDBCOutputFormatTest {
         tuple3.setField(4.4, 2);
 
         jdbcOutputFormat.writeRecord(tuple3);
+        jdbcOutputFormat.close();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIncompatibleTypes() throws IOException {
+        jdbcOutputFormat = JDBCOutputFormat.buildJDBCOutputFormat()
+                .setDrivername("org.apache.derby.jdbc.EmbeddedDriver")
+                .setDBUrl("jdbc:derby:memory:ebookshop")
+                .setQuery("insert into books (id, title, author, price, qty) values (?,?,?,?,?)")
+                .finish();
+        jdbcOutputFormat.open(0, 1);
+
+        Tuple5 tuple5 = new Tuple5();
+        tuple5.setField(4, 0);
+        tuple5.setField("hello", 1);
+        tuple5.setField("world", 2);
+        tuple5.setField(0.99, 3);
+        tuple5.setField("imthewrongtype", 4);
+
+        jdbcOutputFormat.writeRecord(tuple5);
         jdbcOutputFormat.close();
     }
 


### PR DESCRIPTION
I ported the JDBC Formats to the new API. (both formats, tests for each and an example).

The outputformat only supports a number of types, currently these

```
private enum supportedTypes {
        Boolean,
        Byte,
        Short,
        Integer,
        Long,
        String,
        Float,
        Double
    }
```

Are there others i should add, like ValueTypes?
