### PR TITLE
Created TupleBuilder class for each Tuple class( via TupleGenerator )

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple10Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple10Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple10;
+
+public class Tuple10Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> {
+
+	private List<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> tuples = new LinkedList<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>();
+
+	public Tuple10Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9){
+		tuples.add(new Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>[] build(){
+		return tuples.toArray(new Tuple10[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple11Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple11Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple11;
+
+public class Tuple11Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
+
+	private List<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> tuples = new LinkedList<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>();
+
+	public Tuple11Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10){
+		tuples.add(new Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>[] build(){
+		return tuples.toArray(new Tuple11[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple12Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple12Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple12;
+
+public class Tuple12Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> {
+
+	private List<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> tuples = new LinkedList<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>();
+
+	public Tuple12Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11){
+		tuples.add(new Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>[] build(){
+		return tuples.toArray(new Tuple12[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple13Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple13Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple13;
+
+public class Tuple13Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> {
+
+	private List<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> tuples = new LinkedList<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>();
+
+	public Tuple13Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12){
+		tuples.add(new Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>[] build(){
+		return tuples.toArray(new Tuple13[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple14Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple14Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple14;
+
+public class Tuple14Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> {
+
+	private List<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> tuples = new LinkedList<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>();
+
+	public Tuple14Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13){
+		tuples.add(new Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>[] build(){
+		return tuples.toArray(new Tuple14[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple15Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple15Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple15;
+
+public class Tuple15Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> {
+
+	private List<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> tuples = new LinkedList<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>();
+
+	public Tuple15Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14){
+		tuples.add(new Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>[] build(){
+		return tuples.toArray(new Tuple15[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple16Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple16Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple16;
+
+public class Tuple16Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> {
+
+	private List<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> tuples = new LinkedList<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>();
+
+	public Tuple16Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15){
+		tuples.add(new Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>[] build(){
+		return tuples.toArray(new Tuple16[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple17Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple17Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple17;
+
+public class Tuple17Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> {
+
+	private List<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> tuples = new LinkedList<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>();
+
+	public Tuple17Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16){
+		tuples.add(new Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>[] build(){
+		return tuples.toArray(new Tuple17[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple18Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple18Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple18;
+
+public class Tuple18Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> {
+
+	private List<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> tuples = new LinkedList<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>();
+
+	public Tuple18Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17){
+		tuples.add(new Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>[] build(){
+		return tuples.toArray(new Tuple18[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple19Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple19Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple19;
+
+public class Tuple19Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> {
+
+	private List<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> tuples = new LinkedList<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>();
+
+	public Tuple19Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18){
+		tuples.add(new Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>[] build(){
+		return tuples.toArray(new Tuple19[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple1Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple1Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple1;
+
+public class Tuple1Builder<T0> {
+
+	private List<Tuple1<T0>> tuples = new LinkedList<Tuple1<T0>>();
+
+	public Tuple1Builder<T0> add(T0 value0){
+		tuples.add(new Tuple1<T0>(value0));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple1<T0>[] build(){
+		return tuples.toArray(new Tuple1[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple20Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple20Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple20;
+
+public class Tuple20Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> {
+
+	private List<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> tuples = new LinkedList<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>();
+
+	public Tuple20Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19){
+		tuples.add(new Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>[] build(){
+		return tuples.toArray(new Tuple20[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple21Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple21Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple21;
+
+public class Tuple21Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> {
+
+	private List<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> tuples = new LinkedList<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>();
+
+	public Tuple21Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20){
+		tuples.add(new Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>[] build(){
+		return tuples.toArray(new Tuple21[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple22Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple22Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple22;
+
+public class Tuple22Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> {
+
+	private List<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> tuples = new LinkedList<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>();
+
+	public Tuple22Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21){
+		tuples.add(new Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>[] build(){
+		return tuples.toArray(new Tuple22[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple2Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple2Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple2;
+
+public class Tuple2Builder<T0, T1> {
+
+	private List<Tuple2<T0, T1>> tuples = new LinkedList<Tuple2<T0, T1>>();
+
+	public Tuple2Builder<T0, T1> add(T0 value0, T1 value1){
+		tuples.add(new Tuple2<T0, T1>(value0, value1));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple2<T0, T1>[] build(){
+		return tuples.toArray(new Tuple2[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple3Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple3Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple3;
+
+public class Tuple3Builder<T0, T1, T2> {
+
+	private List<Tuple3<T0, T1, T2>> tuples = new LinkedList<Tuple3<T0, T1, T2>>();
+
+	public Tuple3Builder<T0, T1, T2> add(T0 value0, T1 value1, T2 value2){
+		tuples.add(new Tuple3<T0, T1, T2>(value0, value1, value2));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple3<T0, T1, T2>[] build(){
+		return tuples.toArray(new Tuple3[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple4Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple4Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple4;
+
+public class Tuple4Builder<T0, T1, T2, T3> {
+
+	private List<Tuple4<T0, T1, T2, T3>> tuples = new LinkedList<Tuple4<T0, T1, T2, T3>>();
+
+	public Tuple4Builder<T0, T1, T2, T3> add(T0 value0, T1 value1, T2 value2, T3 value3){
+		tuples.add(new Tuple4<T0, T1, T2, T3>(value0, value1, value2, value3));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple4<T0, T1, T2, T3>[] build(){
+		return tuples.toArray(new Tuple4[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple5Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple5Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple5;
+
+public class Tuple5Builder<T0, T1, T2, T3, T4> {
+
+	private List<Tuple5<T0, T1, T2, T3, T4>> tuples = new LinkedList<Tuple5<T0, T1, T2, T3, T4>>();
+
+	public Tuple5Builder<T0, T1, T2, T3, T4> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4){
+		tuples.add(new Tuple5<T0, T1, T2, T3, T4>(value0, value1, value2, value3, value4));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple5<T0, T1, T2, T3, T4>[] build(){
+		return tuples.toArray(new Tuple5[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple6Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple6Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple6;
+
+public class Tuple6Builder<T0, T1, T2, T3, T4, T5> {
+
+	private List<Tuple6<T0, T1, T2, T3, T4, T5>> tuples = new LinkedList<Tuple6<T0, T1, T2, T3, T4, T5>>();
+
+	public Tuple6Builder<T0, T1, T2, T3, T4, T5> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5){
+		tuples.add(new Tuple6<T0, T1, T2, T3, T4, T5>(value0, value1, value2, value3, value4, value5));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple6<T0, T1, T2, T3, T4, T5>[] build(){
+		return tuples.toArray(new Tuple6[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple7Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple7Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple7;
+
+public class Tuple7Builder<T0, T1, T2, T3, T4, T5, T6> {
+
+	private List<Tuple7<T0, T1, T2, T3, T4, T5, T6>> tuples = new LinkedList<Tuple7<T0, T1, T2, T3, T4, T5, T6>>();
+
+	public Tuple7Builder<T0, T1, T2, T3, T4, T5, T6> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6){
+		tuples.add(new Tuple7<T0, T1, T2, T3, T4, T5, T6>(value0, value1, value2, value3, value4, value5, value6));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple7<T0, T1, T2, T3, T4, T5, T6>[] build(){
+		return tuples.toArray(new Tuple7[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple8Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple8Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple8;
+
+public class Tuple8Builder<T0, T1, T2, T3, T4, T5, T6, T7> {
+
+	private List<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> tuples = new LinkedList<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>();
+
+	public Tuple8Builder<T0, T1, T2, T3, T4, T5, T6, T7> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7){
+		tuples.add(new Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>(value0, value1, value2, value3, value4, value5, value6, value7));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>[] build(){
+		return tuples.toArray(new Tuple8[tuples.size()]);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple9Builder.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/builder/Tuple9Builder.java
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+// --------------------------------------------------------------
+//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
+//  GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+// --------------------------------------------------------------
+
+
+package eu.stratosphere.api.java.tuple.builder;
+
+import java.util.List;
+import java.util.LinkedList;
+import eu.stratosphere.api.java.tuple.Tuple9;
+
+public class Tuple9Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8> {
+
+	private List<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> tuples = new LinkedList<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>();
+
+	public Tuple9Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8> add(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8){
+		tuples.add(new Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>(value0, value1, value2, value3, value4, value5, value6, value7, value8));
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>[] build(){
+		return tuples.toArray(new Tuple9[tuples.size()]);
+	}
+}


### PR DESCRIPTION
Corr. Issue: https://github.com/stratosphere/stratosphere/issues/654

Made a TupleNBuilder for each TupleN class. 
All 22 builder get generated by the TupleGenerator.

The example from the issue can now be written like this:

``` java
DataSet<Tuple2<String, Integer>> data = env.fromElements(new Tuple2Builder<String, Integer>()
    .add("hello", 1)
    .add("world", 2)
    .build());
```
