### PR TITLE
New java Api Union

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
@@ -16,12 +16,11 @@ package eu.stratosphere.compiler.dag;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import eu.stratosphere.api.common.functions.AbstractFunction;
 import eu.stratosphere.api.common.operators.DualInputOperator;
-import eu.stratosphere.api.common.operators.Operator;
+import eu.stratosphere.api.common.operators.Union;
 import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
 import eu.stratosphere.compiler.CompilerException;
 import eu.stratosphere.compiler.DataStatistics;
@@ -44,6 +43,13 @@ public class BinaryUnionNode extends TwoInputNode {
 	
 	private Set<RequestedGlobalProperties> channelProps;
 
+	/* 
+	 * Constructor used by the new java API
+	 */
+	public BinaryUnionNode(Union union){
+		super(union);
+	}
+	
 	public BinaryUnionNode(OptimizerNode pred1, OptimizerNode pred2) {
 		super(new UnionPlaceholderContract());
 		
@@ -68,10 +74,10 @@ public class BinaryUnionNode extends TwoInputNode {
 		return "Union";
 	}
 	
-	@Override
+	/*@Override
 	public void setInputs(Map<Operator, OptimizerNode> contractToNode) {
 		throw new UnsupportedOperationException();
-	}
+	}*/
 
 	@Override
 	protected List<OperatorDescriptorDual> getPossibleProperties() {

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Union.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Union.java
@@ -1,0 +1,32 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.api.common.operators;
+
+import eu.stratosphere.api.common.functions.AbstractFunction;
+import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
+
+public class Union extends DualInputOperator<AbstractFunction> {
+	
+	private final static String NAME = "UNION";
+	
+	/* 
+	 * Represent a union as contract with abstract function,  
+	 * it will be replaced in the PACT compiler later
+	 */
+	public Union() {
+		super(new UserCodeClassWrapper<AbstractFunction>(AbstractFunction.class), NAME);
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -49,6 +49,7 @@ import eu.stratosphere.api.java.operators.ProjectOperator;
 import eu.stratosphere.api.java.operators.ProjectOperator.Projection;
 import eu.stratosphere.api.java.operators.ReduceGroupOperator;
 import eu.stratosphere.api.java.operators.ReduceOperator;
+import eu.stratosphere.api.java.operators.UnionOperator;
 import eu.stratosphere.api.java.tuple.Tuple;
 import eu.stratosphere.api.java.typeutils.InputTypeConfigurable;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -532,6 +533,11 @@ public abstract class DataSet<T> {
 	public <R> CrossOperator.CrossOperatorSets<T, R> crossWithHuge(DataSet<R> other) {
 		return new CrossOperator.CrossOperatorSets<T, R>(this, other);
 	}
+	
+	public <R> UnionOperator<T> union(DataSet<T> input){
+		return new UnionOperator<T>(this, input);
+	}
+
 
 	// --------------------------------------------------------------------------------------------
 	//  Iterations

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/UnionOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/UnionOperator.java
@@ -1,0 +1,32 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.api.java.operators;
+
+import eu.stratosphere.api.common.operators.Union;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.operators.translation.BinaryNodeTranslation;
+
+public class UnionOperator<T> extends TwoInputOperator<T, T, T, UnionOperator<T>> {
+
+	public UnionOperator(DataSet<T> input1, DataSet<T> input2) {
+		super(input1, input2, input1.getType());
+	}
+	 
+	@Override
+	protected BinaryNodeTranslation translateToDataFlow() {
+		return new BinaryNodeTranslation(new Union());
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/RuntimeSerializerFactory.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/RuntimeSerializerFactory.java
@@ -22,7 +22,6 @@ public final class RuntimeSerializerFactory<T> implements TypeSerializerFactory<
 
 	private static final long serialVersionUID = 1L;
 
-
 	private static final String CONFIG_KEY_SER = "SER_DATA";
 
 	private static final String CONFIG_KEY_CLASS = "CLASS_DATA";
@@ -79,5 +78,21 @@ public final class RuntimeSerializerFactory<T> implements TypeSerializerFactory<
 	public Class<T> getDataType() {
 		return clazz;
 	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean equals(Object obj) {
+		if(obj == null){
+			return false;
+		}
+		
+		if(!(obj instanceof RuntimeSerializerFactory)){
+			return false;
+		}
+		
+		RuntimeSerializerFactory<T> otherRSF = (RuntimeSerializerFactory<T>) obj;
+		return otherRSF.clazz == this.clazz && otherRSF.serializer.equals(serializer);
+	}
 
+	
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
@@ -15,6 +15,7 @@
 package eu.stratosphere.api.java.typeutils.runtime;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.api.java.tuple.Tuple;
@@ -96,5 +97,21 @@ public final class TupleSerializer<T extends Tuple> extends TypeSerializer<T> {
 		for (int i = 0; i < arity; i++) {
 			fieldSerializers[i].copy(source, target);
 		}
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if(obj == null){
+			return false;
+		}
+		
+		if(!(obj instanceof TupleSerializer<?>)){
+			return false;
+		}
+		
+		TupleSerializer<?> otherTS = (TupleSerializer<?>) obj;
+		
+		return (otherTS.tupleClass == this.tupleClass) && 
+				Arrays.deepEquals(this.fieldSerializers,fieldSerializers);
 	}
 }

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/UnionITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/UnionITCase.java
@@ -1,0 +1,171 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.test.javaApiOperators;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.functions.FilterFunction;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.test.javaApiOperators.util.CollectionDataSets;
+import eu.stratosphere.test.util.JavaProgramTestBase;
+
+@RunWith(Parameterized.class)
+public class UnionITCase extends JavaProgramTestBase {
+	
+	private static int NUM_PROGRAMS = 3; 
+	
+	private int curProgId = config.getInteger("ProgramId", -1);
+	private String resultPath;
+	private String expectedResult;
+
+	public UnionITCase(Configuration config) {
+		super(config);	
+	}
+	
+	@Override
+	protected void preSubmit() throws Exception {
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		expectedResult = FilterProgs.runProgram(curProgId, resultPath);
+	}
+	
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(expectedResult, resultPath);
+	}
+	
+	@Parameters
+	public static Collection<Object[]> getConfigurations() throws FileNotFoundException, IOException {
+
+		LinkedList<Configuration> tConfigs = new LinkedList<Configuration>();
+
+		for(int i=1; i <= NUM_PROGRAMS; i++) {
+			Configuration config = new Configuration();
+			config.setInteger("ProgramId", i);
+			tConfigs.add(config);
+		}
+		
+		return toParameterList(tConfigs);
+	}
+	
+	private static class FilterProgs {
+
+		private static final String FULL_TUPLE_3_STRING = "1,1,Hi\n" +
+				"2,2,Hello\n" +
+				"3,2,Hello world\n" +
+				"4,3,Hello world, how are you?\n" +
+				"5,3,I am fine.\n" +
+				"6,3,Luke Skywalker\n" +
+				"7,4,Comment#1\n" +
+				"8,4,Comment#2\n" +
+				"9,4,Comment#3\n" +
+				"10,4,Comment#4\n" +
+				"11,5,Comment#5\n" +
+				"12,5,Comment#6\n" +
+				"13,5,Comment#7\n" +
+				"14,5,Comment#8\n" +
+				"15,5,Comment#9\n" +
+				"16,6,Comment#10\n" +
+				"17,6,Comment#11\n" +
+				"18,6,Comment#12\n" +
+				"19,6,Comment#13\n" +
+				"20,6,Comment#14\n" +
+				"21,6,Comment#15\n";
+		
+		public static String runProgram(int progId, String resultPath) throws Exception {
+			
+			switch(progId) {
+			case 1: {
+				/*
+				 * Union of 2 Same Data Sets
+				 */
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> unionDs = ds.union(CollectionDataSets.get3TupleDataSet(env));
+				
+				unionDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING;
+			}
+			case 2: {
+				/*
+				 * Union of 5 same Data Sets, with multiple unions
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> unionDs = ds.union(CollectionDataSets.get3TupleDataSet(env))
+						.union(CollectionDataSets.get3TupleDataSet(env))
+						.union(CollectionDataSets.get3TupleDataSet(env))
+						.union(CollectionDataSets.get3TupleDataSet(env));
+				
+				unionDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING;
+			}
+			case 3: {
+				/*
+				 * Test on union with empty dataset
+				 */
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				// Don't know how to make an empty result in an other way than filtering it 
+				DataSet<Tuple3<Integer, Long, String>> empty = CollectionDataSets.get3TupleDataSet(env).
+						filter(new FilterFunction<Tuple3<Integer,Long,String>>() {
+							private static final long serialVersionUID = 1L;
+
+							@Override
+							public boolean filter(Tuple3<Integer, Long, String> value) throws Exception {
+								return false;
+							}
+						});
+				
+				DataSet<Tuple3<Integer, Long, String>> unionDs = CollectionDataSets.get3TupleDataSet(env)
+					.union(empty);
+			
+				unionDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return FULL_TUPLE_3_STRING;				
+			}
+			default: 
+				throw new IllegalArgumentException("Invalid program id");
+			}
+			
+		}
+	
+	}
+	
+}


### PR DESCRIPTION
Corr. Issue: https://github.com/stratosphere/stratosphere/issues/621

A union operator for the new Java-API callable: dataSet1.union(dataSet2)
There exists a binary union operator from the java-api down to the optimizer level. 
This means that unions do not need to be handled over lists of operators by the commons-api anymore, but a cascade of union-operators can be used for this case. Therefore my next step is to clean the code from the operator lists to make the code "slimmer".
