### PR TITLE
New Annotations for JAPI.

### DIFF
--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCollection.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCollection.java
@@ -17,14 +17,15 @@ package eu.stratosphere.example.java.wordcount;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi.ConstantFields;
 import eu.stratosphere.api.java.tuple.*;
 import eu.stratosphere.util.Collector;
-
 import static eu.stratosphere.api.java.aggregation.Aggregations.*;
 
 @SuppressWarnings("serial")
+
 public class WordCountCollection {
-	
+	@ConstantFields(from={1,2,3}, to={0,1})
 	public static final class Tokenizer extends FlatMapFunction<String, Tuple2<String, Integer>> {
 
 		@Override

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCollection.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCollection.java
@@ -19,11 +19,12 @@ import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.tuple.*;
 import eu.stratosphere.util.Collector;
+
 import static eu.stratosphere.api.java.aggregation.Aggregations.*;
 
 @SuppressWarnings("serial")
-
 public class WordCountCollection {
+	
 	public static final class Tokenizer extends FlatMapFunction<String, Tuple2<String, Integer>> {
 
 		@Override

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCollection.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/wordcount/WordCountCollection.java
@@ -17,7 +17,6 @@ package eu.stratosphere.example.java.wordcount;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi.ConstantFields;
 import eu.stratosphere.api.java.tuple.*;
 import eu.stratosphere.util.Collector;
 import static eu.stratosphere.api.java.aggregation.Aggregations.*;
@@ -25,7 +24,6 @@ import static eu.stratosphere.api.java.aggregation.Aggregations.*;
 @SuppressWarnings("serial")
 
 public class WordCountCollection {
-	@ConstantFields(from={1,2,3}, to={0,1})
 	public static final class Tokenizer extends FlatMapFunction<String, Tuple2<String, Integer>> {
 
 		@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
@@ -23,9 +23,7 @@ import com.google.common.primitives.Ints;
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
-import eu.stratosphere.util.Collector;
 
 
 /**

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
@@ -52,7 +52,7 @@ import eu.stratosphere.util.Collector;
  * ({@link MapFunction}, {@link ReduceFunction}) and some only for stubs with two inputs 
  * ({@link CrossFunction}, {@link JoinFunction}, {@link CoGroupFunction}).
  */
-public class FunctionAnnotationJapi {
+public class FunctionAnnotation {
 	
 	/**
 	 * Specifies the fields of an input record that are unchanged in the output of 
@@ -284,7 +284,7 @@ public class FunctionAnnotationJapi {
 	/**
 	 * Private constructor to prevent instantiation. This class is intended only as a container.
 	 */
-	private FunctionAnnotationJapi() {}
+	private FunctionAnnotation() {}
 	
 	// --------------------------------------------------------------------------------------------
 	//                                   Function Annotation Handling

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CoGroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CoGroupOperator.java
@@ -89,7 +89,7 @@ public class CoGroupOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OU
 		
 		return new BinaryNodeTranslation(
 				new PlanCogroupOperator<I1, I2, OUT>(function, logicalKeyPositions1, logicalKeyPositions2, 
-						name, getInput1Type(), getInput2Type(), getResultType()));
+						name, getInput1Type(), getInput2Type(), getResultType(), getSemanticProps()));
 		}
 		else {
 			throw new UnsupportedOperationException("Unrecognized or incompatible key types.");

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CrossOperator.java
@@ -41,7 +41,7 @@ public class CrossOperator<I1, I2, OUT>
 	@Override
 	protected BinaryNodeTranslation translateToDataFlow() {
 		String name = getName() != null ? getName() : function.getClass().getName();
-		return new BinaryNodeTranslation(new PlanCrossOperator<I1, I2, OUT>(function, name, getInput1Type(), getInput2Type(), getResultType()));
+		return new BinaryNodeTranslation(new PlanCrossOperator<I1, I2, OUT>(function, name, getInput1Type(), getInput2Type(), getResultType(), getSemanticProps()));
 	}
 	
 

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/FlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/FlatMapOperator.java
@@ -32,7 +32,7 @@ public class FlatMapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, Fl
 	
 	public FlatMapOperator(DataSet<IN> input, FlatMapFunction<IN, OUT> function) {
 		super(input, TypeExtractor.getFlatMapReturnTypes(function));
-		
+
 		if (function == null)
 			throw new NullPointerException("FlatMap function must not be null.");
 		

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/FlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/FlatMapOperator.java
@@ -14,6 +14,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.operators;
 
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.operators.translation.PlanFlatMapOperator;
@@ -42,6 +43,6 @@ public class FlatMapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, Fl
 	@Override
 	protected UnaryNodeTranslation translateToDataFlow() {
 		String name = getName() != null ? getName() : function.getClass().getName();
-		return new UnaryNodeTranslation(new PlanFlatMapOperator<IN, OUT>(function, name, getInputType(), getResultType()));
+		return new UnaryNodeTranslation(new PlanFlatMapOperator<IN, OUT>(function, name, getInputType(), getResultType(), getSemanticProps()));
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/JoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/JoinOperator.java
@@ -179,7 +179,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 				
 				return new BinaryNodeTranslation(
 						new PlanJoinOperator<I1, I2, OUT>(function, logicalKeyPositions1, logicalKeyPositions2, 
-								name, getInput1Type(), getInput2Type(), getResultType()));
+								name, getInput1Type(), getInput2Type(), getResultType(), getSemanticProps()));
 			}
 			else {
 				throw new UnsupportedOperationException("Unrecognized or incompatible key types.");

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/MapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/MapOperator.java
@@ -43,6 +43,6 @@ public class MapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, MapOpe
 	@Override
 	protected UnaryNodeTranslation translateToDataFlow() {
 		String name = getName() != null ? getName() : function.getClass().getName();
-		return new UnaryNodeTranslation(new PlanMapOperator<IN, OUT>(function, name, getInputType(), getResultType()));
+		return new UnaryNodeTranslation(new PlanMapOperator<IN, OUT>(function, name, getInputType(), getResultType(), getSemanticProps()));
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceGroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceGroupOperator.java
@@ -82,7 +82,7 @@ public class ReduceGroupOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 		// distinguish between grouped reduce and non-grouped reduce
 		if (grouper == null) {
 			// non grouped reduce
-			return new UnaryNodeTranslation(new PlanGroupReduceOperator<IN, OUT>(function, new int[0], name, getInputType(), getResultType()));
+			return new UnaryNodeTranslation(new PlanGroupReduceOperator<IN, OUT>(function, new int[0], name, getInputType(), getResultType(), getSemanticProps()));
 		}
 		
 		
@@ -96,7 +96,7 @@ public class ReduceGroupOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT
 		else if (grouper.getKeys() instanceof Keys.FieldPositionKeys) {
 
 			int[] logicalKeyPositions = grouper.getKeys().computeLogicalKeyPositions();
-			PlanGroupReduceOperator<IN, OUT> reduceOp = new PlanGroupReduceOperator<IN, OUT>(function, logicalKeyPositions, name, getInputType(), getResultType());
+			PlanGroupReduceOperator<IN, OUT> reduceOp = new PlanGroupReduceOperator<IN, OUT>(function, logicalKeyPositions, name, getInputType(), getResultType(), getSemanticProps());
 			
 			// set group order
 			if(grouper.getGroupSortKeyPositions() != null) {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
@@ -74,7 +74,7 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		// distinguish between grouped reduce and non-grouped reduce
 		if (grouper == null) {
 			// non grouped reduce
-			return new UnaryNodeTranslation(new PlanReduceOperator<IN>(function, new int[0], name, getInputType()));
+			return new UnaryNodeTranslation(new PlanReduceOperator<IN>(function, new int[0], name, getInputType(), getSemanticProps()));
 		}
 		
 		
@@ -87,7 +87,7 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 		}
 		else if (grouper.getKeys() instanceof Keys.FieldPositionKeys) {
 			int[] logicalKeyPositions = grouper.getKeys().computeLogicalKeyPositions();
-			PlanReduceOperator<IN> reduceOp = new PlanReduceOperator<IN>(function, logicalKeyPositions, name, getInputType());
+			PlanReduceOperator<IN> reduceOp = new PlanReduceOperator<IN>(function, logicalKeyPositions, name, getInputType(), getSemanticProps());
 			
 			// set group order
 			if(grouper.getGroupSortKeyPositions() != null) {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/SingleInputUdfOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/SingleInputUdfOperator.java
@@ -18,6 +18,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import eu.stratosphere.api.common.operators.SemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 import eu.stratosphere.configuration.Configuration;
@@ -33,6 +35,7 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 	private Configuration parameters;
 	
 	private Map<String, DataSet<?>> broadcastVariables;
+	private SingleInputSemanticProperties semanticProps;
 	
 	// --------------------------------------------------------------------------------------------
 	
@@ -66,7 +69,13 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 		return returnType;
 	}
 	
-	
+	public O withSemanticProps(SingleInputSemanticProperties semanticProps) {
+		this.semanticProps = semanticProps;
+		
+		@SuppressWarnings("unchecked")
+		O returnType = (O) this;
+		return returnType;
+	}
 	// --------------------------------------------------------------------------------------------
 	// Accessors
 	// --------------------------------------------------------------------------------------------
@@ -79,5 +88,9 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 	@Override
 	public Configuration getParameters() {
 		return this.parameters;
+	}
+
+	public SingleInputSemanticProperties getSemanticProps() {
+		return semanticProps;
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/TwoInputUdfOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/TwoInputUdfOperator.java
@@ -18,6 +18,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 import eu.stratosphere.configuration.Configuration;
@@ -33,8 +35,9 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 {
 	private Configuration parameters;
 	
-	private Map<String, DataSet<?>> broadcastVariables;
+	private Map<String, DataSet<?>> broadcastVariables;	
 	
+	private DualInputSemanticProperties semanticProps;
 	// --------------------------------------------------------------------------------------------
 	
 	protected TwoInputUdfOperator(DataSet<IN1> input1, DataSet<IN2> input2, TypeInformation<OUT> resultType) {
@@ -65,11 +68,24 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
 		return returnType;
+	}	
+	
+	public O withSemanticProps(DualInputSemanticProperties semanticProps) {
+		this.semanticProps = semanticProps;
+		
+		@SuppressWarnings("unchecked")
+		O returnType = (O) this;
+		return returnType;
 	}
 	
 	// --------------------------------------------------------------------------------------------
 	// Accessors
 	// --------------------------------------------------------------------------------------------
+	
+
+	public DualInputSemanticProperties getSemanticProps() {
+		return semanticProps;
+	}
 	
 	@Override
 	public Map<String, DataSet<?>> getBroadcastSets() {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
@@ -33,16 +33,26 @@ public class PlanCogroupOperator<IN1, IN2, OUT>
 
 	public PlanCogroupOperator(
 			CoGroupFunction<IN1, IN2, OUT> udf,
+			int[] keyPositions1, int[] keyPositions2, String name, TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType, DualInputSemanticProperties semanticProps) {
+		this(udf, keyPositions1, keyPositions2, name, inType1, inType2, outType);
+		
+		if (semanticProps == null) {
+			UserCodeWrapper<CoGroupFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CoGroupFunction<IN1, IN2, OUT>>(udf);
+	        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        setSemanticProperties(sp);
+		} else {
+			setSemanticProperties(semanticProps);
+		}
+	}
+	
+	public PlanCogroupOperator(
+			CoGroupFunction<IN1, IN2, OUT> udf,
 			int[] keyPositions1, int[] keyPositions2, String name, TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType) {
 		super(udf, keyPositions1, keyPositions2, name);
 		
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
-		
-		UserCodeWrapper<CoGroupFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CoGroupFunction<IN1, IN2, OUT>>(udf);
-        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
-        setSemanticProperties(sp);
 	}
 
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
@@ -15,8 +15,14 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCoGrouper;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CoGroupOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CoGroupFunction;
+import eu.stratosphere.api.java.functions.GroupReduceFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCogroupOperator<IN1, IN2, OUT> 
@@ -35,6 +41,10 @@ public class PlanCogroupOperator<IN1, IN2, OUT>
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
+		
+		UserCodeWrapper<CoGroupFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CoGroupFunction<IN1, IN2, OUT>>(udf);
+        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        setSemanticProperties(sp);
 	}
 
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
@@ -16,13 +16,11 @@ package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCoGrouper;
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
-import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CoGroupOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CoGroupFunction;
-import eu.stratosphere.api.java.functions.GroupReduceFunction;
-import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCogroupOperator<IN1, IN2, OUT> 
@@ -43,7 +41,7 @@ public class PlanCogroupOperator<IN1, IN2, OUT>
 		this.outType = outType;
 		
 		UserCodeWrapper<CoGroupFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CoGroupFunction<IN1, IN2, OUT>>(udf);
-        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
         setSemanticProperties(sp);
 	}
 

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
@@ -17,8 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.GenericCoGrouper;
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CoGroupOperatorBase;
-import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CoGroupFunction;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -37,8 +35,7 @@ public class PlanCogroupOperator<IN1, IN2, OUT>
 		this(udf, keyPositions1, keyPositions2, name, inType1, inType2, outType);
 		
 		if (semanticProps == null) {
-			UserCodeWrapper<CoGroupFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CoGroupFunction<IN1, IN2, OUT>>(udf);
-	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(this.getUserCodeWrapper(), inType1, inType2, outType);
 	        setSemanticProperties(sp);
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
@@ -20,7 +20,7 @@ import eu.stratosphere.api.common.operators.base.CoGroupOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CoGroupFunction;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCogroupOperator<IN1, IN2, OUT> 
@@ -38,7 +38,7 @@ public class PlanCogroupOperator<IN1, IN2, OUT>
 		
 		if (semanticProps == null) {
 			UserCodeWrapper<CoGroupFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CoGroupFunction<IN1, IN2, OUT>>(udf);
-	        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp, inType1, inType2, outType);
 	        setSemanticProperties(sp);
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
@@ -15,8 +15,14 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCrosser;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CrossFunction;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCrossOperator<IN1, IN2, OUT> 
@@ -38,6 +44,9 @@ public class PlanCrossOperator<IN1, IN2, OUT>
 		this.inType2 = inType2;
 		this.outType = outType;
 		
+		UserCodeWrapper<CrossFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CrossFunction<IN1, IN2, OUT>>(udf);
+        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        setSemanticProperties(sp);	
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
@@ -17,8 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.GenericCrosser;
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
-import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CrossFunction;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -39,8 +37,7 @@ public class PlanCrossOperator<IN1, IN2, OUT>
 		this(udf, name, inType1, inType2, outType);
 		
 		if (semanticProps == null) {
-			UserCodeWrapper<CrossFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CrossFunction<IN1, IN2, OUT>>(udf);
-	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(this.getUserCodeWrapper(), inType1, inType2, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
@@ -20,7 +20,7 @@ import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CrossFunction;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCrossOperator<IN1, IN2, OUT> 
@@ -40,7 +40,7 @@ public class PlanCrossOperator<IN1, IN2, OUT>
 		
 		if (semanticProps == null) {
 			UserCodeWrapper<CrossFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CrossFunction<IN1, IN2, OUT>>(udf);
-	        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp, inType1, inType2, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
@@ -16,13 +16,11 @@ package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCrosser;
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
-import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.CrossFunction;
-import eu.stratosphere.api.java.functions.FlatMapFunction;
-import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanCrossOperator<IN1, IN2, OUT> 
@@ -45,7 +43,7 @@ public class PlanCrossOperator<IN1, IN2, OUT>
 		this.outType = outType;
 		
 		UserCodeWrapper<CrossFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CrossFunction<IN1, IN2, OUT>>(udf);
-        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
         setSemanticProperties(sp);	
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
@@ -35,16 +35,27 @@ public class PlanCrossOperator<IN1, IN2, OUT>
 	public PlanCrossOperator(
 			CrossFunction<IN1, IN2, OUT> udf,
 			String name,
+			 TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType, DualInputSemanticProperties semanticProps) {
+		this(udf, name, inType1, inType2, outType);
+		
+		if (semanticProps == null) {
+			UserCodeWrapper<CrossFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CrossFunction<IN1, IN2, OUT>>(udf);
+	        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        setSemanticProperties(sp);	
+		} else {
+			setSemanticProperties(semanticProps);
+		}
+	}
+	
+	public PlanCrossOperator(
+			CrossFunction<IN1, IN2, OUT> udf,
+			String name,
 			 TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType) {
 		super(udf, name);
 		
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
-		
-		UserCodeWrapper<CrossFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<CrossFunction<IN1, IN2, OUT>>(udf);
-        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
-        setSemanticProperties(sp);	
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -15,8 +15,12 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericFlatMap;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -34,6 +38,10 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
+		
+		UserCodeWrapper<FlatMapFunction<T, O>> tmp = new UserCodeObjectWrapper<FlatMapFunction<T,O>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);		
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -20,7 +20,7 @@ import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -38,7 +38,7 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 
 		if (semanticProps == null) {
 			UserCodeWrapper<FlatMapFunction<T, O>> tmp = new UserCodeObjectWrapper<FlatMapFunction<T,O>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, inType, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -33,15 +33,22 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 	
 	private final TypeInformation<O> outType;
 	
+	public PlanFlatMapOperator(FlatMapFunction<T, O> udf, String name, TypeInformation<T> inType, TypeInformation<O> outType, SingleInputSemanticProperties semanticProps) {
+		this(udf, name, inType, outType);
+
+		if (semanticProps == null) {
+			UserCodeWrapper<FlatMapFunction<T, O>> tmp = new UserCodeObjectWrapper<FlatMapFunction<T,O>>(udf);
+	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
+	        setSemanticProperties(sp);	
+		} else {
+			setSemanticProperties(semanticProps);
+		}
+	}
 	
 	public PlanFlatMapOperator(FlatMapFunction<T, O> udf, String name, TypeInformation<T> inType, TypeInformation<O> outType) {
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
-
-		UserCodeWrapper<FlatMapFunction<T, O>> tmp = new UserCodeObjectWrapper<FlatMapFunction<T,O>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
-        setSemanticProperties(sp);		
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -20,7 +20,7 @@ import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
-import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -38,9 +38,9 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
-		
+
 		UserCodeWrapper<FlatMapFunction<T, O>> tmp = new UserCodeObjectWrapper<FlatMapFunction<T,O>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
         setSemanticProperties(sp);		
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -17,8 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.GenericFlatMap;
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
-import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -37,8 +35,7 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 		this(udf, name, inType, outType);
 
 		if (semanticProps == null) {
-			UserCodeWrapper<FlatMapFunction<T, O>> tmp = new UserCodeObjectWrapper<FlatMapFunction<T,O>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, inType, outType);
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper(), inType, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -38,6 +43,10 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 		
 		this.inType = inputType;
 		this.outType = outputType;
+		
+		UserCodeWrapper<GroupReduceFunction<IN, OUT>> tmp = new UserCodeObjectWrapper<GroupReduceFunction<IN, OUT>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);
 	}
 	
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
@@ -20,7 +20,7 @@ import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
@@ -42,7 +42,7 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 		
 		if (semanticProps == null) {
 			UserCodeWrapper<GroupReduceFunction<IN, OUT>> tmp = new UserCodeObjectWrapper<GroupReduceFunction<IN, OUT>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, inType, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
@@ -19,9 +19,8 @@ import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
-import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -45,7 +44,7 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 		this.outType = outputType;
 		
 		UserCodeWrapper<GroupReduceFunction<IN, OUT>> tmp = new UserCodeObjectWrapper<GroupReduceFunction<IN, OUT>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
         setSemanticProperties(sp);
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
@@ -17,9 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
-import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -41,8 +38,7 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 		this(udf, logicalGroupingFields, name, inputType, outputType);
 		
 		if (semanticProps == null) {
-			UserCodeWrapper<GroupReduceFunction<IN, OUT>> tmp = new UserCodeObjectWrapper<GroupReduceFunction<IN, OUT>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, inType, outType);
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper(), inType, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
@@ -19,6 +19,7 @@ import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -33,7 +34,20 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 	private final TypeInformation<IN> inType;
 	
 	private final TypeInformation<OUT> outType;
-	
+		
+	public PlanGroupReduceOperator(GroupReduceFunction<IN, OUT> udf, int[] logicalGroupingFields, String name, 
+			TypeInformation<IN> inputType, TypeInformation<OUT> outputType, SingleInputSemanticProperties semanticProps)
+	{
+		this(udf, logicalGroupingFields, name, inputType, outputType);
+		
+		if (semanticProps == null) {
+			UserCodeWrapper<GroupReduceFunction<IN, OUT>> tmp = new UserCodeObjectWrapper<GroupReduceFunction<IN, OUT>>(udf);
+	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
+	        setSemanticProperties(sp);	
+		} else {
+			setSemanticProperties(semanticProps);
+		}
+	}
 	
 	public PlanGroupReduceOperator(GroupReduceFunction<IN, OUT> udf, int[] logicalGroupingFields, String name, 
 				TypeInformation<IN> inputType, TypeInformation<OUT> outputType)
@@ -42,10 +56,6 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 		
 		this.inType = inputType;
 		this.outType = outputType;
-		
-		UserCodeWrapper<GroupReduceFunction<IN, OUT>> tmp = new UserCodeObjectWrapper<GroupReduceFunction<IN, OUT>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
-        setSemanticProperties(sp);
 	}
 	
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
@@ -33,16 +33,26 @@ public class PlanJoinOperator<IN1, IN2, OUT>
 
 	public PlanJoinOperator(
 			JoinFunction<IN1, IN2, OUT> udf,
+			int[] keyPositions1, int[] keyPositions2, String name, TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType, DualInputSemanticProperties semanticProps) {
+		this(udf, keyPositions1, keyPositions2, name, inType1, inType2, outType);
+		
+		if (semanticProps == null) {
+			UserCodeWrapper<JoinFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<JoinFunction<IN1, IN2, OUT>>(udf);
+	        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        setSemanticProperties(sp);
+		} else {
+			setSemanticProperties(semanticProps);
+		}
+	}
+	
+	public PlanJoinOperator(
+			JoinFunction<IN1, IN2, OUT> udf,
 			int[] keyPositions1, int[] keyPositions2, String name, TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType) {
 		super(udf, keyPositions1, keyPositions2, name);
 		
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
-		
-		UserCodeWrapper<JoinFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<JoinFunction<IN1, IN2, OUT>>(udf);
-        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
-        setSemanticProperties(sp);
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
@@ -17,8 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.GenericJoiner;
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
-import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.JoinFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -37,8 +35,7 @@ public class PlanJoinOperator<IN1, IN2, OUT>
 		this(udf, keyPositions1, keyPositions2, name, inType1, inType2, outType);
 		
 		if (semanticProps == null) {
-			UserCodeWrapper<JoinFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<JoinFunction<IN1, IN2, OUT>>(udf);
-	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(this.getUserCodeWrapper(), inType1, inType2, outType);
 	        setSemanticProperties(sp);
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
@@ -19,7 +19,7 @@ import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.JoinFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
@@ -38,7 +38,7 @@ public class PlanJoinOperator<IN1, IN2, OUT>
 		
 		if (semanticProps == null) {
 			UserCodeWrapper<JoinFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<JoinFunction<IN1, IN2, OUT>>(udf);
-	        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
+	        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp, inType1, inType2, outType);
 	        setSemanticProperties(sp);
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericJoiner;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.CrossFunction;
 import eu.stratosphere.api.java.functions.JoinFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanJoinOperator<IN1, IN2, OUT> 
@@ -35,6 +40,10 @@ public class PlanJoinOperator<IN1, IN2, OUT>
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
+		
+		UserCodeWrapper<JoinFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<JoinFunction<IN1, IN2, OUT>>(udf);
+        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        setSemanticProperties(sp);
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
@@ -19,9 +19,8 @@ import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.functions.CrossFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.functions.JoinFunction;
-import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class PlanJoinOperator<IN1, IN2, OUT> 
@@ -42,7 +41,7 @@ public class PlanJoinOperator<IN1, IN2, OUT>
 		this.outType = outType;
 		
 		UserCodeWrapper<JoinFunction<IN1, IN2, OUT>> tmp = new UserCodeObjectWrapper<JoinFunction<IN1, IN2, OUT>>(udf);
-        DualInputSemanticProperties sp = FunctionAnnotation.readDualConstantAnnotations(tmp);
+        DualInputSemanticProperties sp = FunctionAnnotationJapi.readDualConstantAnnotations(tmp, inType1, inType2, outType);
         setSemanticProperties(sp);
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
@@ -19,7 +19,7 @@ import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.MapFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
@@ -39,7 +39,7 @@ public class PlanMapOperator<T, O> extends PlainMapOperatorBase<GenericMap<T, O>
 		
 		if (semanticProps == null) {
 			UserCodeWrapper<MapFunction<T, O>> tmp = new UserCodeObjectWrapper<MapFunction<T,O>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, inType, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
@@ -19,9 +19,8 @@ import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.functions.MapFunction;
-import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -42,7 +41,7 @@ public class PlanMapOperator<T, O> extends PlainMapOperatorBase<GenericMap<T, O>
 		this.outType = outType;
 		
 		UserCodeWrapper<MapFunction<T, O>> tmp = new UserCodeObjectWrapper<MapFunction<T,O>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
         setSemanticProperties(sp);	
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
@@ -34,15 +34,22 @@ public class PlanMapOperator<T, O> extends PlainMapOperatorBase<GenericMap<T, O>
 	
 	private final TypeInformation<O> outType;
 	
+	public PlanMapOperator(MapFunction<T, O> udf, String name, TypeInformation<T> inType, TypeInformation<O> outType, SingleInputSemanticProperties semanticProps) {
+		this(udf, name, inType, outType);		
+		
+		if (semanticProps == null) {
+			UserCodeWrapper<MapFunction<T, O>> tmp = new UserCodeObjectWrapper<MapFunction<T,O>>(udf);
+	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
+	        setSemanticProperties(sp);	
+		} else {
+			setSemanticProperties(semanticProps);
+		}
+	}
 	
 	public PlanMapOperator(MapFunction<T, O> udf, String name, TypeInformation<T> inType, TypeInformation<O> outType) {
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
-		
-		UserCodeWrapper<MapFunction<T, O>> tmp = new UserCodeObjectWrapper<MapFunction<T,O>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, inType, outType);
-        setSemanticProperties(sp);	
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
@@ -17,8 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.GenericMap;
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
-import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.MapFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -38,8 +36,7 @@ public class PlanMapOperator<T, O> extends PlainMapOperatorBase<GenericMap<T, O>
 		this(udf, name, inType, outType);		
 		
 		if (semanticProps == null) {
-			UserCodeWrapper<MapFunction<T, O>> tmp = new UserCodeObjectWrapper<MapFunction<T,O>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, inType, outType);
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper(), inType, outType);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericMap;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -35,6 +40,10 @@ public class PlanMapOperator<T, O> extends PlainMapOperatorBase<GenericMap<T, O>
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
+		
+		UserCodeWrapper<MapFunction<T, O>> tmp = new UserCodeObjectWrapper<MapFunction<T,O>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);	
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -19,10 +19,8 @@ import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.functions.FlatMapFunction;
-import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.ReduceFunction;
-import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -39,7 +37,7 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 		
 		if (semanticProps == null) {			
 			UserCodeWrapper<ReduceFunction<T>> tmp = new UserCodeObjectWrapper<ReduceFunction<T>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, type, type);
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, type, type);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -20,6 +20,7 @@ import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
 import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
 import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotationJapi;
 import eu.stratosphere.api.java.functions.ReduceFunction;
 import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -38,7 +39,7 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 		super(udf, logicalGroupingFields, name);
 		this.type = type;
 		UserCodeWrapper<ReduceFunction<T>> tmp = new UserCodeObjectWrapper<ReduceFunction<T>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, type, type);
         setSemanticProperties(sp);	
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -15,8 +15,13 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
+import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.ReduceFunction;
+import eu.stratosphere.api.java.record.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
@@ -32,6 +37,9 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type) {
 		super(udf, logicalGroupingFields, name);
 		this.type = type;
+		UserCodeWrapper<ReduceFunction<T>> tmp = new UserCodeObjectWrapper<ReduceFunction<T>>(udf);
+        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp);
+        setSemanticProperties(sp);	
 	}
 	
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -17,8 +17,6 @@ package eu.stratosphere.api.java.operators.translation;
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
-import eu.stratosphere.api.common.operators.util.UserCodeObjectWrapper;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.ReduceFunction;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -35,9 +33,8 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type, SingleInputSemanticProperties semanticProps) {
 		this(udf, logicalGroupingFields, name, type);
 		
-		if (semanticProps == null) {			
-			UserCodeWrapper<ReduceFunction<T>> tmp = new UserCodeObjectWrapper<ReduceFunction<T>>(udf);
-	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(tmp, type, type);
+		if (semanticProps == null) {		
+	        SingleInputSemanticProperties sp = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper(), type, type);
 	        setSemanticProperties(sp);	
 		} else {
 			setSemanticProperties(semanticProps);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -34,13 +34,21 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 
 	private final TypeInformation<T> type;
 	
+	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type, SingleInputSemanticProperties semanticProps) {
+		this(udf, logicalGroupingFields, name, type);
+		
+		if (semanticProps == null) {			
+			UserCodeWrapper<ReduceFunction<T>> tmp = new UserCodeObjectWrapper<ReduceFunction<T>>(udf);
+	        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, type, type);
+	        setSemanticProperties(sp);	
+		} else {
+			setSemanticProperties(semanticProps);
+		}
+	}
 	
 	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type) {
 		super(udf, logicalGroupingFields, name);
 		this.type = type;
-		UserCodeWrapper<ReduceFunction<T>> tmp = new UserCodeObjectWrapper<ReduceFunction<T>>(udf);
-        SingleInputSemanticProperties sp = FunctionAnnotationJapi.readSingleConstantAnnotations(tmp, type, type);
-        setSemanticProperties(sp);	
 	}
 	
 	


### PR DESCRIPTION
Annotations for the new API were implemented. There is now a sepparate FunctionAnnotation class for the new japi because the code is much more different than the code for the record API. The annotations also have new features. It is now possible to specify which field of the input is copied where.

**_Example:**_

```
@ConstantFields(inTuplePos={0,1,2}, outTuplePos={2,0,1})
```

The example specifies that three fields of the input are copied but are on a different position in the output.  At the moment, this only works for tuples. If only the input positions are specified, it is assumed that the position of the specified fields remains the same. If a udf has other input and output, the annotations are ignored. Nevertheless, there is already some infrastructure for future work. You can annotate like this:

```
@ConstantFields(inCustomPos={"Field1", "Field2"}, outCustomPos={"Field2", "Field1"})
```

It is also now possible to hand semanticproperties to the operators themselves via the `withSemanticProperties()` method.
