### PR TITLE
New-Java-API Union

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/PactCompiler.java
@@ -948,7 +948,7 @@ public class PactCompiler {
 			OptimizerNode n = this.con2node.get(c);
 
 			// first connect to the predecessors
-			n.setInputs(this.con2node);
+			n.setInput(this.con2node);
 			n.setBroadcastInputs(this.con2node);
 			
 			// if the node represents a bulk iteration, we recursively translate the data flow now

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/contextcheck/ContextChecker.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/contextcheck/ContextChecker.java
@@ -14,7 +14,6 @@
 package eu.stratosphere.compiler.contextcheck;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import eu.stratosphere.api.common.InvalidProgramException;
@@ -101,7 +100,7 @@ public class ContextChecker implements Visitor<Operator> {
 	 *        DataSinkContract that is checked.
 	 */
 	private void checkDataSink(GenericDataSink dataSinkContract) {
-		Operator input = dataSinkContract.getInputs().get(0);
+		Operator input = dataSinkContract.getInput();
 		// check if input exists
 		if (input == null) {
 			throw new MissingChildException();
@@ -173,9 +172,9 @@ public class ContextChecker implements Visitor<Operator> {
 	 *        SingleInputOperator that is checked.
 	 */
 	private void checkSingleInputContract(SingleInputOperator<?> singleInputContract) {
-		List<Operator> input = singleInputContract.getInputs();
+		Operator input = singleInputContract.getInput();
 		// check if input exists
-		if (input.size() == 0) {
+		if (input == null) {
 			throw new MissingChildException();
 		}
 	}
@@ -188,10 +187,10 @@ public class ContextChecker implements Visitor<Operator> {
 	 *        DualInputOperator that is checked.
 	 */
 	private void checkDualInputContract(DualInputOperator<?> dualInputContract) {
-		List<Operator> input1 = dualInputContract.getFirstInputs();
-		List<Operator> input2 = dualInputContract.getSecondInputs();
+		Operator input1 = dualInputContract.getFirstInput();
+		Operator input2 = dualInputContract.getSecondInput();
 		// check if input exists
-		if (input1.size() == 0 || input2.size() == 0) {
+		if (input1 == null || input2 == null) {
 			throw new MissingChildException();
 		}
 	}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/AbstractPartialSolutionNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/AbstractPartialSolutionNode.java
@@ -63,7 +63,7 @@ public abstract class AbstractPartialSolutionNode extends OptimizerNode {
 	}
 
 	@Override
-	public void setInputs(Map<Operator, OptimizerNode> contractToNode) {}
+	public void setInput(Map<Operator, OptimizerNode> contractToNode) {}
 
 	@Override
 	protected void computeOperatorSpecificDefaultEstimates(DataStatistics statistics) {

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
@@ -18,10 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import eu.stratosphere.api.common.functions.AbstractFunction;
-import eu.stratosphere.api.common.operators.DualInputOperator;
 import eu.stratosphere.api.common.operators.Union;
-import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
 import eu.stratosphere.compiler.CompilerException;
 import eu.stratosphere.compiler.DataStatistics;
 import eu.stratosphere.compiler.costs.CostEstimator;
@@ -49,35 +46,11 @@ public class BinaryUnionNode extends TwoInputNode {
 	public BinaryUnionNode(Union union){
 		super(union);
 	}
-	
-	public BinaryUnionNode(OptimizerNode pred1, OptimizerNode pred2) {
-		super(new UnionPlaceholderContract());
-		
-		this.input1 = new PactConnection(pred1, this);
-		this.input2 = new PactConnection(pred2, this);
-		
-		pred1.addOutgoingConnection(this.input1);
-		pred2.addOutgoingConnection(this.input2);
-	}
-	
-	public BinaryUnionNode(OptimizerNode pred1, OptimizerNode pred2, ShipStrategyType preSet) {
-		this(pred1, pred2);
-		
-		if (preSet != null) {
-			this.input1.setShipStrategy(preSet);
-			this.input2.setShipStrategy(preSet);
-		}
-	}
 
 	@Override
 	public String getName() {
 		return "Union";
 	}
-	
-	/*@Override
-	public void setInputs(Map<Operator, OptimizerNode> contractToNode) {
-		throw new UnsupportedOperationException();
-	}*/
 
 	@Override
 	protected List<OperatorDescriptorDual> getPossibleProperties() {
@@ -309,19 +282,5 @@ public class BinaryUnionNode extends TwoInputNode {
 				in1.estimatedNumRecords + in2.estimatedNumRecords : -1;
 		this.estimatedOutputSize = in1.estimatedOutputSize > 0 && in2.estimatedOutputSize > 0 ?
 			in1.estimatedOutputSize + in2.estimatedOutputSize : -1;
-	}
-	
-	// ------------------------------------------------------------------------
-	//  Mock classes that represents a contract without behavior.
-	// ------------------------------------------------------------------------
-	
-	private static final class MockStub extends AbstractFunction {
-		private static final long serialVersionUID = 1L;
-	}
-	
-	private static final class UnionPlaceholderContract extends DualInputOperator<MockStub> {
-		private UnionPlaceholderContract() {
-			super(new UserCodeClassWrapper<MockStub>(MockStub.class), "Union");
-		}
 	}
 }

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/BinaryUnionNode.java
@@ -16,12 +16,11 @@ package eu.stratosphere.compiler.dag;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import eu.stratosphere.api.common.functions.AbstractFunction;
 import eu.stratosphere.api.common.operators.DualInputOperator;
-import eu.stratosphere.api.common.operators.Operator;
+import eu.stratosphere.api.common.operators.Union;
 import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
 import eu.stratosphere.compiler.CompilerException;
 import eu.stratosphere.compiler.DataStatistics;
@@ -44,6 +43,13 @@ public class BinaryUnionNode extends TwoInputNode {
 	
 	private Set<RequestedGlobalProperties> channelProps;
 
+	/* 
+	 * Constructor used by the new java API
+	 */
+	public BinaryUnionNode(Union union){
+		super(union);
+	}
+	
 	public BinaryUnionNode(OptimizerNode pred1, OptimizerNode pred2) {
 		super(new UnionPlaceholderContract());
 		
@@ -68,10 +74,10 @@ public class BinaryUnionNode extends TwoInputNode {
 		return "Union";
 	}
 	
-	@Override
+	/*@Override
 	public void setInputs(Map<Operator, OptimizerNode> contractToNode) {
 		throw new UnsupportedOperationException();
-	}
+	}*/
 
 	@Override
 	protected List<OperatorDescriptorDual> getPossibleProperties() {

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/DataSinkNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/DataSinkNode.java
@@ -31,7 +31,6 @@ import eu.stratosphere.compiler.dataproperties.RequestedLocalProperties;
 import eu.stratosphere.compiler.plan.Channel;
 import eu.stratosphere.compiler.plan.PlanNode;
 import eu.stratosphere.compiler.plan.SinkPlanNode;
-import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
 import eu.stratosphere.util.Visitor;
 
@@ -112,19 +111,15 @@ public class DataSinkNode extends OptimizerNode {
 	}
 
 	@Override
-	public void setInputs(Map<Operator, OptimizerNode> contractToNode) {
-		List<Operator> children = getPactContract().getInputs();
+	public void setInput(Map<Operator, OptimizerNode> contractToNode) {
+		Operator children = getPactContract().getInput();
 
 		final OptimizerNode pred;
 		final PactConnection conn;
-		if (children.size() == 1) {
-			pred = contractToNode.get(children.get(0));
-			conn = new PactConnection(pred, this);
-		} else {
-			pred = createdUnionCascade(children, contractToNode, null);
-			conn = new PactConnection(pred, this);
-			conn.setShipStrategy(ShipStrategyType.FORWARD);
-		}
+		
+		pred = contractToNode.get(children);
+		conn = new PactConnection(pred, this);
+			
 		// create the connection and add it
 		setInputConnection(conn);
 		pred.addOutgoingConnection(conn);

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/DataSourceNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/DataSourceNode.java
@@ -106,7 +106,7 @@ public class DataSourceNode extends OptimizerNode {
 	}
 
 	@Override
-	public void setInputs(Map<Operator, OptimizerNode> contractToNode) {}
+	public void setInput(Map<Operator, OptimizerNode> contractToNode) {}
 
 	@Override
 	protected void computeOperatorSpecificDefaultEstimates(DataStatistics statistics) {

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/OptimizerNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/OptimizerNode.java
@@ -166,7 +166,7 @@ public abstract class OptimizerNode implements Visitable<OptimizerNode>, Estimat
 	 * @param contractToNode
 	 *        The map to translate the contracts to their corresponding optimizer nodes.
 	 */
-	public abstract void setInputs(Map<Operator, OptimizerNode> contractToNode);
+	public abstract void setInput(Map<Operator, OptimizerNode> contractToNode);
 
 	/**
 	 * This function is for plan translation purposes. Upon invocation, this method creates a {@link PactConnection}
@@ -743,39 +743,6 @@ public abstract class OptimizerNode implements Visitable<OptimizerNode>, Estimat
 	 */
 	public Set<FieldSet> getUniqueFields() {
 		return this.uniqueFields == null ? Collections.<FieldSet>emptySet() : this.uniqueFields;
-	}
-	
-	// --------------------------------------------------------------------------------------------
-	//  Miscellaneous
-	// --------------------------------------------------------------------------------------------
-	
-	public BinaryUnionNode createdUnionCascade(List<Operator> children, Map<Operator, OptimizerNode> contractToNode, ShipStrategyType preSet) {
-		if (children.size() < 2) {
-			throw new IllegalArgumentException();
-		}
-		
-		BinaryUnionNode lastUnion = null;
-		
-		for (int i = 1; i < children.size(); i++) {
-			if (i == 1) {
-				OptimizerNode in1 = contractToNode.get(children.get(0));
-				OptimizerNode in2 = contractToNode.get(children.get(1));
-				
-				lastUnion = new BinaryUnionNode(in1, in2, preSet);
-			} else {
-				OptimizerNode nextIn = contractToNode.get(children.get(i));
-				lastUnion = new BinaryUnionNode(lastUnion, nextIn);
-				lastUnion.getFirstIncomingConnection().setShipStrategy(ShipStrategyType.FORWARD);
-				if (preSet != null) {
-					lastUnion.getSecondIncomingConnection().setShipStrategy(preSet);
-				}
-			}
-			
-			lastUnion.setDegreeOfParallelism(getDegreeOfParallelism());
-			lastUnion.setSubtasksPerInstance(getSubtasksPerInstance());
-		}
-		
-		return lastUnion;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/SingleInputNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/SingleInputNode.java
@@ -154,7 +154,7 @@ public abstract class SingleInputNode extends OptimizerNode {
 	
 
 	@Override
-	public void setInputs(Map<Operator, OptimizerNode> contractToNode) throws CompilerException {
+	public void setInput(Map<Operator, OptimizerNode> contractToNode) throws CompilerException {
 		// see if an internal hint dictates the strategy to use
 		final Configuration conf = getPactContract().getParameters();
 		final String shipStrategy = conf.getString(PactCompiler.HINT_SHIP_STRATEGY, null);
@@ -177,23 +177,20 @@ public abstract class SingleInputNode extends OptimizerNode {
 		}
 		
 		// get the predecessor node
-		List<Operator> children = ((SingleInputOperator<?>) getPactContract()).getInputs();
+		Operator children = ((SingleInputOperator<?>) getPactContract()).getInput();
 		
 		OptimizerNode pred;
 		PactConnection conn;
-		if (children.size() == 0) {
-			throw new CompilerException("Error: Node for '" + getPactContract().getName() + "' has no inputs.");
-		} else if (children.size() == 1) {
-			pred = contractToNode.get(children.get(0));
+		if (children == null) {
+			throw new CompilerException("Error: Node for '" + getPactContract().getName() + "' has no input.");
+		} else {
+			pred = contractToNode.get(children);
 			conn = new PactConnection(pred, this);
 			if (preSet != null) {
 				conn.setShipStrategy(preSet);
 			}
-		} else {
-			pred = createdUnionCascade(children, contractToNode, preSet);
-			conn = new PactConnection(pred, this);
-			conn.setShipStrategy(ShipStrategyType.FORWARD);
 		}
+		
 		// create the connection and add it
 		setIncomingConnection(conn);
 		pred.addOutgoingConnection(conn);

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/TwoInputNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/TwoInputNode.java
@@ -151,7 +151,7 @@ public abstract class TwoInputNode extends OptimizerNode {
 
 
 	@Override
-	public void setInputs(Map<Operator, OptimizerNode> contractToNode) {
+	public void setInput(Map<Operator, OptimizerNode> contractToNode) {
 		// see if there is a hint that dictates which shipping strategy to use for BOTH inputs
 		final Configuration conf = getPactContract().getParameters();
 		ShipStrategyType preSet1 = null;
@@ -213,43 +213,37 @@ public abstract class TwoInputNode extends OptimizerNode {
 		// get the predecessors
 		DualInputOperator<?> contr = (DualInputOperator<?>) getPactContract();
 		
-		List<Operator> leftPreds = contr.getFirstInputs();
-		List<Operator> rightPreds = contr.getSecondInputs();
+		Operator leftPred = contr.getFirstInput();
+		Operator rightPred = contr.getSecondInput();
 		
 		OptimizerNode pred1;
 		PactConnection conn1;
-		if (leftPreds.size() == 0) {
+		if (leftPred == null) {
 			throw new CompilerException("Error: Node for '" + getPactContract().getName() + "' has no input set for first input.");
-		} else if (leftPreds.size() == 1) {
-			pred1 = contractToNode.get(leftPreds.get(0));
+		} else  {
+			pred1 = contractToNode.get(leftPred);
 			conn1 = new PactConnection(pred1, this);
 			if (preSet1 != null) {
 				conn1.setShipStrategy(preSet1);
 			}
-		} else {
-			pred1 = createdUnionCascade(leftPreds, contractToNode, preSet1);
-			conn1 = new PactConnection(pred1, this);
-			conn1.setShipStrategy(ShipStrategyType.FORWARD);
-		}
+		} 
+		
 		// create the connection and add it
 		this.input1 = conn1;
 		pred1.addOutgoingConnection(conn1);
 		
 		OptimizerNode pred2;
 		PactConnection conn2;
-		if (rightPreds.size() == 0) {
+		if (rightPred == null) {
 			throw new CompilerException("Error: Node for '" + getPactContract().getName() + "' has no input set for second input.");
-		} else if (rightPreds.size() == 1) {
-			pred2 = contractToNode.get(rightPreds.get(0));
+		} else {
+			pred2 = contractToNode.get(rightPred);
 			conn2 = new PactConnection(pred2, this);
 			if (preSet2 != null) {
 				conn2.setShipStrategy(preSet2);
 			}
-		} else {
-			pred2 = createdUnionCascade(rightPreds, contractToNode, preSet1);
-			conn2 = new PactConnection(pred2, this);
-			conn2.setShipStrategy(ShipStrategyType.FORWARD);
 		}
+		
 		// create the connection and add it
 		this.input2 = conn2;
 		pred2.addOutgoingConnection(conn2);

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/DualInputPlanNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plan/DualInputPlanNode.java
@@ -25,7 +25,6 @@ import java.util.NoSuchElementException;
 import eu.stratosphere.api.common.operators.util.FieldList;
 import eu.stratosphere.api.common.typeutils.TypeComparatorFactory;
 import eu.stratosphere.api.common.typeutils.TypePairComparatorFactory;
-import eu.stratosphere.compiler.costs.Costs;
 import eu.stratosphere.compiler.dag.OptimizerNode;
 import eu.stratosphere.compiler.dag.TwoInputNode;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/postpass/JavaApiPostPass.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/postpass/JavaApiPostPass.java
@@ -218,8 +218,8 @@ public class JavaApiPostPass implements OptimizerPostPass {
 			type = ((PlanDeltaIterationOperator<?, ?>) worksetPlaceHolder.getContainingWorksetIteration()).getReturnType();
 		}  else if (javaOp instanceof NoOpUnaryUdfOp) {
 			NoOpUnaryUdfOp op = (NoOpUnaryUdfOp) javaOp;
-			if(op.getInputs().get(0) instanceof JavaPlanNode<?>) { 
-				JavaPlanNode<?> javaNode = (JavaPlanNode<?>) op.getInputs().get(0);
+			if(op.getInput() instanceof JavaPlanNode<?>) { 
+				JavaPlanNode<?> javaNode = (JavaPlanNode<?>) op.getInput();
 				type = javaNode.getReturnType();
 			}
 		}else if(javaOp instanceof Union){

--- a/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/UnionPropertyPropagationTest.java
+++ b/stratosphere-compiler/src/test/java/eu/stratosphere/pact/compiler/UnionPropertyPropagationTest.java
@@ -21,8 +21,16 @@ import org.junit.Test;
 import eu.stratosphere.api.common.Plan;
 import eu.stratosphere.api.common.operators.FileDataSink;
 import eu.stratosphere.api.common.operators.FileDataSource;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.aggregation.Aggregations;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.operators.translation.PlanFlatMapOperator;
+import eu.stratosphere.api.java.operators.translation.PlanGroupReduceOperator;
 import eu.stratosphere.api.java.record.operators.ReduceOperator;
+import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.compiler.plan.Channel;
+import eu.stratosphere.compiler.plan.NAryUnionPlanNode;
 import eu.stratosphere.compiler.plan.OptimizedPlan;
 import eu.stratosphere.compiler.plan.PlanNode;
 import eu.stratosphere.compiler.plan.SingleInputPlanNode;
@@ -32,6 +40,7 @@ import eu.stratosphere.pact.compiler.util.DummyOutputFormat;
 import eu.stratosphere.pact.compiler.util.IdentityReduce;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.types.IntValue;
+import eu.stratosphere.util.Collector;
 import eu.stratosphere.util.Visitor;
 
 /**
@@ -39,7 +48,7 @@ import eu.stratosphere.util.Visitor;
 public class UnionPropertyPropagationTest extends CompilerTestBase {
 
 	@Test
-	public void testUnionPropertyPropagation() {
+	public void testUnionPropertyOldApiPropagation() {
 		// construct the plan
 
 		FileDataSource sourceA = new FileDataSource(new DummyInputFormat(), IN_FILE);
@@ -79,6 +88,93 @@ public class UnionPropertyPropagationTest extends CompilerTestBase {
 								inConn.getShipStrategy() == ShipStrategyType.FORWARD); 
 					}
 					//just check latest ReduceNode
+					return false;
+				}
+				return true;
+			}
+			
+			@Override
+			public void postVisit(PlanNode visitable) {
+				// DO NOTHING
+			}
+		});
+	}
+	
+	public static final class DummyFlatMap extends FlatMapFunction<String, Tuple2<String, Integer>> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void flatMap(String value, Collector<Tuple2<String, Integer>> out)
+				throws Exception {
+			out.collect(new Tuple2<String, Integer>(value, 0));
+			
+		}
+	}
+	
+	public static int NUM_INPUTS = 4;
+	
+	@Test
+	public void testUnionNewApiAssembly() {
+		// construct the plan it will be multiple flat maps, all unioned
+		// and the "unioned" dataSet will be grouped
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		
+		DataSet<String> source = env.readTextFile(IN_FILE);
+		DataSet<Tuple2<String, Integer>> lastUnion = null;
+
+		for(int i = 0; i< NUM_INPUTS; i++){
+			if(lastUnion == null){
+				lastUnion = source.flatMap(new DummyFlatMap());
+			}else{
+				lastUnion = lastUnion.union(source.flatMap(new DummyFlatMap()));
+			}
+		}
+		
+		DataSet<Tuple2<String, Integer>> result = lastUnion.groupBy(0).aggregate(Aggregations.SUM, 1);
+		result.writeAsText(OUT_FILE);
+
+		// return the PACT plan
+		Plan plan = env.createProgramPlan("Test union on new java-api");
+		OptimizedPlan oPlan = compileNoStats(plan);
+		NepheleJobGraphGenerator jobGen = new NepheleJobGraphGenerator();
+		
+		//Compile plan to verify that no error is thrown
+		jobGen.compileJobGraph(oPlan);
+		
+		oPlan.accept(new Visitor<PlanNode>() {
+			
+			@Override
+			public boolean preVisit(PlanNode visitable) {
+				
+				/* Test on the union output connections
+				 * It must be under the GroupOperator and the strategy should be forward
+				 */
+				if(visitable instanceof SingleInputPlanNode && visitable.getPactContract() instanceof PlanGroupReduceOperator){
+					final Channel inConn = ((SingleInputPlanNode) visitable).getInput();
+					Assert.assertTrue("Union should just forward the Partitioning",
+							inConn.getShipStrategy() == ShipStrategyType.FORWARD ); 
+					Assert.assertTrue("Union Node should be under Group operator",
+							inConn.getSource() instanceof NAryUnionPlanNode );
+				}
+				
+				/* Test on the union input connections
+				 * Must be NUM_INPUTS input connections, all FlatMapOperators with a own partitioning strategy(propably hash)
+				 */
+				if (visitable instanceof NAryUnionPlanNode) {
+					int numberInputs = 0;
+					for (Iterator<Channel> inputs = visitable.getInputs(); inputs.hasNext(); numberInputs++) {
+						final Channel inConn = inputs.next();
+						PlanNode inNode = inConn.getSource();
+						Assert.assertTrue("Input of Union should be FlatMapOperators",
+								inNode.getPactContract() instanceof PlanFlatMapOperator); 
+						Assert.assertTrue("Shipment strategy under union should partition the data",
+								inConn.getShipStrategy() != ShipStrategyType.FORWARD && 
+								inConn.getShipStrategy() != ShipStrategyType.NONE ); 
+					}
+					
+					Assert.assertTrue("NAryUnion should have " + NUM_INPUTS + " inputs",
+							numberInputs == NUM_INPUTS);
 					return false;
 				}
 				return true;

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/BulkIteration.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/BulkIteration.java
@@ -135,7 +135,7 @@ public class BulkIteration extends SingleInputOperator<AbstractFunction> impleme
 	 * @throws Exception
 	 */
 	public void validate() throws InvalidProgramException {
-		if (this.input == null || this.input.isEmpty()) {
+		if (this.input == null) {
 			throw new RuntimeException("Operator for initial partial solution is not set.");
 		}
 		if (this.iterationResult == null) {

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DeltaIteration.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DeltaIteration.java
@@ -13,6 +13,7 @@
 
 package eu.stratosphere.api.common.operators;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import eu.stratosphere.api.common.aggregators.AggregatorRegistry;
@@ -154,8 +155,22 @@ public class DeltaIteration extends DualInputOperator<AbstractFunction> implemen
 	 * 
 	 * @return The iteration's initial solution set input.
 	 */
-	public List<Operator> getInitialSolutionSet() {
-		return getFirstInputs();
+	public Operator getInitialSolutionSet() {
+		return getFirstInput();
+	}
+	
+	/**
+	 * Returns the initial solution set input as list, or null, if none is set.
+	 * 
+	 * @return The iteration's initial solution set input as list.
+	 */
+	public List<Operator> getInitialSolutionSets() {
+		if(this.input1 == null){
+			return null;
+		}
+		ArrayList<Operator> inputs = new ArrayList<Operator>();
+		inputs.add(this.input1);
+		return inputs;
 	}
 	
 	/**
@@ -163,8 +178,23 @@ public class DeltaIteration extends DualInputOperator<AbstractFunction> implemen
 	 * 
 	 * @return The iteration's workset input.
 	 */
-	public List<Operator> getInitialWorkset() {
-		return getSecondInputs();
+	public Operator getInitialWorkset() {
+		return getSecondInput();
+	}
+
+	
+	/**
+	 * Returns the initial solution set input as list, or null, if none is set.
+	 * 
+	 * @return The iteration's initial solution set input as list.
+	 */
+	public List<Operator> getInitialWorksets() {
+		if(this.input1 == null){
+			return null;
+		}
+		ArrayList<Operator> inputs = new ArrayList<Operator>();
+		inputs.add(this.input1);
+		return inputs;
 	}
 	
 	/**

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
@@ -28,11 +28,11 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	/**
 	 * The contract producing the first input.
 	 */
-	protected final List<Operator> input1 = new ArrayList<Operator>();
+	protected Operator input1 = null;
 	/**
 	 * The contract producing the second input.
 	 */
-	protected final List<Operator> input2 = new ArrayList<Operator>();
+	protected Operator input2 = null;
 
 	/**
 	 * The positions of the keys in the tuples of the first input.
@@ -90,8 +90,23 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * 
 	 * @return The contract's first input.
 	 */
-	public List<Operator> getFirstInputs() {
+	public Operator getFirstInput() {
 		return this.input1;
+	}
+	
+	/**
+	 * Returns the first input as list, or null, if none is set.
+	 * This function is here for compatibility=reasons of the old-java-API with the scala API
+	 * 
+	 * @return The contract's first input contract as list.
+	 */
+	public List<Operator> getFirstInputs() {
+		if(this.input1 == null){
+			return null;
+		}
+		ArrayList<Operator> inputs = new ArrayList<Operator>();
+		inputs.add(this.input1);
+		return inputs;
 	}
 	
 	/**
@@ -99,22 +114,37 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * 
 	 * @return The contract's second input.
 	 */
-	public List<Operator> getSecondInputs() {
+	public Operator getSecondInput() {
 		return this.input2;
+	}
+	
+	/**
+	 * Returns the second input as list, or null, if none is set.
+	 * This function is here for compatibility=reasons of the old-java-API with the scala API
+	 * 
+	 * @return The contract's second input contract as list
+	 */
+	public List<Operator> getSecondInputs() {
+		if(this.input2 == null){
+			return null;
+		}
+		ArrayList<Operator> inputs = new ArrayList<Operator>();
+		inputs.add(this.input2);
+		return inputs;
 	}
 	
 	/**
 	 * Removes all inputs from this contract's first input.
 	 */
-	public void clearFirstInputs() {
-		this.input1.clear();
+	public void clearFirstInput() {
+		this.input1 = null;
 	}
 	
 	/**
 	 * Removes all inputs from this contract's second input.
 	 */
-	public void clearSecondInputs() {
-		this.input2.clear();
+	public void clearSecondInput() {
+		this.input2 = null;
 	}
 
 	/**
@@ -123,13 +153,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param input The contract will be set as the first input.
 	 */
 	public void addFirstInput(Operator ... input) {
-		for (Operator c : input) {
-			if (c == null) {
-				throw new IllegalArgumentException("The input may not contain null elements.");
-			} else {
-				this.input1.add(c);
-			}
-		}
+		this.input1 = Operator.createUnionCascade(this.input1, input);
 	}
 	
 	/**
@@ -138,13 +162,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param input The contract will be set as the second input.
 	 */
 	public void addSecondInput(Operator ... input) {
-		for (Operator c : input) {
-			if (c == null) {
-				throw new IllegalArgumentException("The input may not contain null elements.");
-			} else {
-				this.input2.add(c);
-			}
-		}
+		this.input2 = Operator.createUnionCascade(this.input2, input);
 	}
 
 	/**
@@ -153,13 +171,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param inputs The contracts that is connected as the first inputs.
 	 */
 	public void addFirstInputs(List<Operator> inputs) {
-		for (Operator c : inputs) {
-			if (c == null) {
-				throw new IllegalArgumentException("The input may not contain null elements.");
-			} else {
-				this.input1.add(c);
-			}
-		}
+		this.input1 = Operator.createUnionCascade(this.input1, inputs.toArray(new Operator[inputs.size()]));
 	}
 
 	/**
@@ -168,14 +180,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param inputs The contracts that is connected as the second inputs.
 	 */
 	public void addSecondInputs(List<Operator> inputs) {
-		for (Operator c : inputs) {
-			if (c == null) {
-				throw new IllegalArgumentException("The input may not contain null elements.");
-			} else {
-				this.input2.add(c);
-			}
-		}
-	}
+		this.input2 = Operator.createUnionCascade(this.input2, inputs.toArray(new Operator[inputs.size()]));	}
 	
 	/**
 	 * Clears all previous connections and connects the first input to the task wrapped in this contract
@@ -183,8 +188,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param input The contract that is connected as the first input.
 	 */
 	public void setFirstInput(Operator input) {
-		this.input1.clear();
-		addFirstInput(input);
+		this.input1 = input;
 	}
 
 	/**
@@ -193,8 +197,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param input The contract that is connected as the second input.
 	 */
 	public void setSecondInput(Operator input) {
-		this.input2.clear();
-		addSecondInput(input);
+		this.input2 = input;
 	}
 	
 	/**
@@ -203,7 +206,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param inputs The contracts that are connected as the first input.
 	 */
 	public void setFirstInput(Operator ... inputs) {
-		this.input1.clear();
+		this.input1 = null;
 		addFirstInput(inputs);
 	}
 
@@ -213,7 +216,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param inputs The contracts that are connected as the second input.
 	 */
 	public void setSecondInput(Operator ... inputs) {
-		this.input2.clear();
+		this.input2 = null;
 		addSecondInput(inputs);
 	}
 	
@@ -223,7 +226,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param inputs The contracts that are connected as the first inputs.
 	 */
 	public void setFirstInputs(List<Operator> inputs) {
-		this.input1.clear();
+		this.input1 = null;
 		addFirstInputs(inputs);
 	}
 
@@ -233,7 +236,7 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	 * @param inputs The contracts that are connected as the second inputs.
 	 */
 	public void setSecondInputs(List<Operator> inputs) {
-		this.input2.clear();
+		this.input2 = null;
 		addSecondInputs(inputs);
 	}
 	
@@ -272,12 +275,8 @@ public abstract class DualInputOperator<T extends Function> extends AbstractUdfO
 	public void accept(Visitor<Operator> visitor) {
 		boolean descend = visitor.preVisit(this);
 		if (descend) {
-			for (Operator c : this.input1) {
-				c.accept(visitor);
-			}
-			for (Operator c : this.input2) {
-				c.accept(visitor);
-			}
+			this.input1.accept(visitor);
+			this.input2.accept(visitor);
 			for (Operator c : this.broadcastInputs.values()) {
 				c.accept(visitor);
 			}

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Operator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Operator.java
@@ -170,6 +170,49 @@ public abstract class Operator implements Visitable<Operator> {
 	}
 	
 	
+    /**
+     * Gets a single Operator and a list of operators and creates a cascade of unions of this inputs, if needed.
+     * If not needed there was only one operator as input, then this operator is returned.
+     * a
+     *  @return A cascade (or deep-right) tree with the operators of input1 and input2
+     */
+    public static Operator createUnionCascade(Operator input1, Operator...input2){
+    	// return cases where we don't need a union
+    	if(input2.length == 0){
+    		return input1;
+    	}else if(input2.length == 1 && input1 == null){
+    		return input2[0];
+    	}
+    	// Otherwise construct union cascade
+        Union lastUnion = new Union();
+        int i;
+        if(input2[0] == null){
+            throw new IllegalArgumentException("The input may not contain null elements.");
+        }
+        lastUnion.setFirstInput(input2[0]);
+            
+        if(input1 != null){
+        	lastUnion.setSecondInput(input1);
+            i = 1;
+        }else{
+        	if(input2[1] == null){
+        		throw new IllegalArgumentException("The input may not contain null elements.");
+        	}
+        	lastUnion.setSecondInput(input2[1]);
+            i = 2;
+        }
+        for(; i < input2.length; i++){
+        	Union tmpUnion = new Union();
+        	tmpUnion.setSecondInput(lastUnion);
+        	if(input2[i] == null){
+        		throw new IllegalArgumentException("The input may not contain null elements.");
+        	}
+        	tmpUnion.setFirstInput(input2[i]);
+        	lastUnion = tmpUnion;
+        }
+        return lastUnion;
+    }
+    
 	// --------------------------------------------------------------------------------------------
 	
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Union.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Union.java
@@ -18,13 +18,18 @@ package eu.stratosphere.api.common.operators;
 import eu.stratosphere.api.common.functions.AbstractFunction;
 import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
 
+/**
+ * This operator represents a Union between two inputs.
+ * 
+ * @see UnionOperator
+ */
 public class Union extends DualInputOperator<AbstractFunction> {
 	
 	private final static String NAME = "UNION";
 	
-	/* 
+	/** 
 	 * Represent a union as contract with abstract function,  
-	 * it will be replaced in the PACT compiler later
+	 * it will be replaced in the PACT compiler later, therefore we can give it an AbstractFunction
 	 */
 	public Union() {
 		super(new UserCodeClassWrapper<AbstractFunction>(AbstractFunction.class), NAME);

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Union.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/Union.java
@@ -1,0 +1,32 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.api.common.operators;
+
+import eu.stratosphere.api.common.functions.AbstractFunction;
+import eu.stratosphere.api.common.operators.util.UserCodeClassWrapper;
+
+public class Union extends DualInputOperator<AbstractFunction> {
+	
+	private final static String NAME = "UNION";
+	
+	/* 
+	 * Represent a union as contract with abstract function,  
+	 * it will be replaced in the PACT compiler later
+	 */
+	public Union() {
+		super(new UserCodeClassWrapper<AbstractFunction>(AbstractFunction.class), NAME);
+	}
+}

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/util/OperatorUtil.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/util/OperatorUtil.java
@@ -13,8 +13,6 @@
 
 package eu.stratosphere.api.common.operators.util;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -104,42 +102,6 @@ public class OperatorUtil {
 		throw new IllegalArgumentException("not supported");
 	}
 
-	/**
-	 * Returns a list of all inputs for the given {@link Operator}.<br>
-	 * Currently, the list can have 0, 1, or 2 elements.
-	 * 
-	 * @param contract
-	 *        the Operator whose inputs should be returned
-	 * @return all input contracts to this contract
-	 */
-	public static List<List<Operator>> getInputs(final Operator contract) {
-		ArrayList<List<Operator>> inputs = new ArrayList<List<Operator>>();
-
-		if (contract instanceof GenericDataSink)
-			inputs.add(new ArrayList<Operator>(((GenericDataSink) contract).getInputs()));
-		else if (contract instanceof SingleInputOperator)
-			inputs.add(new ArrayList<Operator>(((SingleInputOperator<?>) contract).getInputs()));
-		else if (contract instanceof DualInputOperator) {
-			inputs.add(new ArrayList<Operator>(((DualInputOperator<?>) contract).getFirstInputs()));
-			inputs.add(new ArrayList<Operator>(((DualInputOperator<?>) contract).getSecondInputs()));
-		}
-		return inputs;
-	}
-
-	public static List<Operator> getFlatInputs(final Operator contract) {
-		if (contract instanceof GenericDataSink)
-			return ((GenericDataSink) contract).getInputs();
-		if (contract instanceof SingleInputOperator)
-			return ((SingleInputOperator<?>) contract).getInputs();
-		if (contract instanceof DualInputOperator) {
-			ArrayList<Operator> inputs = new ArrayList<Operator>();
-			inputs.addAll(((DualInputOperator<?>) contract).getFirstInputs());
-			inputs.addAll(((DualInputOperator<?>) contract).getSecondInputs());
-			return inputs;
-		}
-
-		return new ArrayList<Operator>();
-	}
 
 	/**
 	 * Sets the inputs of the given {@link Operator}.<br>
@@ -165,21 +127,5 @@ public class OperatorUtil {
 			((DualInputOperator<?>) contract).setFirstInputs(inputs.get(0));
 			((DualInputOperator<?>) contract).setSecondInputs(inputs.get(1));
 		}
-	}
-
-	/**
-	 * Swaps two inputs of the given contract.
-	 * 
-	 * @param contract
-	 *        the contract
-	 * @param input1
-	 *        the first input index
-	 * @param input2
-	 *        the second input index
-	 */
-	public static void swapInputs(Operator contract, int input1, int input2) {
-		final List<List<Operator>> inputs = new ArrayList<List<Operator>>(getInputs(contract));
-		Collections.swap(inputs, input1, input2);
-		setInputs(contract, inputs);
 	}
 }

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/WordCount.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/record/wordcount/WordCount.java
@@ -120,6 +120,7 @@ public class WordCount implements Program, ProgramDescription {
 			.input(mapper)
 			.name("Count Words")
 			.build();
+		
 		@SuppressWarnings("unchecked")
 		FileDataSink out = new FileDataSink(new CsvOutputFormat("\n", " ", StringValue.class, IntValue.class), output, reducer, "Word Counts");
 		

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -49,6 +49,7 @@ import eu.stratosphere.api.java.operators.ProjectOperator;
 import eu.stratosphere.api.java.operators.ProjectOperator.Projection;
 import eu.stratosphere.api.java.operators.ReduceGroupOperator;
 import eu.stratosphere.api.java.operators.ReduceOperator;
+import eu.stratosphere.api.java.operators.UnionOperator;
 import eu.stratosphere.api.java.tuple.Tuple;
 import eu.stratosphere.api.java.typeutils.InputTypeConfigurable;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -532,6 +533,11 @@ public abstract class DataSet<T> {
 	public <R> CrossOperator.CrossOperatorSets<T, R> crossWithHuge(DataSet<R> other) {
 		return new CrossOperator.CrossOperatorSets<T, R>(this, other);
 	}
+	
+	public <R> UnionOperator<T> union(DataSet<T> input){
+		return new UnionOperator<T>(this, input);
+	}
+
 
 	// --------------------------------------------------------------------------------------------
 	//  Iterations

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -533,9 +533,16 @@ public abstract class DataSet<T> {
 	public <R> CrossOperator.CrossOperatorSets<T, R> crossWithHuge(DataSet<R> other) {
 		return new CrossOperator.CrossOperatorSets<T, R>(this, other);
 	}
-	
-	public <R> UnionOperator<T> union(DataSet<T> input){
-		return new UnionOperator<T>(this, input);
+
+	/**
+	 * Union with an other {@link Tuple} {@link DataSet} which must be of the same type.
+	 * 
+	 * @param other The other DataSet which is appended to the current DataSet via union .
+	 * @return The result DataSet which is of the same type as the two inputs
+	 */
+
+	public UnionOperator<T> union(DataSet<T> other){
+		return new UnionOperator<T>(this, other);
 	}
 
 

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/UnionOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/UnionOperator.java
@@ -19,12 +19,27 @@ import eu.stratosphere.api.common.operators.Union;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.operators.translation.BinaryNodeTranslation;
 
+/**
+ * Operator for union of two data sets
+ * 
+ * @param <T> The type of the two input data sets and the Output dataSet 
+ */
 public class UnionOperator<T> extends TwoInputOperator<T, T, T, UnionOperator<T>> {
 
+	/**
+	 * Constructor just calls super constructor.
+	 * @param input1
+	 * @param input2
+	 */
 	public UnionOperator(DataSet<T> input1, DataSet<T> input2) {
 		super(input1, input2, input1.getType());
 	}
 	 
+	/**
+	 * Returns the BinaryNodeTranslation of the Union.
+	 * Just return a BinaryNodeTranslation holding a new common.operator Union.
+	 * The inputs of the union are automatically set by the {@link OperatorTranslation}.
+	 */
 	@Override
 	protected BinaryNodeTranslation translateToDataFlow() {
 		return new BinaryNodeTranslation(new Union());

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/UnionOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/UnionOperator.java
@@ -1,0 +1,32 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+
+package eu.stratosphere.api.java.operators;
+
+import eu.stratosphere.api.common.operators.Union;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.operators.translation.BinaryNodeTranslation;
+
+public class UnionOperator<T> extends TwoInputOperator<T, T, T, UnionOperator<T>> {
+
+	public UnionOperator(DataSet<T> input1, DataSet<T> input2) {
+		super(input1, input2, input1.getType());
+	}
+	 
+	@Override
+	protected BinaryNodeTranslation translateToDataFlow() {
+		return new BinaryNodeTranslation(new Union());
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/RuntimeSerializerFactory.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/RuntimeSerializerFactory.java
@@ -22,7 +22,6 @@ public final class RuntimeSerializerFactory<T> implements TypeSerializerFactory<
 
 	private static final long serialVersionUID = 1L;
 
-
 	private static final String CONFIG_KEY_SER = "SER_DATA";
 
 	private static final String CONFIG_KEY_CLASS = "CLASS_DATA";
@@ -79,5 +78,21 @@ public final class RuntimeSerializerFactory<T> implements TypeSerializerFactory<
 	public Class<T> getDataType() {
 		return clazz;
 	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean equals(Object obj) {
+		if(obj == null){
+			return false;
+		}
+		
+		if(!(obj instanceof RuntimeSerializerFactory)){
+			return false;
+		}
+		
+		RuntimeSerializerFactory<T> otherRSF = (RuntimeSerializerFactory<T>) obj;
+		return otherRSF.clazz == this.clazz && otherRSF.serializer.equals(serializer);
+	}
 
+	
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
@@ -112,6 +112,6 @@ public final class TupleSerializer<T extends Tuple> extends TypeSerializer<T> {
 		TupleSerializer<?> otherTS = (TupleSerializer<?>) obj;
 		
 		return (otherTS.tupleClass == this.tupleClass) && 
-				Arrays.deepEquals(this.fieldSerializers,fieldSerializers);
+				Arrays.deepEquals(this.fieldSerializers, otherTS.fieldSerializers);
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
@@ -15,6 +15,7 @@
 package eu.stratosphere.api.java.typeutils.runtime;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.api.java.tuple.Tuple;
@@ -96,5 +97,21 @@ public final class TupleSerializer<T extends Tuple> extends TypeSerializer<T> {
 		for (int i = 0; i < arity; i++) {
 			fieldSerializers[i].copy(source, target);
 		}
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if(obj == null){
+			return false;
+		}
+		
+		if(!(obj instanceof TupleSerializer<?>)){
+			return false;
+		}
+		
+		TupleSerializer<?> otherTS = (TupleSerializer<?>) obj;
+		
+		return (otherTS.tupleClass == this.tupleClass) && 
+				Arrays.deepEquals(this.fieldSerializers,fieldSerializers);
 	}
 }

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaGenerator.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaGenerator.scala
@@ -109,8 +109,8 @@ class GlobalSchemaGenerator {
 
       case contract : DeltaIteration with DeltaIterationScalaOperator[_] => {
 //      case contract @ WorksetIterate4sContract(s0, ws0, deltaS, newWS, placeholderS, placeholderWS) => {
-        val s0 = contract.getInitialSolutionSet.get(0)
-        val ws0 = contract.getInitialWorkset.get(0)
+        val s0 = contract.getInitialSolutionSets.get(0)
+        val ws0 = contract.getInitialWorksets.get(0)
         val deltaS = contract.getSolutionSetDelta
         val newWS = contract.getNextWorkset
 

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaPrinter.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaPrinter.scala
@@ -55,7 +55,7 @@ object GlobalSchemaPrinter {
 
         val children = node match {
           case bi: BulkIteration => bi.getInputs().toList :+ bi.getNextPartialSolution()
-          case wi: DeltaIteration => wi.getInitialSolutionSet().toList ++ wi.getInitialWorkset().toList :+ wi.getSolutionSetDelta() :+ wi.getNextWorkset()
+          case wi: DeltaIteration => wi.getInitialSolutionSets().toList ++ wi.getInitialWorksets().toList :+ wi.getSolutionSetDelta() :+ wi.getNextWorkset()
           case si : SingleInputOperator[_] => si.getInputs().toList
           case di : DualInputOperator[_] => di.getFirstInputs().toList ++ di.getSecondInputs().toList
           case gds : GenericDataSink => gds.getInputs().toList

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/UnionITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/UnionITCase.java
@@ -1,0 +1,171 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.test.javaApiOperators;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.functions.FilterFunction;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.configuration.Configuration;
+import eu.stratosphere.test.javaApiOperators.util.CollectionDataSets;
+import eu.stratosphere.test.util.JavaProgramTestBase;
+
+@RunWith(Parameterized.class)
+public class UnionITCase extends JavaProgramTestBase {
+	
+	private static int NUM_PROGRAMS = 3; 
+	
+	private int curProgId = config.getInteger("ProgramId", -1);
+	private String resultPath;
+	private String expectedResult;
+
+	public UnionITCase(Configuration config) {
+		super(config);	
+	}
+	
+	@Override
+	protected void preSubmit() throws Exception {
+		resultPath = getTempDirPath("result");
+	}
+
+	@Override
+	protected void testProgram() throws Exception {
+		expectedResult = FilterProgs.runProgram(curProgId, resultPath);
+	}
+	
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(expectedResult, resultPath);
+	}
+	
+	@Parameters
+	public static Collection<Object[]> getConfigurations() throws FileNotFoundException, IOException {
+
+		LinkedList<Configuration> tConfigs = new LinkedList<Configuration>();
+
+		for(int i=1; i <= NUM_PROGRAMS; i++) {
+			Configuration config = new Configuration();
+			config.setInteger("ProgramId", i);
+			tConfigs.add(config);
+		}
+		
+		return toParameterList(tConfigs);
+	}
+	
+	private static class FilterProgs {
+
+		private static final String FULL_TUPLE_3_STRING = "1,1,Hi\n" +
+				"2,2,Hello\n" +
+				"3,2,Hello world\n" +
+				"4,3,Hello world, how are you?\n" +
+				"5,3,I am fine.\n" +
+				"6,3,Luke Skywalker\n" +
+				"7,4,Comment#1\n" +
+				"8,4,Comment#2\n" +
+				"9,4,Comment#3\n" +
+				"10,4,Comment#4\n" +
+				"11,5,Comment#5\n" +
+				"12,5,Comment#6\n" +
+				"13,5,Comment#7\n" +
+				"14,5,Comment#8\n" +
+				"15,5,Comment#9\n" +
+				"16,6,Comment#10\n" +
+				"17,6,Comment#11\n" +
+				"18,6,Comment#12\n" +
+				"19,6,Comment#13\n" +
+				"20,6,Comment#14\n" +
+				"21,6,Comment#15\n";
+		
+		public static String runProgram(int progId, String resultPath) throws Exception {
+			
+			switch(progId) {
+			case 1: {
+				/*
+				 * Union of 2 Same Data Sets
+				 */
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> unionDs = ds.union(CollectionDataSets.get3TupleDataSet(env));
+				
+				unionDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING;
+			}
+			case 2: {
+				/*
+				 * Union of 5 same Data Sets, with multiple unions
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> unionDs = ds.union(CollectionDataSets.get3TupleDataSet(env))
+						.union(CollectionDataSets.get3TupleDataSet(env))
+						.union(CollectionDataSets.get3TupleDataSet(env))
+						.union(CollectionDataSets.get3TupleDataSet(env));
+				
+				unionDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING + FULL_TUPLE_3_STRING;
+			}
+			case 3: {
+				/*
+				 * Test on union with empty dataset
+				 */
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				// Don't know how to make an empty result in an other way than filtering it 
+				DataSet<Tuple3<Integer, Long, String>> empty = CollectionDataSets.get3TupleDataSet(env).
+						filter(new FilterFunction<Tuple3<Integer,Long,String>>() {
+							private static final long serialVersionUID = 1L;
+
+							@Override
+							public boolean filter(Tuple3<Integer, Long, String> value) throws Exception {
+								return false;
+							}
+						});
+				
+				DataSet<Tuple3<Integer, Long, String>> unionDs = CollectionDataSets.get3TupleDataSet(env)
+					.union(empty);
+			
+				unionDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return FULL_TUPLE_3_STRING;				
+			}
+			default: 
+				throw new IllegalArgumentException("Invalid program id");
+			}
+			
+		}
+	
+	}
+	
+}

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/UnionITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/UnionITCase.java
@@ -51,7 +51,7 @@ public class UnionITCase extends JavaProgramTestBase {
 
 	@Override
 	protected void testProgram() throws Exception {
-		expectedResult = FilterProgs.runProgram(curProgId, resultPath);
+		expectedResult = UnionProgs.runProgram(curProgId, resultPath);
 	}
 	
 	@Override
@@ -73,7 +73,7 @@ public class UnionITCase extends JavaProgramTestBase {
 		return toParameterList(tConfigs);
 	}
 	
-	private static class FilterProgs {
+	private static class UnionProgs {
 
 		private static final String FULL_TUPLE_3_STRING = "1,1,Hi\n" +
 				"2,2,Hello\n" +


### PR DESCRIPTION
First PR: https://github.com/stratosphere/stratosphere/pull/674
Corr. Issue: https://github.com/stratosphere/stratosphere/issues/621

Now the old-java-api is also using the binary-union-operator by automatically creating a cascade of unions if needed. Therefore every operator in the common-package saves a single operator instead of a list of operators.

But the scala-api has some parts where it expects list of operators for getInputs() calls. Therefore there are getInputs() methods which are wrapping lists around the single operator and return the list. This is a little be ugly, but I assume we switch the scala-api to use the new java-api in the future, so we can remove them then.
