### PR TITLE
Moved SerializerTestBase to stratosphere-core and resolved Maven dependencies

### DIFF
--- a/stratosphere-core/pom.xml
+++ b/stratosphere-core/pom.xml
@@ -23,5 +23,22 @@
 			<version>3.1</version>
 		</dependency>
 	</dependencies>
+	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/SerializerTestBase.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/SerializerTestBase.java
@@ -12,7 +12,7 @@
  * specific language governing permissions and limitations under the License.
  *
  **********************************************************************************************************************/
-package eu.stratosphere.api.java.typeutils.runtime;
+package eu.stratosphere.api.common.typeutils;
 
 import static org.junit.Assert.*;
 

--- a/stratosphere-java/pom.xml
+++ b/stratosphere-java/pom.xml
@@ -23,6 +23,13 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>stratosphere-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+  			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
 			<version>1.7.5</version>

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/typeutils/runtime/LongArraySerializerTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/typeutils/runtime/LongArraySerializerTest.java
@@ -14,6 +14,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.typeutils.runtime;
 
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 
 /**

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/typeutils/runtime/StringArraySerializerTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/typeutils/runtime/StringArraySerializerTest.java
@@ -16,6 +16,7 @@ package eu.stratosphere.api.java.typeutils.runtime;
 
 import java.util.Random;
 
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.util.StringUtils;
 


### PR DESCRIPTION
Moved the SerializerTestBase from stratosphere-java to stratosphere-core where the abstract TypeSerializer class and all base type serializers are defined.
Had add some Maven stuff to get the dependency on test code working.
