### PR TITLE
Add test for String Serializer for #589

### DIFF
--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
@@ -1,0 +1,47 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.common.typeutils.base;
+
+import java.util.Random;
+
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+import eu.stratosphere.util.StringUtils;
+
+/**
+ * A test for the {@link StringSerializer}.
+ */
+public class StringSerializerTest extends SerializerTestBase<String> {
+	
+	@Override
+	protected TypeSerializer<String> createSerializer() {
+		return new StringSerializer();
+	}
+	
+	@Override
+	protected int getLength() {
+		return -1;
+	}
+	
+	@Override
+	protected Class<String> getTypeClass() {
+		return String.class;
+	}
+	
+	@Override
+	protected String[] getTestData() {
+		return new String[] {"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
+	}
+}


### PR DESCRIPTION
#589

First test is the String Serializer. One thing that I'm wondering about the StringSerializer is whether it should be able to handle `null` values. I took the test strings from `stratosphere-core.src.test.java.eu.stratosphere.types.StringSerializationTest.java` as the test strings for the StringSerializer.

It was able to handle `new String[] {"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"}`
 but not `new String[] {"a", null, "", null, "bcd", null, "jbmbmner8 jhk hj \n \t üäßß@µ", null, "", null, "non-empty"}`.

I am not sure if this is intended, so I have kept the array that does not include null for now.
