### PR TITLE
Add projection join, join JavaDocs and removes unsupported join methods.

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/JoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/JoinOperator.java
@@ -15,7 +15,7 @@
 package eu.stratosphere.api.java.operators;
 
 import java.security.InvalidParameterException;
-
+import java.util.Arrays;
 import eu.stratosphere.api.common.InvalidProgramException;
 import eu.stratosphere.api.common.operators.Operator;
 import eu.stratosphere.api.java.DataSet;
@@ -26,13 +26,41 @@ import eu.stratosphere.api.java.operators.translation.PlanJoinOperator;
 import eu.stratosphere.api.java.operators.translation.PlanMapOperator;
 import eu.stratosphere.api.java.operators.translation.PlanUnwrappingJoinOperator;
 import eu.stratosphere.api.java.operators.translation.TupleKeyExtractingMapper;
+import eu.stratosphere.api.java.tuple.Tuple;
+import eu.stratosphere.api.java.tuple.Tuple1;
+import eu.stratosphere.api.java.tuple.Tuple10;
+import eu.stratosphere.api.java.tuple.Tuple11;
+import eu.stratosphere.api.java.tuple.Tuple12;
+import eu.stratosphere.api.java.tuple.Tuple13;
+import eu.stratosphere.api.java.tuple.Tuple14;
+import eu.stratosphere.api.java.tuple.Tuple15;
+import eu.stratosphere.api.java.tuple.Tuple16;
+import eu.stratosphere.api.java.tuple.Tuple17;
+import eu.stratosphere.api.java.tuple.Tuple18;
+import eu.stratosphere.api.java.tuple.Tuple19;
 import eu.stratosphere.api.java.tuple.Tuple2;
+import eu.stratosphere.api.java.tuple.Tuple20;
+import eu.stratosphere.api.java.tuple.Tuple21;
+import eu.stratosphere.api.java.tuple.Tuple22;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.api.java.tuple.Tuple4;
+import eu.stratosphere.api.java.tuple.Tuple5;
+import eu.stratosphere.api.java.tuple.Tuple6;
+import eu.stratosphere.api.java.tuple.Tuple7;
+import eu.stratosphere.api.java.tuple.Tuple8;
+import eu.stratosphere.api.java.tuple.Tuple9;
 import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
 import eu.stratosphere.api.java.typeutils.TypeExtractor;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 /**
- *
+ * A {@link DataSet} that is the result of a Join transformation. 
+ * 
+ * @param <I1> The type of the first input DataSet of the Join transformation.
+ * @param <I2> The type of the second input DataSet of the Join transformation.
+ * @param <OUT> The type of the result of the Join transformation.
+ * 
+ * @see DataSet
  */
 public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT, JoinOperator<I1, I2, OUT>> {
 	
@@ -81,12 +109,10 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		REPARTITION_SORT_MERGE,
 	};
 	
-	
 	private final Keys<I1> keys1;
 	private final Keys<I2> keys2;
 	
 	private JoinHint joinHint;
-	
 	
 	protected JoinOperator(DataSet<I1> input1, DataSet<I2> input2, 
 			Keys<I1> keys1, Keys<I2> keys2,
@@ -118,6 +144,17 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 	// special join types
 	// --------------------------------------------------------------------------------------------
 	
+	/**
+	 * A Join transformation that applies a {@JoinFunction} on each pair of joining elements.<br/>
+	 * It also represents the {@link DataSet} that is the result of a Join transformation. 
+	 * 
+	 * @param <I1> The type of the first input DataSet of the Join transformation.
+	 * @param <I2> The type of the second input DataSet of the Join transformation.
+	 * @param <OUT> The type of the result of the Join transformation.
+	 * 
+	 * @see JoinFunction
+	 * @see DataSet
+	 */
 	public static class EquiJoin<I1, I2, OUT> extends JoinOperator<I1, I2, OUT> {
 		
 		private final JoinFunction<I1, I2, OUT> function;
@@ -139,22 +176,24 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			this.function = function;
 		}
 		
-		
-		public EquiJoin<I1, I2, OUT> leftOuter() {
-			this.preserve1 = true;
-			return this;
-		}
+		// TODO
+//		public EquiJoin<I1, I2, OUT> leftOuter() {
+//			this.preserve1 = true;
+//			return this;
+//		}
 
-		public EquiJoin<I1, I2, OUT> rightOuter() {
-			this.preserve2 = true;
-			return this;
-		}
+		// TODO
+//		public EquiJoin<I1, I2, OUT> rightOuter() {
+//			this.preserve2 = true;
+//			return this;
+//		}
 		
-		public EquiJoin<I1, I2, OUT> fullOuter() {
-			this.preserve1 = true;
-			this.preserve2 = true;
-			return this;
-		}
+		// TODO
+//		public EquiJoin<I1, I2, OUT> fullOuter() {
+//			this.preserve1 = true;
+//			this.preserve2 = true;
+//			return this;
+//		}
 		
 		@Override
 		protected Operator translateToDataFlow(Operator input1, Operator input2) {
@@ -348,40 +387,128 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		}
 	}
 	
+	/**
+	 * A Join transformation that wraps pairs of joining elements into {@link Tuple2}.<br/>
+	 * It also represents the {@link DataSet} that is the result of a Join transformation. 
+	 * 
+	 * @param <I1> The type of the first input DataSet of the Join transformation.
+	 * @param <I2> The type of the second input DataSet of the Join transformation.
+	 * @param <OUT> The type of the result of the Join transformation.
+	 * 
+	 * @see Tuple2
+	 * @see DataSet
+	 */
 	public static final class DefaultJoin<I1, I2> extends EquiJoin<I1, I2, Tuple2<I1, I2>> {
 
 		protected DefaultJoin(DataSet<I1> input1, DataSet<I2> input2, 
 				Keys<I1> keys1, Keys<I2> keys2, JoinHint hint)
 		{
-			super(input1, input2, keys1, keys2,
+			super(input1, input2, keys1, keys2, 
 				(JoinFunction<I1, I2, Tuple2<I1, I2>>) new DefaultJoinFunction<I1, I2>(),
 				new TupleTypeInfo<Tuple2<I1, I2>>(input1.getType(), input2.getType()), hint);
 		}
 		
-		
+		/**
+		 * Finalizes a Join transformation by applying a {@link JoinFunction} to each pair of joined elements.<br/>
+		 * Each JoinFunction call returns exactly one element. 
+		 * 
+		 * @param function The JoinFunction that is called for each pair of joined elements.
+		 * @return An EquiJoin that represents the joined result DataSet
+		 * 
+		 * @see JoinFunction
+		 * @see EquiJoin
+		 * @see DataSet
+		 */
 		public <R> EquiJoin<I1, I2, R> with(JoinFunction<I1, I2, R> function) {
 			TypeInformation<R> returnType = TypeExtractor.getJoinReturnTypes(function, getInput1Type(), getInput2Type());
 			return new EquiJoin<I1, I2, R>(getInput1(), getInput2(), getKeys1(), getKeys2(), function, returnType, getJoinHint());
 		}
 		
-		public JoinOperator<I1, I2, I1> leftSemiJoin() {
-			return new LeftSemiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
+		/**
+		 * Initiates a ProjectJoin transformation and projects the first join input<br/>
+		 * If the first join input is a {@link Tuple} {@link DataSet}, fields can be selected by their index.
+		 * If the first join input is not a Tuple DataSet, no parameters should be passed.<br/>
+		 * 
+		 * Fields of the first and second input can be added by chaining the method calls of
+		 * {@link JoinProjection#projectFirst(int...)} and {@link JoinProjection#projectSecond(int...)}.
+		 * 
+		 * @param fieldIndexes If the first input is a Tuple DataSet, the indexes of the selected fields. 
+		 * 					   For a non-Tuple DataSet, do not provide parameters.
+		 * 					   The order of fields in the output tuple is defined by to the order of field indexes.
+		 * @return A JoinProjection that needs to be converted into a {@link ProjectOperator} to complete the 
+		 *           ProjectJoin transformation by calling {@link JoinProjection#types()}.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 * @see JoinProjection
+		 * @see ProjectJoin
+		 */
+		public JoinProjection<I1, I2> projectFirst(int... firstFieldIndexes) {
+			return new JoinProjection<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint(), firstFieldIndexes, null);
 		}
 		
-		public JoinOperator<I1, I2, I2> rightSemiJoin() {
-			return new RightSemiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
+		/**
+		 * Initiates a ProjectJoin transformation and projects the second join input<br/>
+		 * If the second join input is a {@link Tuple} {@link DataSet}, fields can be selected by their index.
+		 * If the second join input is not a Tuple DataSet, no parameters should be passed.<br/>
+		 * 
+		 * Fields of the first and second input can be added by chaining the method calls of
+		 * {@link JoinProjection#projectFirst(int...)} and {@link JoinProjection#projectSecond(int...)}.
+		 * 
+		 * @param fieldIndexes If the second input is a Tuple DataSet, the indexes of the selected fields. 
+		 * 					   For a non-Tuple DataSet, do not provide parameters.
+		 * 					   The order of fields in the output tuple is defined by to the order of field indexes.
+		 * @return A JoinProjection that needs to be converted into a {@link ProjectOperator} to complete the 
+		 *           ProjectJoin transformation by calling {@link JoinProjection#types()}.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 * @see JoinProjection
+		 * @see ProjectJoin
+		 */
+		public JoinProjection<I1, I2> projectSecond(int... secondFieldIndexes) {
+			return new JoinProjection<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint(), null, secondFieldIndexes);
 		}
 		
-		public JoinOperator<I1, I2, I1> leftAntiJoin() {
-			return new LeftAntiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
-		}
+//		public JoinOperator<I1, I2, I1> leftSemiJoin() {
+//			return new LeftSemiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
+//		}
 		
-		public JoinOperator<I1, I2, I2> rightAntiJoin() {
-			return new RightAntiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
+//		public JoinOperator<I1, I2, I2> rightSemiJoin() {
+//			return new RightSemiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
+//		}
+		
+//		public JoinOperator<I1, I2, I1> leftAntiJoin() {
+//			return new LeftAntiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
+//		}
+		
+//		public JoinOperator<I1, I2, I2> rightAntiJoin() {
+//			return new RightAntiJoin<I1, I2>(getInput1(), getInput2(), getKeys1(), getKeys2(), getJoinHint());
+//		}
+	}
+	
+	/**
+	 * A Join transformation that projects joining elements or fields of joining {@link Tuple Tuples} 
+	 * into result {@link Tuple Tuples}. <br/>
+	 * It also represents the {@link DataSet} that is the result of a Join transformation. 
+	 * 
+	 * @param <I1> The type of the first input DataSet of the Join transformation.
+	 * @param <I2> The type of the second input DataSet of the Join transformation.
+	 * @param <OUT> The type of the result of the Join transformation.
+	 * 
+	 * @see Tuple
+	 * @see DataSet
+	 */
+	private static final class ProjectJoin<I1, I2, OUT extends Tuple> extends EquiJoin<I1, I2, OUT> {
+		
+		protected ProjectJoin(DataSet<I1> input1, DataSet<I2> input2, Keys<I1> keys1, Keys<I2> keys2, JoinHint hint, int[] fields, boolean[] isFromFirst, TupleTypeInfo<OUT> returnType) {
+			super(input1, input2, keys1, keys2, 
+					new ProjectJoinFunction<I1, I2, OUT>(fields, isFromFirst, returnType.createSerializer().createInstance()), 
+					returnType, hint);
 		}
 	}
 	
-
+	@SuppressWarnings("unused")
 	private static final class LeftAntiJoin<I1, I2> extends JoinOperator<I1, I2, I1> {
 		
 		protected LeftAntiJoin(DataSet<I1> input1, DataSet<I2> input2, Keys<I1> keys1, Keys<I2> keys2, JoinHint hint) {
@@ -394,6 +521,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		}
 	}
 	
+	@SuppressWarnings("unused")
 	private static final class RightAntiJoin<I1, I2> extends JoinOperator<I1, I2, I2> {
 		
 		protected RightAntiJoin(DataSet<I1> input1, DataSet<I2> input2, Keys<I1> keys1, Keys<I2> keys2, JoinHint hint) {
@@ -406,6 +534,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		}
 	}
 	
+	@SuppressWarnings("unused")
 	private static final class LeftSemiJoin<I1, I2> extends EquiJoin<I1, I2, I1> {
 		
 		protected LeftSemiJoin(DataSet<I1> input1, DataSet<I2> input2, Keys<I1> keys1, Keys<I2> keys2, JoinHint hint) {
@@ -421,6 +550,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		}
 	}
 	
+	@SuppressWarnings("unused")
 	private static final class RightSemiJoin<I1, I2> extends EquiJoin<I1, I2, I2> {
 		
 		protected RightSemiJoin(DataSet<I1> input1, DataSet<I2> input2, Keys<I1> keys1, Keys<I2> keys2, JoinHint hint) {
@@ -440,6 +570,14 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 	// Builder classes for incremental construction
 	// --------------------------------------------------------------------------------------------
 	
+	/**
+	 * Intermediate step of a Join transformation. <br/>
+	 * To continue the Join transformation, select the join key of the first input {@link DataSet} by calling 
+	 * {@link JoinOperatorSets#where(int...)} or {@link JoinOperatorSets#where(KeySelector)}.
+	 *
+	 * @param <I1> The type of the first input DataSet of the Join transformation.
+	 * @param <I2> The type of the second input DataSet of the Join transformation.
+	 */
 	public static final class JoinOperatorSets<I1, I2> {
 		
 		private final DataSet<I1> input1;
@@ -460,7 +598,18 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			this.joinHint = hint;
 		}
 		
-		
+		/**
+		 * Continues a Join transformation. <br/>
+		 * Defines the {@link Tuple} fields of the first join {@link DataSet} that should be used as join keys.<br/>
+		 * <b>Note: Fields can only be selected as join keys on Tuple DataSets.</b><br/>
+		 * 
+		 * @param fields The indexes of the Tuple fields of the first join DataSets that should be used as keys.
+		 * @return An incomplete Join transformation. 
+		 *           Call {@link JoinOperatorSetsPredicate#equalTo(int...)} to continue the Join. 
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
 		public JoinOperatorSetsPredicate where(int... fields) {
 			return new JoinOperatorSetsPredicate(new Keys.FieldPositionKeys<I1>(fields, input1.getType()));
 		}
@@ -469,12 +618,18 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 			return new JoinOperatorSetsPredicate(new Keys.SelectorFunctionKeys<I1, K>(keyExtractor, input1.getType()));
 		}
 		
-		public JoinOperatorSetsPredicate where(String keyExpression) {
-			return new JoinOperatorSetsPredicate(new Keys.ExpressionKeys<I1>(keyExpression, input1.getType()));
-		}
+//		public JoinOperatorSetsPredicate where(String keyExpression) {
+//			return new JoinOperatorSetsPredicate(new Keys.ExpressionKeys<I1>(keyExpression, input1.getType()));
+//		}
 	
 		// ----------------------------------------------------------------------------------------
 		
+		/**
+		 * Intermediate step of a Join transformation. <br/>
+		 * To continue the Join transformation, select the join key of the second input {@link DataSet} by calling 
+		 * {@link JoinOperatorSetsPredicate#equalTo(int...)}.
+		 *
+		 */
 		public class JoinOperatorSetsPredicate {
 			
 			private final Keys<I1> keys1;
@@ -490,18 +645,41 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 				this.keys1 = keys1;
 			}
 			
-			
+			/**
+			 * Continues a Join transformation and defines the {@link Tuple} fields of the second join 
+			 * {@link DataSet} that should be used as join keys.<br/>
+			 * <b>Note: Fields can only be selected as join keys on Tuple DataSets.</b><br/>
+			 * 
+			 * The resulting {@link DefaultJoin} wraps each pair of joining elements into a {@link Tuple2}, with 
+			 * the element of the first input being the first field of the tuple and the element of the 
+			 * second input being the second field of the tuple. 
+			 * 
+			 * @param fields The indexes of the Tuple fields of the second join DataSets that should be used as keys.
+			 * @return A DefaultJoin that represents the joined DataSet.
+			 */
 			public DefaultJoin<I1, I2> equalTo(int... fields) {
 				return createJoinOperator(new Keys.FieldPositionKeys<I2>(fields, input2.getType()));
 			}
 
-			public DefaultJoin<I1, I2> equalTo(String keyExpression) {
-				return createJoinOperator(new Keys.ExpressionKeys<I2>(keyExpression, input2.getType()));
-			}
-			
+			/**
+			 * Continues a Join transformation and defines a {@link KeySelector} function for the second join {@link DataSet}.</br>
+			 * The KeySelector function is called for each element of the second DataSet and extracts a single 
+			 * key value on which the DataSet is joined. </br>
+			 * 
+			 * The resulting {@link DefaultJoin} wraps each pair of joining elements into a {@link Tuple2}, with 
+			 * the element of the first input being the first field of the tuple and the element of the 
+			 * second input being the second field of the tuple. 
+			 * 
+			 * @param keyExtractor The KeySelector function which extracts the key values from the DataSet on which it is joined.
+			 * @return A DefaultJoin that represents the joined DataSet.
+			 */
 			public <K> DefaultJoin<I1, I2> equalTo(KeySelector<I2, K> keyExtractor) {
 				return createJoinOperator(new Keys.SelectorFunctionKeys<I2, K>(keyExtractor, input2.getType()));
 			}
+			
+//			public DefaultJoin<I1, I2> equalTo(String keyExpression) {
+//				return createJoinOperator(new Keys.ExpressionKeys<I2>(keyExpression, input2.getType()));
+//			}
 			
 			protected DefaultJoin<I1, I2> createJoinOperator(Keys<I2> keys2) {
 				if (keys2 == null)
@@ -534,6 +712,40 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		}
 	}
 	
+	public static final class ProjectJoinFunction<T1, T2, R extends Tuple> extends JoinFunction<T1, T2, R> {
+		
+		private static final long serialVersionUID = 1L;
+		
+		private final int[] fields;
+		private final boolean[] isFromFirst;
+		private final R outTuple;
+	
+		private ProjectJoinFunction(int[] fields, boolean[] isFromFirst, R outTupleInstance) {
+			this.fields = fields;
+			this.isFromFirst = isFromFirst;
+			this.outTuple = outTupleInstance;
+		}
+		
+		public R join(T1 in1, T2 in2) {
+			for(int i=0; i<fields.length; i++) {
+				if(isFromFirst[i]) {
+					if(fields[i] >= 0) {
+						outTuple.setField(((Tuple)in1).getField(fields[i]), i);
+					} else {
+						outTuple.setField(in1, i);
+					}
+				} else {
+					if(fields[i] >= 0) {
+						outTuple.setField(((Tuple)in2).getField(fields[i]), i);
+					} else {
+						outTuple.setField(in2, i);
+					}
+				}
+			}
+			return outTuple;
+		}
+	}
+	
 	public static final class LeftSemiJoinFunction<T1, T2> extends JoinFunction<T1, T2, T1> {
 
 		private static final long serialVersionUID = 1L;
@@ -552,5 +764,994 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		public T2 join(T1 left, T2 right) throws Exception {
 			return right;
 		}
+	}
+	
+	public static final class JoinProjection<I1, I2> {
+		
+		private final DataSet<I1> ds1;
+		private final DataSet<I2> ds2;
+		private final Keys<I1> keys1;
+		private final Keys<I2> keys2;
+		private final JoinHint hint;
+		
+		private int[] fieldIndexes;
+		private boolean[] isFieldInFirst;
+		
+		private final int numFieldsDs1;
+		private final int numFieldsDs2;
+		
+		public JoinProjection(DataSet<I1> ds1, DataSet<I2> ds2, Keys<I1> keys1, Keys<I2> keys2, JoinHint hint, int[] firstFieldIndexes, int[] secondFieldIndexes) {
+			
+			boolean isFirstTuple;
+			boolean isSecondTuple;
+			
+			if(ds1.getType() instanceof TupleTypeInfo) {
+				numFieldsDs1 = ((TupleTypeInfo<?>)ds1.getType()).getArity();
+				isFirstTuple = true;
+			} else {
+				numFieldsDs1 = 1;
+				isFirstTuple = false;
+			}
+			if(ds2.getType() instanceof TupleTypeInfo) {
+				numFieldsDs2 = ((TupleTypeInfo<?>)ds2.getType()).getArity();
+				isSecondTuple = true;
+			} else {
+				numFieldsDs2 = 1;
+				isSecondTuple = false;
+			}
+			
+			boolean isTuple;
+			boolean firstInput;
+			
+			if(firstFieldIndexes != null && secondFieldIndexes == null) {
+				// index array for first input is provided
+				firstInput = true;
+				isTuple = isFirstTuple;
+				this.fieldIndexes = firstFieldIndexes;
+				
+				if(this.fieldIndexes.length == 0) {
+					// no indexes provided, treat tuple as regular object
+					isTuple = false;
+				}
+			} else if (firstFieldIndexes == null && secondFieldIndexes != null) {
+				// index array for second input is provided
+				firstInput = false;
+				isTuple = isSecondTuple;
+				this.fieldIndexes = secondFieldIndexes;
+				
+				if(this.fieldIndexes.length == 0) {
+					// no indexes provided, treat tuple as regular object
+					isTuple = false;
+				}
+			} else if (firstFieldIndexes == null && secondFieldIndexes == null) {
+				throw new IllegalArgumentException("You must provide at least one field index array.");
+			} else {
+				throw new IllegalArgumentException("You must provide at most one field index array.");
+			}
+			
+			if(!isTuple && this.fieldIndexes.length != 0) {
+				// field index provided for non-Tuple input
+				throw new IllegalArgumentException("Input is not a Tuple. Call projectSecond without arguments to include it.");
+			} else if(this.fieldIndexes.length > 22) {
+				throw new IllegalArgumentException("You may select only up to twenty-two (22) fields.");
+			}
+			
+			isFieldInFirst = new boolean[this.fieldIndexes.length];
+			
+			if(isTuple) {
+				// check field indexes and adapt to position in tuple
+				int maxFieldIndex = firstInput ? numFieldsDs1 : numFieldsDs2;
+				for(int i=0; i<this.fieldIndexes.length; i++) {
+					if(this.fieldIndexes[i] > maxFieldIndex - 1) {
+						throw new IndexOutOfBoundsException("Provided field index is out of bounds of input tuple.");
+					}
+					if(firstInput) {
+						this.isFieldInFirst[i] = true;
+					} else {
+						this.isFieldInFirst[i] = false;
+					}
+				}
+			} else {
+				this.isFieldInFirst = new boolean[]{firstInput};
+				this.fieldIndexes = new int[]{-1};
+			}
+
+			this.ds1 = ds1;
+			this.ds2 = ds2;
+			this.keys1 = keys1;
+			this.keys2 = keys2;
+			this.hint = hint;
+		}
+		
+		/**
+		 * Continues a ProjectJoin transformation and adds fields of the first join input.<br/>
+		 * If the first join input is a {@link Tuple} {@link DataSet}, fields can be selected by their index.
+		 * If the first join input is not a Tuple DataSet, no parameters should be passed.<br/>
+		 * 
+		 * Fields of the first and second input can be added by chaining the method calls of
+		 * {@link JoinProjection#projectFirst(int...)} and {@link JoinProjection#projectSecond(int...)}.
+		 * 
+		 * @param fieldIndexes If the first input is a Tuple DataSet, the indexes of the selected fields. 
+		 * 					   For a non-Tuple DataSet, do not provide parameters.
+		 * 					   The order of fields in the output tuple is defined by to the order of field indexes.
+		 * @return A JoinProjection that needs to be converted into a {@link ProjectOperator} to complete the 
+		 *           ProjectJoin transformation by calling {@link JoinProjection#types()}.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 * @see JoinProjection
+		 * @see ProjectJoin
+		 */
+		public JoinProjection<I1, I2> projectFirst(int... firstFieldIndexes) {
+			
+			boolean isFirstTuple;
+			
+			if(ds1.getType() instanceof TupleTypeInfo && firstFieldIndexes.length > 0) {
+				isFirstTuple = true;
+			} else {
+				isFirstTuple = false;
+			}
+			
+			if(!isFirstTuple && firstFieldIndexes.length != 0) {
+				// field index provided for non-Tuple input
+				throw new IllegalArgumentException("Input is not a Tuple. Call projectSecond without arguments to include it.");
+			} else if(firstFieldIndexes.length > (22 - this.fieldIndexes.length)) {
+				// to many field indexes provided
+				throw new IllegalArgumentException("You may select only up to twenty-two (22) fields in total.");
+			}
+			
+			int offset = this.fieldIndexes.length;
+			
+			if(isFirstTuple) {
+				// extend index and flag arrays
+				this.fieldIndexes = Arrays.copyOf(this.fieldIndexes, this.fieldIndexes.length + firstFieldIndexes.length);
+				this.isFieldInFirst = Arrays.copyOf(this.isFieldInFirst, this.isFieldInFirst.length + firstFieldIndexes.length);
+				
+				// copy field indexes
+				int maxFieldIndex = numFieldsDs1;
+				for(int i = 0; i < firstFieldIndexes.length; i++) {
+					// check if indexes in range
+					if(firstFieldIndexes[i] > maxFieldIndex - 1) {
+						throw new IndexOutOfBoundsException("Provided field index is out of bounds of input tuple.");
+					}
+					this.isFieldInFirst[offset + i] = true;
+					this.fieldIndexes[offset + i] = firstFieldIndexes[i];
+				}
+			} else {
+				// extend index and flag arrays
+				this.fieldIndexes = Arrays.copyOf(this.fieldIndexes, this.fieldIndexes.length + 1);
+				this.isFieldInFirst = Arrays.copyOf(this.isFieldInFirst, this.isFieldInFirst.length + 1);
+				
+				// add input object to output tuple
+				this.isFieldInFirst[offset] = true;
+				this.fieldIndexes[offset] = -1;
+			}
+			
+			return this;
+		}
+		
+		/**
+		 * Continues a ProjectJoin transformation and adds fields of the second join input.<br/>
+		 * If the second join input is a {@link Tuple} {@link DataSet}, fields can be selected by their index.
+		 * If the second join input is not a Tuple DataSet, no parameters should be passed.<br/>
+		 * 
+		 * Fields of the first and second input can be added by chaining the method calls of
+		 * {@link JoinProjection#projectFirst(int...)} and {@link JoinProjection#projectSecond(int...)}.
+		 * 
+		 * @param fieldIndexes If the second input is a Tuple DataSet, the indexes of the selected fields. 
+		 * 					   For a non-Tuple DataSet, do not provide parameters.
+		 * 					   The order of fields in the output tuple is defined by to the order of field indexes.
+		 * @return A JoinProjection that needs to be converted into a {@link ProjectOperator} to complete the 
+		 *           ProjectJoin transformation by calling {@link JoinProjection#types()}.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 * @see JoinProjection
+		 * @see ProjectJoin
+		 */
+		public JoinProjection<I1, I2> projectSecond(int... secondFieldIndexes) {
+			
+			boolean isSecondTuple;
+			
+			if(ds2.getType() instanceof TupleTypeInfo && secondFieldIndexes.length > 0) {
+				isSecondTuple = true;
+			} else {
+				isSecondTuple = false;
+			}
+			
+			if(!isSecondTuple && secondFieldIndexes.length != 0) {
+				// field index provided for non-Tuple input
+				throw new IllegalArgumentException("Input is not a Tuple. Call projectSecond without arguments to include it.");
+			} else if(secondFieldIndexes.length > (22 - this.fieldIndexes.length)) {
+				// to many field indexes provided
+				throw new IllegalArgumentException("You may select only up to twenty-two (22) fields in total.");
+			}
+			
+			int offset = this.fieldIndexes.length;
+			
+			if(isSecondTuple) {
+				// extend index and flag arrays
+				this.fieldIndexes = Arrays.copyOf(this.fieldIndexes, this.fieldIndexes.length + secondFieldIndexes.length);
+				this.isFieldInFirst = Arrays.copyOf(this.isFieldInFirst, this.isFieldInFirst.length + secondFieldIndexes.length);
+				
+				// copy field indexes
+				int maxFieldIndex = numFieldsDs2;
+				for(int i = 0; i < secondFieldIndexes.length; i++) {
+					// check if indexes in range
+					if(secondFieldIndexes[i] > maxFieldIndex - 1) {
+						throw new IndexOutOfBoundsException("Provided field index is out of bounds of input tuple.");
+					}
+					this.isFieldInFirst[offset + i] = false;
+					this.fieldIndexes[offset + i] = secondFieldIndexes[i];
+				}
+			} else {
+				// extend index and flag arrays
+				this.fieldIndexes = Arrays.copyOf(this.fieldIndexes, this.fieldIndexes.length + 1);
+				this.isFieldInFirst = Arrays.copyOf(this.isFieldInFirst, this.isFieldInFirst.length + 1);
+				
+				// add input object to output tuple
+				this.isFieldInFirst[offset] = false;
+				this.fieldIndexes[offset] = -1;
+			}
+			
+			return this;
+		}
+		
+		// --------------------------------------------------------------------------------------------	
+		// The following lines are generated.
+		// --------------------------------------------------------------------------------------------	
+		// BEGIN_OF_TUPLE_DEPENDENT_CODE	
+		// GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0> ProjectJoin<I1, I2, Tuple1<T0>> types(Class<T0> type0) {
+			Class<?>[] types = {type0};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple1<T0>> tType = new TupleTypeInfo<Tuple1<T0>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple1<T0>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1> ProjectJoin<I1, I2, Tuple2<T0, T1>> types(Class<T0> type0, Class<T1> type1) {
+			Class<?>[] types = {type0, type1};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple2<T0, T1>> tType = new TupleTypeInfo<Tuple2<T0, T1>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple2<T0, T1>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2> ProjectJoin<I1, I2, Tuple3<T0, T1, T2>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2) {
+			Class<?>[] types = {type0, type1, type2};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple3<T0, T1, T2>> tType = new TupleTypeInfo<Tuple3<T0, T1, T2>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple3<T0, T1, T2>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3> ProjectJoin<I1, I2, Tuple4<T0, T1, T2, T3>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
+			Class<?>[] types = {type0, type1, type2, type3};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple4<T0, T1, T2, T3>> tType = new TupleTypeInfo<Tuple4<T0, T1, T2, T3>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple4<T0, T1, T2, T3>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4> ProjectJoin<I1, I2, Tuple5<T0, T1, T2, T3, T4>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
+			Class<?>[] types = {type0, type1, type2, type3, type4};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>> tType = new TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple5<T0, T1, T2, T3, T4>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5> ProjectJoin<I1, I2, Tuple6<T0, T1, T2, T3, T4, T5>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>> tType = new TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple6<T0, T1, T2, T3, T4, T5>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6> ProjectJoin<I1, I2, Tuple7<T0, T1, T2, T3, T4, T5, T6>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>> tType = new TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple7<T0, T1, T2, T3, T4, T5, T6>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7> ProjectJoin<I1, I2, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> tType = new TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8> ProjectJoin<I1, I2, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> tType = new TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> ProjectJoin<I1, I2, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> tType = new TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ProjectJoin<I1, I2, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> tType = new TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> ProjectJoin<I1, I2, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> tType = new TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> ProjectJoin<I1, I2, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> tType = new TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> ProjectJoin<I1, I2, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> tType = new TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> ProjectJoin<I1, I2, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> tType = new TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> ProjectJoin<I1, I2, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> tType = new TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> ProjectJoin<I1, I2, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> tType = new TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> ProjectJoin<I1, I2, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> tType = new TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> ProjectJoin<I1, I2, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> tType = new TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @param type19 The class of field '19' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> ProjectJoin<I1, I2, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> tType = new TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @param type19 The class of field '19' of the result tuples.
+		 * @param type20 The class of field '20' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> ProjectJoin<I1, I2, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> tType = new TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		/**
+		 * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. 
+		 * Requires the classes of the fields of the resulting tuples. 
+		 * 
+		 * @param type0 The class of field '0' of the result tuples.
+		 * @param type1 The class of field '1' of the result tuples.
+		 * @param type2 The class of field '2' of the result tuples.
+		 * @param type3 The class of field '3' of the result tuples.
+		 * @param type4 The class of field '4' of the result tuples.
+		 * @param type5 The class of field '5' of the result tuples.
+		 * @param type6 The class of field '6' of the result tuples.
+		 * @param type7 The class of field '7' of the result tuples.
+		 * @param type8 The class of field '8' of the result tuples.
+		 * @param type9 The class of field '9' of the result tuples.
+		 * @param type10 The class of field '10' of the result tuples.
+		 * @param type11 The class of field '11' of the result tuples.
+		 * @param type12 The class of field '12' of the result tuples.
+		 * @param type13 The class of field '13' of the result tuples.
+		 * @param type14 The class of field '14' of the result tuples.
+		 * @param type15 The class of field '15' of the result tuples.
+		 * @param type16 The class of field '16' of the result tuples.
+		 * @param type17 The class of field '17' of the result tuples.
+		 * @param type18 The class of field '18' of the result tuples.
+		 * @param type19 The class of field '19' of the result tuples.
+		 * @param type20 The class of field '20' of the result tuples.
+		 * @param type21 The class of field '21' of the result tuples.
+		 * @return The projected data set.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
+		 */
+		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> ProjectJoin<I1, I2, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20, Class<T21> type21) {
+			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20, type21};
+			if(types.length != this.fieldIndexes.length) {
+				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
+			}
+			
+			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
+			TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> tType = new TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(fTypes);
+
+			return new ProjectJoin<I1, I2, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);
+		}
+
+		// END_OF_TUPLE_DEPENDENT_CODE
+		// -----------------------------------------------------------------------------------------
+		
+			
+		private TypeInformation<?>[] extractFieldTypes(int[] fields, Class<?>[] givenTypes) {
+			
+			TypeInformation<?>[] fieldTypes = new TypeInformation[fields.length];
+
+			for(int i=0; i<fields.length; i++) {
+				
+				TypeInformation<?> typeInfo;
+				if(isFieldInFirst[i]) {
+					if(fields[i] >= 0) {
+						typeInfo = ((TupleTypeInfo<?>)ds1.getType()).getTypeAt(fields[i]);
+					} else {
+						typeInfo = ds1.getType();
+					}
+				} else {
+					if(fields[i] >= 0) {
+						typeInfo = ((TupleTypeInfo<?>)ds2.getType()).getTypeAt(fields[i]);
+					} else {
+						typeInfo = ds2.getType();
+					}
+				}
+				
+				if(typeInfo.getTypeClass() != givenTypes[i]) {
+					throw new IllegalArgumentException("Given types do not match types of input data set.");
+				}
+
+				fieldTypes[i] = typeInfo;
+			}
+			
+			return fieldTypes;
+		}
+				
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ProjectOperator.java
@@ -108,14 +108,17 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		// The following lines are generated.
 		// --------------------------------------------------------------------------------------------	
 		// BEGIN_OF_TUPLE_DEPENDENT_CODE	
-		// GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
+	// GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0> ProjectOperator<T, Tuple1<T0>> types(Class<T0> type0) {
 			Class<?>[] types = {type0};
@@ -130,12 +133,15 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1> ProjectOperator<T, Tuple2<T0, T1>> types(Class<T0> type0, Class<T1> type1) {
 			Class<?>[] types = {type0, type1};
@@ -150,13 +156,16 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2> ProjectOperator<T, Tuple3<T0, T1, T2>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2) {
 			Class<?>[] types = {type0, type1, type2};
@@ -171,14 +180,17 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3> ProjectOperator<T, Tuple4<T0, T1, T2, T3>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3) {
 			Class<?>[] types = {type0, type1, type2, type3};
@@ -193,15 +205,18 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4> ProjectOperator<T, Tuple5<T0, T1, T2, T3, T4>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4) {
 			Class<?>[] types = {type0, type1, type2, type3, type4};
@@ -216,16 +231,19 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5> ProjectOperator<T, Tuple6<T0, T1, T2, T3, T4, T5>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5};
@@ -240,17 +258,20 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6> ProjectOperator<T, Tuple7<T0, T1, T2, T3, T4, T5, T6>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6};
@@ -265,18 +286,21 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7> ProjectOperator<T, Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7};
@@ -291,19 +315,22 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8> ProjectOperator<T, Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8};
@@ -318,20 +345,23 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> ProjectOperator<T, Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9};
@@ -346,21 +376,24 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ProjectOperator<T, Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10};
@@ -375,22 +408,25 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> ProjectOperator<T, Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11};
@@ -405,23 +441,26 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> ProjectOperator<T, Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12};
@@ -436,24 +475,27 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> ProjectOperator<T, Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13};
@@ -468,25 +510,28 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> ProjectOperator<T, Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14};
@@ -501,26 +546,29 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @param type15 The class of field '15' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @param type15 The class of field '15' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> ProjectOperator<T, Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15};
@@ -535,27 +583,30 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @param type15 The class of field '15' of the result tuples.
-		 * @param type16 The class of field '16' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @param type15 The class of field '15' of the result Tuples.
+		 * @param type16 The class of field '16' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> ProjectOperator<T, Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16};
@@ -570,28 +621,31 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @param type15 The class of field '15' of the result tuples.
-		 * @param type16 The class of field '16' of the result tuples.
-		 * @param type17 The class of field '17' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @param type15 The class of field '15' of the result Tuples.
+		 * @param type16 The class of field '16' of the result Tuples.
+		 * @param type17 The class of field '17' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> ProjectOperator<T, Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17};
@@ -606,29 +660,32 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @param type15 The class of field '15' of the result tuples.
-		 * @param type16 The class of field '16' of the result tuples.
-		 * @param type17 The class of field '17' of the result tuples.
-		 * @param type18 The class of field '18' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @param type15 The class of field '15' of the result Tuples.
+		 * @param type16 The class of field '16' of the result Tuples.
+		 * @param type17 The class of field '17' of the result Tuples.
+		 * @param type18 The class of field '18' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> ProjectOperator<T, Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18};
@@ -643,30 +700,33 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @param type15 The class of field '15' of the result tuples.
-		 * @param type16 The class of field '16' of the result tuples.
-		 * @param type17 The class of field '17' of the result tuples.
-		 * @param type18 The class of field '18' of the result tuples.
-		 * @param type19 The class of field '19' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @param type15 The class of field '15' of the result Tuples.
+		 * @param type16 The class of field '16' of the result Tuples.
+		 * @param type17 The class of field '17' of the result Tuples.
+		 * @param type18 The class of field '18' of the result Tuples.
+		 * @param type19 The class of field '19' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> ProjectOperator<T, Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19};
@@ -681,31 +741,34 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @param type15 The class of field '15' of the result tuples.
-		 * @param type16 The class of field '16' of the result tuples.
-		 * @param type17 The class of field '17' of the result tuples.
-		 * @param type18 The class of field '18' of the result tuples.
-		 * @param type19 The class of field '19' of the result tuples.
-		 * @param type20 The class of field '20' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @param type15 The class of field '15' of the result Tuples.
+		 * @param type16 The class of field '16' of the result Tuples.
+		 * @param type17 The class of field '17' of the result Tuples.
+		 * @param type18 The class of field '18' of the result Tuples.
+		 * @param type19 The class of field '19' of the result Tuples.
+		 * @param type20 The class of field '20' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> ProjectOperator<T, Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20};
@@ -720,32 +783,35 @@ public class ProjectOperator<IN, OUT extends Tuple>
 		}
 
 		/**
-		 * Projects a tuple data set to the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
+		 * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. 
+		 * Requires the classes of the fields of the resulting Tuples. 
 		 * 
-		 * @param type0 The class of field '0' of the result tuples.
-		 * @param type1 The class of field '1' of the result tuples.
-		 * @param type2 The class of field '2' of the result tuples.
-		 * @param type3 The class of field '3' of the result tuples.
-		 * @param type4 The class of field '4' of the result tuples.
-		 * @param type5 The class of field '5' of the result tuples.
-		 * @param type6 The class of field '6' of the result tuples.
-		 * @param type7 The class of field '7' of the result tuples.
-		 * @param type8 The class of field '8' of the result tuples.
-		 * @param type9 The class of field '9' of the result tuples.
-		 * @param type10 The class of field '10' of the result tuples.
-		 * @param type11 The class of field '11' of the result tuples.
-		 * @param type12 The class of field '12' of the result tuples.
-		 * @param type13 The class of field '13' of the result tuples.
-		 * @param type14 The class of field '14' of the result tuples.
-		 * @param type15 The class of field '15' of the result tuples.
-		 * @param type16 The class of field '16' of the result tuples.
-		 * @param type17 The class of field '17' of the result tuples.
-		 * @param type18 The class of field '18' of the result tuples.
-		 * @param type19 The class of field '19' of the result tuples.
-		 * @param type20 The class of field '20' of the result tuples.
-		 * @param type21 The class of field '21' of the result tuples.
-		 * @return The projected data set.
+		 * @param type0 The class of field '0' of the result Tuples.
+		 * @param type1 The class of field '1' of the result Tuples.
+		 * @param type2 The class of field '2' of the result Tuples.
+		 * @param type3 The class of field '3' of the result Tuples.
+		 * @param type4 The class of field '4' of the result Tuples.
+		 * @param type5 The class of field '5' of the result Tuples.
+		 * @param type6 The class of field '6' of the result Tuples.
+		 * @param type7 The class of field '7' of the result Tuples.
+		 * @param type8 The class of field '8' of the result Tuples.
+		 * @param type9 The class of field '9' of the result Tuples.
+		 * @param type10 The class of field '10' of the result Tuples.
+		 * @param type11 The class of field '11' of the result Tuples.
+		 * @param type12 The class of field '12' of the result Tuples.
+		 * @param type13 The class of field '13' of the result Tuples.
+		 * @param type14 The class of field '14' of the result Tuples.
+		 * @param type15 The class of field '15' of the result Tuples.
+		 * @param type16 The class of field '16' of the result Tuples.
+		 * @param type17 The class of field '17' of the result Tuples.
+		 * @param type18 The class of field '18' of the result Tuples.
+		 * @param type19 The class of field '19' of the result Tuples.
+		 * @param type20 The class of field '20' of the result Tuples.
+		 * @param type21 The class of field '21' of the result Tuples.
+		 * @return The projected DataSet.
+		 * 
+		 * @see Tuple
+		 * @see DataSet
 		 */
 		public <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> ProjectOperator<T, Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> types(Class<T0> type0, Class<T1> type1, Class<T2> type2, Class<T3> type3, Class<T4> type4, Class<T5> type5, Class<T6> type6, Class<T7> type7, Class<T8> type8, Class<T9> type9, Class<T10> type10, Class<T11> type11, Class<T12> type12, Class<T13> type13, Class<T14> type14, Class<T15> type15, Class<T16> type16, Class<T17> type17, Class<T18> type18, Class<T19> type19, Class<T20> type20, Class<T21> type21) {
 			Class<?>[] types = {type0, type1, type2, type3, type4, type5, type6, type7, type8, type9, type10, type11, type12, type13, type14, type15, type16, type17, type18, type19, type20, type21};

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/TupleGenerator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/tuple/TupleGenerator.java
@@ -55,6 +55,11 @@ class TupleGenerator {
 	private static final String PROJECT_OPERATOR_PACKAGE = "eu.stratosphere.api.java.operators";
 	
 	private static final String PROJECT_OPERATOR_CLASSNAME = "ProjectOperator";
+	
+	// Parameters for JoinOperator
+	private static final String JOIN_OPERATOR_PACKAGE = "eu.stratosphere.api.java.operators";
+	
+	private static final String JOIN_OPERATOR_CLASSNAME = "JoinOperator";
 
 	// min. and max. tuple arity	
 	private static final int FIRST = 1;
@@ -73,6 +78,8 @@ class TupleGenerator {
 		modifyTupleTypeInfo(root);
 		
 		modifyProjectOperator(root);
+		
+		modifyJoinProjectOperator(root);
 	}
 
 	private static File getPackage(File root, String packageString) {
@@ -141,13 +148,16 @@ class TupleGenerator {
 			
 			// method comment
 			sb.append("\t\t/**\n");
-			sb.append("\t\t * Projects a tuple data set to the previously selected fields. \n");
-			sb.append("\t\t * Requires the classes of the fields of the resulting tuples. \n");
+			sb.append("\t\t * Projects a {@link Tuple} {@link DataSet} to the previously selected fields. \n");
+			sb.append("\t\t * Requires the classes of the fields of the resulting Tuples. \n");
 			sb.append("\t\t * \n");			
 			for (int i = 0; i < numFields; i++) {
-				sb.append("\t\t * @param type" + i + " The class of field '"+i+"' of the result tuples.\n");
+				sb.append("\t\t * @param type" + i + " The class of field '"+i+"' of the result Tuples.\n");
 			}
-			sb.append("\t\t * @return The projected data set.\n");
+			sb.append("\t\t * @return The projected DataSet.\n");
+			sb.append("\t\t * \n");			
+			sb.append("\t\t * @see Tuple\n");
+			sb.append("\t\t * @see DataSet\n");
 			sb.append("\t\t */\n");
 			
 			// method signature
@@ -203,6 +213,85 @@ class TupleGenerator {
 		// insert code into file
 		File dir = getPackage(root, PROJECT_OPERATOR_PACKAGE);
 		File projectOperatorClass = new File(dir, PROJECT_OPERATOR_CLASSNAME + ".java");
+		insertCodeIntoFile(sb.toString(), projectOperatorClass);
+	}
+	
+	private static void modifyJoinProjectOperator(File root) throws IOException {
+		// generate code
+		StringBuilder sb = new StringBuilder();
+		
+		for (int numFields = FIRST; numFields <= LAST; numFields++) {
+
+			// method begin
+			sb.append("\n");
+			
+			// method comment
+			sb.append("\t\t/**\n");
+			sb.append("\t\t * Projects a pair of joined elements to a {@link Tuple} with the previously selected fields. \n");
+			sb.append("\t\t * Requires the classes of the fields of the resulting tuples. \n");
+			sb.append("\t\t * \n");			
+			for (int i = 0; i < numFields; i++) {
+				sb.append("\t\t * @param type" + i + " The class of field '"+i+"' of the result tuples.\n");
+			}
+			sb.append("\t\t * @return The projected data set.\n");
+			sb.append("\t\t * \n");			
+			sb.append("\t\t * @see Tuple\n");
+			sb.append("\t\t * @see DataSet\n");
+			sb.append("\t\t */\n");
+			
+			// method signature
+			sb.append("\t\tpublic <");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append("> ProjectJoin<I1, I2, Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">> types(");
+			for (int i = 0; i < numFields; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append("Class<");
+				sb.append(GEN_TYPE_PREFIX + i);
+				sb.append("> type" + i);
+			}
+			sb.append(") {\n");
+			
+			// convert type0..1 to types array
+			sb.append("\t\t\tClass<?>[] types = {");
+			for (int i = 0; i < numFields; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append("type" + i);
+			}
+			sb.append("};\n");
+			
+			// check number of types and extract field types
+			sb.append("\t\t\tif(types.length != this.fieldIndexes.length) {\n");
+			sb.append("\t\t\t\tthrow new IllegalArgumentException(\"Numbers of projected fields and types do not match.\");\n");
+			sb.append("\t\t\t}\n");
+			sb.append("\t\t\t\n");
+			sb.append("\t\t\tTypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);\n");
+			
+			// create new tuple type info
+			sb.append("\t\t\tTupleTypeInfo<Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">> tType = new TupleTypeInfo<Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">>(fTypes);\n\n");
+			
+			// create and return new project operator
+			sb.append("\t\t\treturn new ProjectJoin<I1, I2, Tuple"+numFields+"<");
+			appendTupleTypeGenerics(sb, numFields);
+			sb.append(">>(this.ds1, this.ds2, this.keys1, this.keys2, this.hint, this.fieldIndexes, this.isFieldInFirst, tType);\n");
+			
+			// method end
+			sb.append("\t\t}\n");
+			
+		}
+		
+		// insert code into file
+		File dir = getPackage(root, JOIN_OPERATOR_PACKAGE);
+		File projectOperatorClass = new File(dir, JOIN_OPERATOR_CLASSNAME + ".java");
 		insertCodeIntoFile(sb.toString(), projectOperatorClass);
 	}
 	

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/operator/JoinOperatorTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/operator/JoinOperatorTest.java
@@ -263,7 +263,250 @@ public class JoinOperatorTest {
 //					}
 //				   );
 //	}
+	
+	@Test
+	public void testJoinProjection1() {
 		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			ds1.join(ds2).where(0).equalTo(0)
+			   .projectFirst(0)
+			   .types(Integer.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+	
+	@Test
+	public void testJoinProjection2() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			ds1.join(ds2).where(0).equalTo(0)
+			   .projectFirst(0,3)
+			   .types(Integer.class, Long.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+	
+	@Test
+	public void testJoinProjection3() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			ds1.join(ds2).where(0).equalTo(0)
+			   .projectFirst(0)
+			   .projectSecond(3)
+			   .types(Integer.class, Long.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+	
+	@Test
+	public void testJoinProjection4() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			ds1.join(ds2).where(0).equalTo(0)
+			   .projectFirst(0,2)
+			   .projectSecond(1,4)
+			   .projectFirst(1)
+			   .types(Integer.class, String.class, Long.class, Integer.class, Long.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+		
+	}
+	
+	@Test
+	public void testJoinProjection5() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			ds1.join(ds2).where(0).equalTo(0)
+			   .projectSecond(0,2)
+			   .projectFirst(1,4)
+			   .projectFirst(1)
+			   .types(Integer.class, String.class, Long.class, Integer.class, Long.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+	
+	@Test
+	public void testJoinProjection6() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<CustomType> ds1 = env.fromCollection(customTypeData);
+		DataSet<CustomType> ds2 = env.fromCollection(customTypeData);
+
+		// should work
+		try {
+			ds1.join(ds2)
+			   .where(
+					   new KeySelector<CustomType, Long>() {
+							
+							@Override
+							public Long getKey(CustomType value) {
+								return value.myLong;
+							}
+						}
+					 )
+			   .equalTo(
+					   new KeySelector<CustomType, Long>() {
+							
+							@Override
+							public Long getKey(CustomType value) {
+								return value.myLong;
+							}
+						}
+					   )
+				.projectFirst()
+				.projectSecond()
+				.types(CustomType.class, CustomType.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+	
+	@Test
+	public void testJoinProjection7() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should work
+		try {
+			ds1.join(ds2).where(0).equalTo(0)
+			   .projectSecond()
+			   .projectFirst(1,4)
+			   .types(Tuple5.class, Long.class, Integer.class);
+		} catch(Exception e) {
+			Assert.fail();
+		}
+	}
+	
+	@Test(expected=IndexOutOfBoundsException.class)
+	public void testJoinProjection8() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should not work, index out of range
+		ds1.join(ds2).where(0).equalTo(0)
+		   .projectFirst(5)
+		   .types(Integer.class);
+	}
+	
+	@Test(expected=IndexOutOfBoundsException.class)
+	public void testJoinProjection9() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should not work, index out of range
+		ds1.join(ds2).where(0).equalTo(0)
+		   .projectSecond(5)
+		   .types(Integer.class);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testJoinProjection10() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should not work, type does not match
+		ds1.join(ds2).where(0).equalTo(0)
+		   .projectFirst(2)
+		   .types(Integer.class);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testJoinProjection11() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should not work, type does not match
+		ds1.join(ds2).where(0).equalTo(0)
+		   .projectSecond(2)
+		   .types(Integer.class);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testJoinProjection12() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should not work, number of types and fields does not match
+		ds1.join(ds2).where(0).equalTo(0)
+		   .projectSecond(2)
+		   .projectFirst(1)
+		   .types(String.class);
+	}
+	
+	@Test(expected=IndexOutOfBoundsException.class)
+	public void testJoinProjection13() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should not work, index out of range
+		ds1.join(ds2).where(0).equalTo(0)
+		   .projectSecond(0)
+		   .projectFirst(5)
+		   .types(Integer.class);
+	}
+	
+	@Test(expected=IndexOutOfBoundsException.class)
+	public void testJoinProjection14() {
+		
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds1 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+		DataSet<Tuple5<Integer, Long, String, Long, Integer>> ds2 = env.fromCollection(emptyTupleData, tupleTypeInfo);
+
+		// should not work, index out of range
+		ds1.join(ds2).where(0).equalTo(0)
+		   .projectFirst(0)
+		   .projectSecond(5)
+		   .types(Integer.class);
+	}
+	
+	/*
+	 * ####################################################################
+	 */
+
 	public static class CustomType implements Serializable {
 		
 		private static final long serialVersionUID = 1L;

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/JoinITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/JoinITCase.java
@@ -30,6 +30,7 @@ import eu.stratosphere.api.java.functions.KeySelector;
 import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.api.java.tuple.Tuple3;
 import eu.stratosphere.api.java.tuple.Tuple5;
+import eu.stratosphere.api.java.tuple.Tuple6;
 import eu.stratosphere.configuration.Configuration;
 import eu.stratosphere.test.javaApiOperators.util.CollectionDataSets;
 import eu.stratosphere.test.javaApiOperators.util.CollectionDataSets.CustomType;
@@ -39,7 +40,7 @@ import eu.stratosphere.test.util.JavaProgramTestBase;
 @RunWith(Parameterized.class)
 public class JoinITCase extends JavaProgramTestBase {
 	
-	private static int NUM_PROGRAMS = 9;
+	private static int NUM_PROGRAMS = 11;
 	
 	private int curProgId = config.getInteger("ProgramId", -1);
 	private String resultPath;
@@ -316,9 +317,67 @@ public class JoinITCase extends JavaProgramTestBase {
 					"Hello,Hello\n" +
 					"Hello world,Hello\n";
 			
-		}
+			}
+			case 10: {
+				
+				/*
+				 * Project join on a tuple input 1
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+				DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
+				DataSet<Tuple6<String, Long, String, Integer, Long, Long>> joinDs = 
+						ds1.join(ds2)
+						   .where(1)
+						   .equalTo(1)
+						   .projectFirst(2,1)
+						   .projectSecond(3)
+						   .projectFirst(0)
+						   .projectSecond(4,1)
+						   .types(String.class, Long.class, String.class, Integer.class, Long.class, Long.class);
+				
+				joinDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return "Hi,1,Hallo,1,1,1\n" +
+						"Hello,2,Hallo Welt,2,2,2\n" +
+						"Hello world,2,Hallo Welt,3,2,2\n";
+				
+			}
+			case 11: {
+				
+				/*
+				 * Project join on a tuple input 2
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				
+				DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+				DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
+				DataSet<Tuple6<String, String, Long, Long, Long, Integer>> joinDs = 
+						ds1.join(ds2)
+						   .where(1)
+						   .equalTo(1)
+						   .projectSecond(3)
+						   .projectFirst(2,1)
+						   .projectSecond(4,1)
+						   .projectFirst(0)
+						   .types(String.class, String.class, Long.class, Long.class, Long.class, Integer.class);
+				
+				joinDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return "Hallo,Hi,1,1,1,1\n" +
+						"Hallo Welt,Hello,2,2,2,2\n" +
+						"Hallo Welt,Hello world,2,2,2,3\n";
+			}
+				
 			// TODO: Activate once Avro Serializer supports copy()
-//			case 10: {
+//			case 12: {
 //				
 //				/*
 //				 * Join on a tuple input with key field selector and a custom type input with key extractor
@@ -348,7 +407,7 @@ public class JoinITCase extends JavaProgramTestBase {
 //						
 //			}
 			// TODO: Activate once Avro Serializer supports copy()
-//			case 11: {
+//			case 13: {
 //				
 //				/*
 //				 * (Default) Join on two custom type inputs with key extractors


### PR DESCRIPTION
This PR 
- adds projection joins as described in the [documentation](http://stratosphere.eu/docs/0.5/programming_guides/java.html#transformations). Unit and integration tests are included.
- adds JavaDocs to the join transformation methods.
- removes unsupported join transformation methods.
