### PR TITLE
Mixed key types for join

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanUnwrappingJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanUnwrappingJoinOperator.java
@@ -44,6 +44,28 @@ public class PlanUnwrappingJoinOperator<I1, I2, OUT, K>
 		this.inTypeWithKey2 = typeInfoWithKey2;
 	}
 	
+	public PlanUnwrappingJoinOperator(JoinFunction<I1, I2, OUT> udf, 
+			int[] key1, Keys.SelectorFunctionKeys<I2, K> key2, String name,
+			TypeInformation<OUT> type, TypeInformation<Tuple2<K, I1>> typeInfoWithKey1, TypeInformation<Tuple2<K, I2>> typeInfoWithKey2)
+	{
+		super(new TupleUnwrappingJoiner<I1, I2, OUT, K>(udf), new int[]{0}, key2.computeLogicalKeyPositions(), name);
+		this.outType = type;
+		
+		this.inTypeWithKey1 = typeInfoWithKey1;
+		this.inTypeWithKey2 = typeInfoWithKey2;
+	}
+	
+	public PlanUnwrappingJoinOperator(JoinFunction<I1, I2, OUT> udf, 
+			Keys.SelectorFunctionKeys<I1, K> key1, int[] key2, String name,
+			TypeInformation<OUT> type, TypeInformation<Tuple2<K, I1>> typeInfoWithKey1, TypeInformation<Tuple2<K, I2>> typeInfoWithKey2)
+	{
+		super(new TupleUnwrappingJoiner<I1, I2, OUT, K>(udf), key1.computeLogicalKeyPositions(), new int[]{0}, name);
+		this.outType = type;
+		
+		this.inTypeWithKey1 = typeInfoWithKey1;
+		this.inTypeWithKey2 = typeInfoWithKey2;
+	}
+	
 
 	@Override
 	public TypeInformation<OUT> getReturnType() {

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/JoinITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/JoinITCase.java
@@ -26,6 +26,7 @@ import org.junit.runners.Parameterized.Parameters;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.api.java.functions.JoinFunction;
+import eu.stratosphere.api.java.functions.KeySelector;
 import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.api.java.tuple.Tuple3;
 import eu.stratosphere.api.java.tuple.Tuple5;
@@ -38,7 +39,7 @@ import eu.stratosphere.test.util.JavaProgramTestBase;
 @RunWith(Parameterized.class)
 public class JoinITCase extends JavaProgramTestBase {
 	
-	private static int NUM_PROGRAMS = 8;
+	private static int NUM_PROGRAMS = 9;
 	
 	private int curProgId = config.getInteger("ProgramId", -1);
 	private String resultPath;
@@ -285,8 +286,39 @@ public class JoinITCase extends JavaProgramTestBase {
 						"Hello,Hallo Welt,55\n" +
 						"Hello world,Hallo Welt,55\n";
 			}
-			// TODO: Activate once key type mixing has been implemented
-//			case 9: {
+			case 9: {
+			
+			/*
+			 * Join on a tuple input with key field selector and a custom type input with key extractor
+			 */
+			
+			final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+			DataSet<CustomType> ds1 = CollectionDataSets.getSmallCustomTypeDataSet(env);
+			DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.get3TupleDataSet(env);
+			DataSet<Tuple2<String, String>> joinDs = 
+					ds1.join(ds2)
+					   .where(new KeySelector<CustomType, Integer>() {
+								   @Override
+								   public Integer getKey(CustomType value) {
+									   return value.myInt;
+								   }
+							   }
+							   )
+					   .equalTo(0)
+					   .with(new CustT3Join());
+			
+			joinDs.writeAsCsv(resultPath);
+			env.execute();
+			
+			// return expected result
+			return "Hi,Hi\n" +
+					"Hello,Hello\n" +
+					"Hello world,Hello\n";
+			
+		}
+			// TODO: Activate once Avro Serializer supports copy()
+//			case 10: {
 //				
 //				/*
 //				 * Join on a tuple input with key field selector and a custom type input with key extractor
@@ -298,15 +330,12 @@ public class JoinITCase extends JavaProgramTestBase {
 //				DataSet<CustomType> ds2 = CollectionDataSets.getCustomTypeDataSet(env);
 //				DataSet<Tuple2<String, String>> joinDs = 
 //						ds1.join(ds2)
-//						   .where(1)
-//						   .equalTo(
-//								   new KeySelector<CustomType, Long>() {
+//						   .where(1).equalTo(new KeySelector<CustomType, Long>() {
 //									   @Override
 //									   public Long getKey(CustomType value) {
 //										   return value.myLong;
 //									   }
-//								   }
-//								   )
+//								   })
 //						   .with(new T3CustJoin());
 //				
 //				joinDs.writeAsCsv(resultPath);
@@ -317,38 +346,6 @@ public class JoinITCase extends JavaProgramTestBase {
 //						"Hello,Hello world\n" +
 //						"Hello world,Hello world\n";
 //						
-//			}
-			// TODO: Activate once key type mixing has been implemented
-//			case 10: {
-//				
-//				/*
-//				 * Join on a tuple input with key field selector and a custom type input with key extractor
-//				 */
-//				
-//				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-//
-//				DataSet<CustomType> ds1 = CollectionDataSets.getSmallCustomTypeDataSet(env);
-//				DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.get3TupleDataSet(env);
-//				DataSet<Tuple2<String, String>> joinDs = 
-//						ds1.join(ds2)
-//						   .where(new KeySelector<CustomType, Integer>() {
-//									   @Override
-//									   public Integer getKey(CustomType value) {
-//										   return value.myInt;
-//									   }
-//								   }
-//								   )
-//						   .equalTo(0)
-//						   .with(new CustT3Join());
-//				
-//				joinDs.writeAsCsv(resultPath);
-//				env.execute();
-//				
-//				// return expected result
-//				return "Hi,Hi\n" +
-//						"Hello,Hello\n" +
-//						"Hello world,Hello\n";
-//				
 //			}
 			// TODO: Activate once Avro Serializer supports copy()
 //			case 11: {


### PR DESCRIPTION
See #675
For some reasons one of the tests is already running because copy() in the Avro Serializer is not called for it. I suppose it has something to do with one dataset being very small so that the optimizer decides for some different strategy.
The other test has copy() support for the Avro Serializer pending.
