### PR TITLE
(Re)add TransitiveClosureNaive, fix join, add ITCase

### DIFF
--- a/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/graph/TransitiveClosureNaive.scala
+++ b/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/graph/TransitiveClosureNaive.scala
@@ -1,0 +1,81 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.examples.scala.graph;
+
+import eu.stratosphere.client.LocalExecutor
+import eu.stratosphere.api.common.Program
+import eu.stratosphere.api.common.ProgramDescription
+
+import eu.stratosphere.api.scala._
+import eu.stratosphere.api.scala.operators._
+
+class TransitiveClosureNaive extends Program with ProgramDescription with Serializable {
+
+  def getScalaPlan(numSubTasks: Int, numIterations: Int, verticesInput: String, edgesInput: String, pathsOutput: String) = {
+    val vertices = DataSource(verticesInput, DelimitedInputFormat(parseVertex))
+    val edges = DataSource(edgesInput, DelimitedInputFormat(parseEdge))
+
+    def createClosure(paths: DataSet[Path]) = {
+
+      val allNewPaths = paths join edges where { p => p.to } isEqualTo { e => e.from } map joinPaths
+      val shortestPaths = allNewPaths union paths groupBy { p => (p.from, p.to) } reduceGroup { _ minBy { _.dist } }
+
+      shortestPaths
+    }
+
+    val transitiveClosure = vertices.iterate(numIterations, createClosure)
+
+    val output = transitiveClosure.write(pathsOutput, DelimitedOutputFormat(formatOutput))
+
+    val plan = new ScalaPlan(Seq(output), "Transitive Closure (Naive)")
+    plan.setDefaultParallelism(numSubTasks)
+    plan
+  }
+
+  def joinPaths = (p1: Path, p2: Path) => (p1, p2) match {
+      case (Path(from, _, dist1), Path(_, to, dist2)) => Path(from, to, dist1 + dist2)
+  }
+
+  case class Path(from: Int, to: Int, dist: Int)
+
+  def parseVertex = (line: String) => { val v = line.toInt; Path(v, v, 0) }
+
+  val EdgeInputPattern = """(\d+)\|(\d+)""".r
+
+  def parseEdge = (line: String) => line match {
+    case EdgeInputPattern(from, to) => Path(from.toInt, to.toInt, 1)
+  }
+
+  def formatOutput = (path: Path) => "%d|%d|%d".format(path.from, path.to, path.dist)
+
+  override def getDescription() = {
+    "Parameters: <numSubStasks> <numIterations> <vertices> <edges> <output>"
+  }
+
+  override def getPlan(args: String*) = {
+    getScalaPlan(args(0).toInt, args(1).toInt, args(2), args(3), args(4))
+  }
+}
+
+object RunTransitiveClosureNaive {
+  def main(pArgs: Array[String]) {
+    if (pArgs.size < 3) {
+      println("usage: [-numIterations <int:2>] -vertices <file> -edges <file> -output <file>")
+      return
+    }
+    val args = Args.parse(pArgs)
+    val plan = new TransitiveClosureNaive().getScalaPlan(2, args("numIterations", "10").toInt, args("vertices"), args("edges"), args("output"))
+    LocalExecutor.execute(plan)
+  }
+}

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/DataSet.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/DataSet.scala
@@ -21,7 +21,7 @@ import eu.stratosphere.api.scala.operators.JoinDataSet
 import eu.stratosphere.api.scala.operators.MapMacros
 import eu.stratosphere.api.scala.operators.KeyedDataSet
 import eu.stratosphere.api.scala.operators.ReduceMacros
-import eu.stratosphere.api.scala.operators.UnionMacros
+import eu.stratosphere.api.scala.operators.UnionOperator
 import eu.stratosphere.api.scala.operators.IterateMacros
 import eu.stratosphere.api.scala.operators.WorksetIterateMacros
 
@@ -43,7 +43,7 @@ class DataSet[T] (val contract: Operator with ScalaOperator[T]) {
   def reduceAll[Out](fun: Iterator[T] => Out) = macro ReduceMacros.globalReduceGroup[T, Out]
   def combinableReduceAll[Out](fun: Iterator[T] => Out) = macro ReduceMacros.combinableGlobalReduceGroup[T]
 
-  // def union(secondInput: DataSet[T]) = macro UnionMacros.impl[T]
+  def union(secondInput: DataSet[T]) = UnionOperator.impl[T](this, secondInput)
   
   def iterateWithDelta[DeltaItem](stepFunction: DataSet[T] => (DataSet[T], DataSet[DeltaItem])) = macro IterateMacros.iterateWithDelta[T, DeltaItem]
   def iterate(n: Int, stepFunction: DataSet[T] => DataSet[T])= macro IterateMacros.iterate[T]

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaGenerator.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/analysis/GlobalSchemaGenerator.scala
@@ -44,8 +44,9 @@ import eu.stratosphere.api.common.operators.Union
 class GlobalSchemaGenerator {
 
   def initGlobalSchema(sinks: Seq[Operator with ScalaOperator[_]]): Unit = {
-
-    sinks.foldLeft(0) { (freePos, contract) => globalizeContract(contract, Seq(), Map(), None, freePos) }
+    // don't do anything, we don't need global positions if we don't do reordering of operators
+    // FieldSet.toSerializerIndexArray returns local positions and ignores global positions
+    // sinks.foldLeft(0) { (freePos, contract) => globalizeContract(contract, Seq(), Map(), None, freePos) }
   }
 
   /**

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/CoGroupOperator.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/CoGroupOperator.scala
@@ -129,7 +129,7 @@ object CoGroupMacros {
       val builder = new NoKeyCoGroupBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
-      val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
+      val rightKeyPositions = rightKeySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.leftInputUDT.getKeySet(leftKeyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), leftKeyPositions(i), rightKeyPositions(i)) }
@@ -204,7 +204,7 @@ object CoGroupMacros {
       val builder = new NoKeyCoGroupBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
-      val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
+      val rightKeyPositions = rightKeySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.leftInputUDT.getKeySet(leftKeyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), leftKeyPositions(i), rightKeyPositions(i)) }

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/DataSinkMacros.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/DataSinkMacros.scala
@@ -313,7 +313,7 @@ object CsvOutputFormat {
           fields foreach { field: InputField =>
             val tpe = getUDF.inputUDT.fieldTypes(field.localPos)
             config.setClass(JavaCsvOutputFormat.FIELD_TYPE_PARAMETER_PREFIX + index, tpe)
-            config.setInteger(JavaCsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + index, field.globalPos.getValue)
+            config.setInteger(JavaCsvOutputFormat.RECORD_POSITION_PARAMETER_PREFIX + index, field.localPos)
             index = index + 1
           }
 

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/DataSourceMacros.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/DataSourceMacros.scala
@@ -350,7 +350,7 @@ object TextInputFormat {
 
         charSetName map { config.setString(JavaTextInputFormat.CHARSET_NAME, _) }
 
-        config.setInteger(JavaTextInputFormat.FIELD_POS, getUDF.outputFields(0).globalPos.getValue)
+        config.setInteger(JavaTextInputFormat.FIELD_POS, getUDF.outputFields(0).localPos)
       }
      // override val udt: UDT[String] = UDT.StringUDT
       val udf: UDF0[String] = new UDF0(UDT.StringUDT)

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/JoinOperator.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/JoinOperator.scala
@@ -124,7 +124,8 @@ object JoinMacros {
       val builder = new NoKeyMatchBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
-      val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
+      val rightKeyPositions = rightKeySelector.selectedFields.toIndexArray
+
       val keyTypes = generatedStub.leftInputUDT.getKeySet(leftKeyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), leftKeyPositions(i), rightKeyPositions(i)) }
@@ -198,7 +199,7 @@ object JoinMacros {
       val builder = new NoKeyMatchBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
-      val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
+      val rightKeyPositions = rightKeySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.leftInputUDT.getKeySet(leftKeyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), leftKeyPositions(i), rightKeyPositions(i)) }
@@ -260,7 +261,7 @@ object JoinMacros {
       val builder = new NoKeyMatchBuilder(generatedStub).input1(leftInput).input2(rightInput)
 
       val leftKeyPositions = leftKeySelector.selectedFields.toIndexArray
-      val rightKeyPositions = leftKeySelector.selectedFields.toIndexArray
+      val rightKeyPositions = rightKeySelector.selectedFields.toIndexArray
       val keyTypes = generatedStub.leftInputUDT.getKeySet(leftKeyPositions)
       // global indexes haven't been computed yet...
       0 until keyTypes.size foreach { i => builder.keyField(keyTypes(i), leftKeyPositions(i), rightKeyPositions(i)) }

--- a/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/UnionOperator.scala
+++ b/stratosphere-scala/src/main/scala/eu/stratosphere/api/scala/operators/UnionOperator.scala
@@ -14,54 +14,20 @@
 package eu.stratosphere.api.scala.operators
 
 import language.experimental.macros
-import scala.collection.JavaConversions._
-import scala.reflect.macros.Context
-import eu.stratosphere.api.scala.codegen.MacroContextHolder
-import eu.stratosphere.api.scala.ScalaOperator
-import eu.stratosphere.api.java.record.operators.MapOperator
-import eu.stratosphere.api.scala.analysis.UDT
-import eu.stratosphere.types.Record
-import eu.stratosphere.api.java.record.functions.MapFunction
-import eu.stratosphere.util.Collector
-import eu.stratosphere.api.common.operators.Operator
-import eu.stratosphere.api.scala.analysis.UDF1
-import eu.stratosphere.api.scala.analysis.UDTSerializer
-import eu.stratosphere.configuration.Configuration
-import eu.stratosphere.api.scala.ScalaOperator
-import eu.stratosphere.api.scala.analysis.UDF0
-import eu.stratosphere.api.scala.ScalaOperator
 import eu.stratosphere.api.scala.UnionScalaOperator
 import eu.stratosphere.api.scala.DataSet
 import eu.stratosphere.api.scala.analysis.UDF2
 import eu.stratosphere.api.common.operators.Union
 
-object UnionMacros {
+object UnionOperator {
 
-  def impl[In: c.WeakTypeTag](c: Context { type PrefixType = DataSet[In] })(secondInput: c.Expr[DataSet[In]]): c.Expr[DataSet[In]] = {
-    import c.universe._
+  def impl[In](firstInput: DataSet[In], secondInput: DataSet[In]): DataSet[In] = {
+    val union = new Union(firstInput.contract, secondInput.contract) with UnionScalaOperator[In] {
+      private val inputUDT = firstInput.contract.getUDF().outputUDT
+      private val udf: UDF2[In, In, In] = new UDF2(inputUDT, inputUDT, inputUDT)
 
-    val slave = MacroContextHolder.newMacroHelper(c)
-    
-//    val (paramName, udfBody) = slave.extractOneInputUdf(fun.tree)
-
-    val (udtIn, createUdtIn) = slave.mkUdtClass[In]
-
-    val contract = reify {
-
-      val firstInOp = c.prefix.splice.contract;
-      val secondInOp = secondInput.splice.contract
-      
-      val ret = new Union(firstInOp, secondInOp) with UnionScalaOperator[In] {
-        private val inputUDT = c.Expr[UDT[In]](createUdtIn).splice
-        private val udf: UDF2[In, In, In] = new UDF2(inputUDT, inputUDT, inputUDT)
-        
-        override def getUDF = udf;
-      }
-      new DataSet(ret)
+      override def getUDF = udf;
     }
-
-    val result = c.Expr[DataSet[In]](Block(List(udtIn), contract.tree))
-
-    return result
+    return new DataSet(union)
   }
 }

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleScalaPrograms/TransitiveClosureNaiveITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/exampleScalaPrograms/TransitiveClosureNaiveITCase.java
@@ -1,0 +1,49 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.test.exampleScalaPrograms;
+
+import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.test.util.TestBase2;
+
+import eu.stratosphere.examples.scala.graph.TransitiveClosureNaive;
+
+public class TransitiveClosureNaiveITCase extends TestBase2 {
+
+	protected String verticesPath = null;
+	protected String edgesPath = null;
+	protected String resultPath = null;
+
+	private static final String VERTICES = "0\n1\n2";
+	private static final String EDGES = "0|1\n1|2";
+	private static final String EXPECTED = "0|0|0\n0|1|1\n0|2|2\n1|1|0\n1|2|1\n2|2|0";
+
+	@Override
+	protected void preSubmit() throws Exception {
+		verticesPath = createTempFile("vertices.txt", VERTICES);
+		edgesPath = createTempFile("edges.txt", EDGES);
+		resultPath = getTempDirPath("transitiveClosure");
+	}
+
+	@Override
+	protected Plan getTestJob() {
+		TransitiveClosureNaive transitiveClosureNaive = new TransitiveClosureNaive();
+		// "2" is the number of iterations here
+		return transitiveClosureNaive.getScalaPlan(4, 2, verticesPath, edgesPath, resultPath);
+	}
+
+	@Override
+	protected void postSubmit() throws Exception {
+		compareResultsByLinesInMemory(EXPECTED, resultPath);
+	}
+}


### PR DESCRIPTION
Scala Join took left key selector for both sides of join. Re-enable
union. TransitiveClosureNaive uses union, this is tested in the ITCase.

Properly disable GlobalSchemaGenerator, the information it created has
not been used, only local field positions have been used.
