### PR TITLE
Added Int, Short and Long Serializer Tests

### DIFF
--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/DoubleSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/DoubleSerializerTest.java
@@ -1,0 +1,52 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.common.typeutils.base;
+
+import java.util.Random;
+
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+/**
+ * A test for the {@link DoubleSerializerTest}.
+ */
+public class DoubleSerializerTest extends SerializerTestBase<Double> {
+	
+	@Override
+	protected TypeSerializer<Double> createSerializer() {
+		return new DoubleSerializer();
+	}
+	
+	@Override
+	protected int getLength() {
+		return 8;
+	}
+	
+	@Override
+	protected Class<Double> getTypeClass() {
+		return Double.class;
+	}
+	
+	@Override
+	protected Double[] getTestData() {
+		Random rnd = new Random(874597969123412341L);
+		Double rndDouble = rnd.nextDouble() * Double.MAX_VALUE;
+		
+		return new Double[] {new Double(0), new Double(1), new Double(-1),
+							new Double(Double.MAX_VALUE), new Double(Double.MIN_VALUE),
+							new Double(rndDouble), new Double(-rndDouble),
+							new Double(Double.NaN),
+							new Double(Double.NEGATIVE_INFINITY), new Double(Double.POSITIVE_INFINITY)};
+	}
+}	

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/FloatSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/FloatSerializerTest.java
@@ -1,0 +1,52 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.common.typeutils.base;
+
+import java.util.Random;
+
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+/**
+ * A test for the {@link FloatSerializerTest}.
+ */
+public class FloatSerializerTest extends SerializerTestBase<Float> {
+	
+	@Override
+	protected TypeSerializer<Float> createSerializer() {
+		return new FloatSerializer();
+	}
+	
+	@Override
+	protected int getLength() {
+		return 4;
+	}
+	
+	@Override
+	protected Class<Float> getTypeClass() {
+		return Float.class;
+	}
+	
+	@Override
+	protected Float[] getTestData() {
+		Random rnd = new Random(874597969123412341L);
+		float rndFloat = rnd.nextFloat() * Float.MAX_VALUE;
+		
+		return new Float[] {new Float(0), new Float(1), new Float(-1),
+							new Float(Float.MAX_VALUE), new Float(Float.MIN_VALUE),
+							new Float(rndFloat), new Float(-rndFloat),
+							new Float(Float.NaN),
+							new Float(Float.NEGATIVE_INFINITY), new Float(Float.POSITIVE_INFINITY)};
+	}
+}	

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/IntSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/IntSerializerTest.java
@@ -1,0 +1,50 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.common.typeutils.base;
+
+import java.util.Random;
+
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+/**
+ * A test for the {@link IntSerializerTest}.
+ */
+public class IntSerializerTest extends SerializerTestBase<Integer> {
+	
+	@Override
+	protected TypeSerializer<Integer> createSerializer() {
+		return new IntSerializer();
+	}
+	
+	@Override
+	protected int getLength() {
+		return 4;
+	}
+	
+	@Override
+	protected Class<Integer> getTypeClass() {
+		return Integer.class;
+	}
+	
+	@Override
+	protected Integer[] getTestData() {
+		Random rnd = new Random(874597969123412341L);
+		int rndInt = rnd.nextInt();
+		
+		return new Integer[] {new Integer(0), new Integer(1), new Integer(-1),
+							new Integer(Integer.MAX_VALUE), new Integer(Integer.MIN_VALUE),
+							new Integer(rndInt), new Integer(-rndInt)};
+	}
+}	

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/LongSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/LongSerializerTest.java
@@ -1,0 +1,50 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.common.typeutils.base;
+
+import java.util.Random;
+
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+/**
+ * A test for the {@link LongSerializerTest}.
+ */
+public class LongSerializerTest extends SerializerTestBase<Long> {
+	
+	@Override
+	protected TypeSerializer<Long> createSerializer() {
+		return new LongSerializer();
+	}
+	
+	@Override
+	protected int getLength() {
+		return 8;
+	}
+	
+	@Override
+	protected Class<Long> getTypeClass() {
+		return Long.class;
+	}
+	
+	@Override
+	protected Long[] getTestData() {
+		Random rnd = new Random(874597969123412341L);
+		long rndLong = rnd.nextLong();
+		
+		return new Long[] {new Long(0L), new Long(1L), new Long(-1L),
+							new Long(Long.MAX_VALUE), new Long(Long.MIN_VALUE),
+							new Long(rndLong), new Long(-rndLong)};
+	}
+}	

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/ShortSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/ShortSerializerTest.java
@@ -1,0 +1,52 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.common.typeutils.base;
+
+import java.util.Random;
+
+import eu.stratosphere.api.common.typeutils.SerializerTestBase;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
+
+/**
+ * A test for the {@link StringSerializer}.
+ */
+public class ShortSerializerTest extends SerializerTestBase<Short> {
+	
+	@Override
+	protected TypeSerializer<Short> createSerializer() {
+		return new ShortSerializer();
+	}
+	
+	@Override
+	protected int getLength() {
+		return 2;
+	}
+	
+	@Override
+	protected Class<Short> getTypeClass() {
+		return Short.class;
+	}
+	
+	@Override
+	protected Short[] getTestData() {
+		Random rnd = new Random(874597969123412341L);
+		int rndInt = rnd.nextInt(32767);
+		
+		return new Short[] {new Short((short) 0), new Short((short) 1), new Short((short) -1),
+							new Short((short) rndInt), new Short((short) -rndInt),
+							new Short((short) -32767), new Short((short) 32768)};
+	}
+}
+	

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
@@ -14,11 +14,8 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.common.typeutils.base;
 
-import java.util.Random;
-
 import eu.stratosphere.api.common.typeutils.SerializerTestBase;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
-import eu.stratosphere.util.StringUtils;
 
 /**
  * A test for the {@link StringSerializer}.


### PR DESCRIPTION
#589

Will continue to add commits for other types in this pull request.

For number types, the test cases are {0, 1, -1, Type.MAX_VALUE, Type.MIN_VALUE, random_value, -random_value}. 

The Type.MIN_VALUE is negative.

random_value may be positive or negative depending on how it was generated. If random_value is negative , then -random_value is positive; and, vice versa. So both negative and positive cases are covered.

I left unused imports in the StringSerializerTest. Is it appropriate to use this pull request to fix it too?
