### PR TITLE
Divided Reduce and GroupReduce

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/costs/CostEstimator.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/costs/CostEstimator.java
@@ -158,13 +158,15 @@ public abstract class CostEstimator {
 		case FLAT_MAP:
 			
 		case ALL_GROUP:
-			// this operation does not do any actual grouping, since every element is in the same single group
+		case ALL_REDUCE:
+			// this operations does not do any actual grouping, since every element is in the same single group
 			
 		case CO_GROUP:
 		case SORTED_GROUP:
+		case SORTED_REDUCE:
 			// grouping or co-grouping over sorted streams for free
 			
-		case PARTIAL_GROUP:
+		case PARTIAL_GROUP_COMBINE:
 			// partial grouping is always local and main memory resident. we should add a relative cpu cost at some point
 		
 		case UNION:

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/ReduceNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/ReduceNode.java
@@ -19,8 +19,10 @@ import java.util.List;
 import eu.stratosphere.api.common.operators.base.ReduceOperatorBase;
 import eu.stratosphere.compiler.DataStatistics;
 import eu.stratosphere.compiler.operators.AllGroupWithPartialPreGroupProperties;
+import eu.stratosphere.compiler.operators.AllReduceWithPartialPreGroupProperties;
 import eu.stratosphere.compiler.operators.GroupWithPartialPreGroupProperties;
 import eu.stratosphere.compiler.operators.OperatorDescriptorSingle;
+import eu.stratosphere.compiler.operators.ReduceWithPartialPreGroupProperties;
 
 /**
  * The Optimizer representation of a <i>Reduce</i> operator.
@@ -59,8 +61,8 @@ public class ReduceNode extends SingleInputNode {
 	@Override
 	protected List<OperatorDescriptorSingle> getPossibleProperties() {
 		OperatorDescriptorSingle props = this.keys == null ?
-			new AllGroupWithPartialPreGroupProperties() :
-			new GroupWithPartialPreGroupProperties(this.keys);
+			new AllReduceWithPartialPreGroupProperties() :
+			new ReduceWithPartialPreGroupProperties(this.keys);
 		
 			return Collections.singletonList(props);
 	}

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/ReduceNode.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/dag/ReduceNode.java
@@ -18,9 +18,7 @@ import java.util.List;
 
 import eu.stratosphere.api.common.operators.base.ReduceOperatorBase;
 import eu.stratosphere.compiler.DataStatistics;
-import eu.stratosphere.compiler.operators.AllGroupWithPartialPreGroupProperties;
 import eu.stratosphere.compiler.operators.AllReduceWithPartialPreGroupProperties;
-import eu.stratosphere.compiler.operators.GroupWithPartialPreGroupProperties;
 import eu.stratosphere.compiler.operators.OperatorDescriptorSingle;
 import eu.stratosphere.compiler.operators.ReduceWithPartialPreGroupProperties;
 

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/operators/AllReduceWithPartialPreGroupProperties.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/operators/AllReduceWithPartialPreGroupProperties.java
@@ -15,9 +15,7 @@ package eu.stratosphere.compiler.operators;
 import java.util.Collections;
 import java.util.List;
 
-import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
-import eu.stratosphere.api.common.operators.util.FieldSet;
-import eu.stratosphere.compiler.dag.GroupReduceNode;
+import eu.stratosphere.compiler.costs.Costs;
 import eu.stratosphere.compiler.dag.SingleInputNode;
 import eu.stratosphere.compiler.dataproperties.GlobalProperties;
 import eu.stratosphere.compiler.dataproperties.LocalProperties;
@@ -26,41 +24,52 @@ import eu.stratosphere.compiler.dataproperties.RequestedGlobalProperties;
 import eu.stratosphere.compiler.dataproperties.RequestedLocalProperties;
 import eu.stratosphere.compiler.plan.Channel;
 import eu.stratosphere.compiler.plan.SingleInputPlanNode;
+import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
 
-public final class PartialGroupProperties extends OperatorDescriptorSingle {
-	
-	public PartialGroupProperties(FieldSet keys) {
-		super(keys);
-	}
-	
-	@Override
-	public DriverStrategy getStrategy() {
-		return DriverStrategy.PARTIAL_GROUP_COMBINE;
-	}
+public final class AllReduceWithPartialPreGroupProperties extends OperatorDescriptorSingle
+{
 
 	@Override
-	public SingleInputPlanNode instantiate(Channel in, SingleInputNode node) {
-		// create in input node for combine with same DOP as input node
-		GroupReduceNode combinerNode = new GroupReduceNode((GroupReduceOperatorBase<?>) node.getPactContract());
-		combinerNode.setDegreeOfParallelism(in.getSource().getDegreeOfParallelism());
-		combinerNode.setSubtasksPerInstance(in.getSource().getSubtasksPerInstance());
-		
-		return new SingleInputPlanNode(combinerNode, "Combine("+node.getPactContract().getName()+")", in, DriverStrategy.PARTIAL_GROUP_COMBINE, this.keyList);
+	public DriverStrategy getStrategy() {
+		return DriverStrategy.ALL_REDUCE;
 	}
+
+	/* (non-Javadoc)
+	 * @see eu.stratosphere.pact.compiler.dataproperties.DriverPropertiesHandlerSingle#instantiate(eu.stratosphere.pact.compiler.plan.candidate.Channel, eu.stratosphere.pact.compiler.plan.SingleInputNode, eu.stratosphere.pact.common.util.FieldList)
+	 */
+	@Override
+	public SingleInputPlanNode instantiate(Channel in, SingleInputNode node) {
+		if (in.getShipStrategy() == ShipStrategyType.FORWARD) {
+			// locally connected, directly instantiate
+			return new SingleInputPlanNode(node, "Reduce("+node.getPactContract().getName()+")", in, DriverStrategy.ALL_REDUCE);
+		} else {
+			// non forward case.plug in a combiner
+			Channel toCombiner = new Channel(in.getSource());
+			toCombiner.setShipStrategy(ShipStrategyType.FORWARD);
+			SingleInputPlanNode combiner = new SingleInputPlanNode(node, "Combine("+node.getPactContract().getName()+")", toCombiner, DriverStrategy.ALL_REDUCE);
+			combiner.setCosts(new Costs(0, 0));
+			
+			Channel toReducer = new Channel(combiner);
+			toReducer.setShipStrategy(in.getShipStrategy(), in.getShipStrategyKeys(), in.getShipStrategySortOrder());
+			toReducer.setLocalStrategy(in.getLocalStrategy(), in.getLocalStrategyKeys(), in.getLocalStrategySortOrder());
+			return new SingleInputPlanNode(node, "Reduce("+node.getPactContract().getName()+")", toReducer, DriverStrategy.ALL_REDUCE);
+		}
+	}
+
 
 	@Override
 	protected List<RequestedGlobalProperties> createPossibleGlobalProperties() {
 		return Collections.singletonList(new RequestedGlobalProperties());
 	}
 
+
 	@Override
 	protected List<RequestedLocalProperties> createPossibleLocalProperties() {
-		RequestedLocalProperties props = new RequestedLocalProperties();
-		props.setGroupedFields(this.keys);
-		return Collections.singletonList(props);
+		return Collections.singletonList(new RequestedLocalProperties());
 	}
 	
+
 	@Override
 	public GlobalProperties computeGlobalProperties(GlobalProperties gProps) {
 		if (gProps.getUniqueFieldCombination() != null && gProps.getUniqueFieldCombination().size() > 0 &&
@@ -72,6 +81,7 @@ public final class PartialGroupProperties extends OperatorDescriptorSingle {
 		return gProps;
 	}
 	
+
 	@Override
 	public LocalProperties computeLocalProperties(LocalProperties lProps) {
 		lProps.clearUniqueFieldSets();

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/operators/GroupWithPartialPreGroupProperties.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/operators/GroupWithPartialPreGroupProperties.java
@@ -87,7 +87,7 @@ public final class GroupWithPartialPreGroupProperties extends OperatorDescriptor
 			combinerNode.setDegreeOfParallelism(in.getSource().getDegreeOfParallelism());
 			combinerNode.setSubtasksPerInstance(in.getSource().getSubtasksPerInstance());
 			
-			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine("+node.getPactContract().getName()+")", toCombiner, DriverStrategy.PARTIAL_GROUP, this.keyList);
+			SingleInputPlanNode combiner = new SingleInputPlanNode(combinerNode, "Combine("+node.getPactContract().getName()+")", toCombiner, DriverStrategy.PARTIAL_GROUP_COMBINE, this.keyList);
 			combiner.setCosts(new Costs(0, 0));
 			combiner.initProperties(toCombiner.getGlobalProperties(), toCombiner.getLocalProperties());
 			

--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plandump/PlanJSONDumpGenerator.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plandump/PlanJSONDumpGenerator.java
@@ -232,7 +232,7 @@ public class PlanJSONDumpGenerator {
 		
 		String name = n.getName();
 		if (name.equals("Reduce") && (node instanceof SingleInputPlanNode) && 
-				((SingleInputPlanNode) node).getDriverStrategy() == DriverStrategy.PARTIAL_GROUP) {
+				((SingleInputPlanNode) node).getDriverStrategy() == DriverStrategy.PARTIAL_GROUP_COMBINE) {
 			name = "Combine";
 		}
 		
@@ -404,7 +404,7 @@ public class PlanJSONDumpGenerator {
 			case FLAT_MAP:
 				locString = "Map";
 				break;
-			case PARTIAL_GROUP:
+			case PARTIAL_GROUP_COMBINE:
 				locString = "Ordered Partial Grouping";
 				break;
 			case SORTED_GROUP:

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericCombine.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericCombine.java
@@ -1,7 +1,6 @@
 /***********************************************************************************************************************
  *
  * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
- *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
@@ -10,39 +9,19 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
  **********************************************************************************************************************/
-package eu.stratosphere.api.java.operators.translation;
 
-import eu.stratosphere.api.common.functions.GenericReduce;
-import eu.stratosphere.api.common.operators.base.ReduceOperatorBase;
-import eu.stratosphere.api.java.functions.ReduceFunction;
-import eu.stratosphere.api.java.typeutils.TypeInformation;
+package eu.stratosphere.api.common.functions;
+
+import java.util.Iterator;
+
+import eu.stratosphere.util.Collector;
 
 /**
- *
+ * GenericInterface used for the two functions which currently support combine.
+ * (Reduce and Group Reduce) 
  */
-public class PlanReduceOperator<T> extends ReduceOperatorBase<GenericReduce<T>>
-	implements UnaryJavaPlanNode<T, T>
-{
+public interface GenericCombine<T> extends Function {
 
-	private final TypeInformation<T> type;
-	
-	
-	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type) {
-		super(udf, logicalGroupingFields, name);
-		this.type = type;
-	}
-	
-	
-	@Override
-	public TypeInformation<T> getReturnType() {
-		return this.type;
-	}
-
-	@Override
-	public TypeInformation<T> getInputType() {
-		return this.type;
-	}
-	
+	void combine(Iterator<T> records, Collector<T> out) throws Exception;
 }

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericGroupReduce.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericGroupReduce.java
@@ -19,7 +19,7 @@ import eu.stratosphere.util.Collector;
 
 
 
-public interface GenericGroupReduce<T, O> extends Function {
+public interface GenericGroupReduce<T, O> extends GenericCombine<T> {
 	
 	void reduce(Iterator<T> records, Collector<O> out) throws Exception;
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericReduce.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/functions/GenericReduce.java
@@ -13,8 +13,14 @@
 
 package eu.stratosphere.api.common.functions;
 
+import java.util.Iterator;
 
-public interface GenericReduce<T> extends Function {
+import eu.stratosphere.util.Collector;
+
+
+public interface GenericReduce<T> extends GenericCombine<T> {
 	
 	T reduce(T value1, T value2) throws Exception;
+	
+	void combine(Iterator<T> iter, Collector<T> collector) throws Exception;
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/ReduceFunction.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/ReduceFunction.java
@@ -18,10 +18,11 @@ import java.util.Iterator;
 
 import eu.stratosphere.api.common.functions.AbstractFunction;
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.functions.GenericReduce;
 import eu.stratosphere.util.Collector;
 
 
-public abstract class ReduceFunction<T> extends AbstractFunction implements GenericGroupReduce<T, T> {
+public abstract class ReduceFunction<T> extends AbstractFunction implements GenericReduce<T> {
 	
 	private static final long serialVersionUID = 1L;
 
@@ -41,9 +42,8 @@ public abstract class ReduceFunction<T> extends AbstractFunction implements Gene
 	*/
 	public abstract T reduce(T value1, T value2) throws Exception;
 	
-	
 	@Override
-	public final void reduce(Iterator<T> values, Collector<T> out) throws Exception {
+	public final void combine(Iterator<T> values, Collector<T> out) throws Exception {
 		T curr = values.next();
 		
 		while (values.hasNext()) {
@@ -51,10 +51,5 @@ public abstract class ReduceFunction<T> extends AbstractFunction implements Gene
 		}
 		
 		out.collect(curr);
-	}
-	
-	@Override
-	public final void combine(Iterator<T> values, Collector<T> out) throws Exception {
-		reduce(values, out);
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
@@ -89,8 +89,8 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 			
 			// Show an Exception if the user tries two sort on a ReduceFunction, which is not supported
 			if(grouper.getGroupSortKeyPositions() != null) {
-				throw new UnsupportedOperationException("Sort is supported for ReduceFuntion, please use GroupReduceFuntion or"
-						+ "delete the sort");
+				throw new UnsupportedOperationException("Sort is unsupported for ReduceFunction, please use GroupReduceFunction or"
+						+ " delete the sort");
 			}
 			
 			return new UnaryNodeTranslation(reduceOp);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceOperator.java
@@ -87,6 +87,12 @@ public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOpe
 			int[] logicalKeyPositions = grouper.getKeys().computeLogicalKeyPositions();
 			PlanReduceOperator<IN> reduceOp = new PlanReduceOperator<IN>(function, logicalKeyPositions, name, getInputType());
 			
+			// Show an Exception if the user tries two sort on a ReduceFunction, which is not supported
+			if(grouper.getGroupSortKeyPositions() != null) {
+				throw new UnsupportedOperationException("Sort is supported for ReduceFuntion, please use GroupReduceFuntion or"
+						+ "delete the sort");
+			}
+			
 			return new UnaryNodeTranslation(reduceOp);
 		}
 		else {

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/sort/CombiningUnilateralSortMerger.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/sort/CombiningUnilateralSortMerger.java
@@ -24,7 +24,7 @@ import java.util.Queue;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.functions.GenericCombine;
 import eu.stratosphere.api.common.typeutils.TypeComparator;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.configuration.Configuration;
@@ -46,12 +46,14 @@ import eu.stratosphere.util.MutableObjectIterator;
 
 /**
  * The {@link CombiningUnilateralSortMerger} is part of a merge-sort implementation.
- * The {@link ReduceTask} requires a grouping of the incoming key-value pairs by key. Typically grouping is achieved by
+ * The {@link ReduceTask} requires a grouping of the incoming key-value pairs by key. 
+ * For a {@link GroupReduceFunction}  grouping is achieved by
  * determining a total order for the given set of pairs (sorting). Thereafter an iteration over the ordered set is
  * performed and each time the key changes the consecutive objects are united into a new group. Reducers have a combining feature
  * can reduce the data before it is written to disk. In order to implement a combining Reducer, the 
  * {@link eu.stratosphere.pact.ReduceFunction.stub.ReduceStub#combine(Key, Iterator, Collector)} method must be implemented and the ReduceFunction 
  * must be annotated with the {@link eu.stratosphere.api.java.record.operators.ReduceOperator.Combinable} annotation.
+ * For a {@link ReduceFuntion} the combine method can automatically call the reduce function without a combine annotation.
  * Conceptually, a merge sort with combining works as follows:
  * (1) Divide the unsorted list into n sublists of about 1/n the size. (2) Sort each sublist recursively by re-applying
  * merge sort. (3) Combine all tuples with the same key within a sublist (4) Merge the two sublists back into one sorted
@@ -72,7 +74,7 @@ public class CombiningUnilateralSortMerger<E> extends UnilateralSortMerger<E> {
 	 */
 	private static final Log LOG = LogFactory.getLog(CombiningUnilateralSortMerger.class);
 
-	private final GenericGroupReduce<E, ?> combineStub;	// the user code stub that does the combining
+	private final GenericCombine<E> combineStub;	// the user code stub that does the combining
 	
 	private Configuration udfConfig;
 	
@@ -103,7 +105,7 @@ public class CombiningUnilateralSortMerger<E> extends UnilateralSortMerger<E> {
 	 * @throws MemoryAllocationException Thrown, if not enough memory can be obtained from the memory manager to
 	 *                                   perform the sort.
 	 */
-	public CombiningUnilateralSortMerger(GenericGroupReduce<E, ?> combineStub, MemoryManager memoryManager, IOManager ioManager,
+	public CombiningUnilateralSortMerger(GenericCombine<E> combineStub, MemoryManager memoryManager, IOManager ioManager,
 			MutableObjectIterator<E> input, AbstractInvokable parentTask, 
 			TypeSerializer<E> serializer, TypeComparator<E> comparator,
 			long totalMemory, int maxNumFileHandles, float startSpillingFraction)
@@ -136,7 +138,7 @@ public class CombiningUnilateralSortMerger<E> extends UnilateralSortMerger<E> {
 	 * @throws MemoryAllocationException Thrown, if not enough memory can be obtained from the memory manager to
 	 *                                   perform the sort.
 	 */
-	public CombiningUnilateralSortMerger(GenericGroupReduce<E, ?> combineStub, MemoryManager memoryManager, IOManager ioManager,
+	public CombiningUnilateralSortMerger(GenericCombine<E> combineStub, MemoryManager memoryManager, IOManager ioManager,
 			MutableObjectIterator<E> input, AbstractInvokable parentTask, 
 			TypeSerializer<E> serializer, TypeComparator<E> comparator,
 			long totalMemory, int numSortBuffers, int maxNumFileHandles, 
@@ -257,7 +259,7 @@ public class CombiningUnilateralSortMerger<E> extends UnilateralSortMerger<E> {
 			
 			// ------------------- Spilling Phase ------------------------
 			
-			final GenericGroupReduce<E, ?> combineStub = CombiningUnilateralSortMerger.this.combineStub;
+			final GenericCombine<E> combineStub = CombiningUnilateralSortMerger.this.combineStub;
 			
 			// now that we are actually spilling, take the combiner, and open it
 			try {
@@ -461,7 +463,7 @@ public class CombiningUnilateralSortMerger<E> extends UnilateralSortMerger<E> {
 																			this.memManager.getPageSize());
 			
 			final WriterCollector<E> collector = new WriterCollector<E>(output, this.serializer);
-			final GenericGroupReduce<E, ?> combineStub = CombiningUnilateralSortMerger.this.combineStub;
+			final GenericCombine<E> combineStub = CombiningUnilateralSortMerger.this.combineStub;
 
 			// combine and write to disk
 			try {

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/AllGroupReduceDriver.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/AllGroupReduceDriver.java
@@ -7,7 +7,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WTHOUT WARRANTIES OR CONDTIONS OF ANY KIND, either express or implied. See the License for the
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  **********************************************************************************************************************/
 
@@ -17,7 +17,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
-import eu.stratosphere.api.common.functions.GenericReduce;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.pact.runtime.task.util.TaskConfig;
 import eu.stratosphere.pact.runtime.util.MutableToRegularIteratorWrapper;
@@ -25,33 +24,30 @@ import eu.stratosphere.util.Collector;
 import eu.stratosphere.util.MutableObjectIterator;
 
 /**
- * Reduce task which is executed by a Nephele task manager. The task has a
- * single input and one or multiple outputs. It is provided with a ReduceFunction
+ * GroupReduce task which is executed by a Nephele task manager. The task has a
+ * single input and one or multiple outputs. It is provided with a GroupReduceFunction
  * implementation.
  * <p>
- * The ReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
- * key. The iterator is handed to the <code>reduce()</code> method of the ReduceFunction.
+ * The GroupReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
+ * key. The iterator is handed to the <code>reduce()</code> method of the GroupReduceFunction.
  * 
  * @see GenericGroupReduce
  */
-public class AllReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
+public class AllGroupReduceDriver<IT, OT> implements PactDriver<GenericGroupReduce<IT, OT>, OT> {
 	
-	private static final Log LOG = LogFactory.getLog(AllReduceDriver.class);
+	private static final Log LOG = LogFactory.getLog(AllGroupReduceDriver.class);
 
-	private PactTaskContext<GenericReduce<T>, T> taskContext;
+	private PactTaskContext<GenericGroupReduce<IT, OT>, OT> taskContext;
 	
-	private MutableObjectIterator<T> input;
+	private MutableObjectIterator<IT> input;
 
-	private TypeSerializer<T> serializer;
-	
-	private boolean running;
+	private TypeSerializer<IT> serializer;
 
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void setup(PactTaskContext<GenericReduce<T>, T> context) {
+	public void setup(PactTaskContext<GenericGroupReduce<IT, OT>, OT> context) {
 		this.taskContext = context;
-		this.running = true;
 	}
 	
 	@Override
@@ -60,9 +56,9 @@ public class AllReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
 	}
 
 	@Override
-	public Class<GenericReduce<T>> getStubType() {
+	public Class<GenericGroupReduce<IT, OT>> getStubType() {
 		@SuppressWarnings("unchecked")
-		final Class<GenericReduce<T>> clazz = (Class<GenericReduce<T>>) (Class<?>) GenericReduce.class;
+		final Class<GenericGroupReduce<IT, OT>> clazz = (Class<GenericGroupReduce<IT, OT>>) (Class<?>) GenericGroupReduce.class;
 		return clazz;
 	}
 
@@ -76,8 +72,8 @@ public class AllReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
 	@Override
 	public void prepare() throws Exception {
 		final TaskConfig config = this.taskContext.getTaskConfig();
-		if (config.getDriverStrategy() != DriverStrategy.ALL_REDUCE) {
-			throw new Exception("Unrecognized driver strategy for AllReduce driver: " + config.getDriverStrategy().name());
+		if (config.getDriverStrategy() != DriverStrategy.ALL_GROUP) {
+			throw new Exception("Unrecognized driver strategy for AllGroupReduce driver: " + config.getDriverStrategy().name());
 		}
 		this.serializer = this.taskContext.getInputSerializer(0);
 		this.input = this.taskContext.getInput(0);
@@ -86,27 +82,22 @@ public class AllReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
 	@Override
 	public void run() throws Exception {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(this.taskContext.formatLogString("AllReduce preprocessing done. Running Reducer code."));
+			LOG.debug(this.taskContext.formatLogString("AllGroupReduce preprocessing done. Running Reducer code."));
 		}
 
-		final GenericReduce<T> stub = this.taskContext.getStub();
-		final Collector<T> output = this.taskContext.getOutputCollector();
-		final MutableToRegularIteratorWrapper<T> inIter = new MutableToRegularIteratorWrapper<T>(this.input, this.serializer);
+		final GenericGroupReduce<IT, OT> stub = this.taskContext.getStub();
+		final Collector<OT> output = this.taskContext.getOutputCollector();
+		final MutableToRegularIteratorWrapper<IT> inIter = new MutableToRegularIteratorWrapper<IT>(this.input, this.serializer);
 
-		// Reduce everything together
-		T curr = inIter.next();
-		while(running & inIter.hasNext()){
-			curr = stub.reduce(curr, inIter.next());
+		// single UDF call with the single group
+		if (inIter.hasNext()) {
+			stub.reduce(inIter, output);
 		}
-			
-		output.collect(curr);
 	}
 
 	@Override
 	public void cleanup() {}
 
 	@Override
-	public void cancel() {
-		this.running = false;
-	}
+	public void cancel() {}
 }

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/AllReduceDriver.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/AllReduceDriver.java
@@ -7,7 +7,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WTHOUT WARRANTIES OR CONDTIONS OF ANY KIND, either express or implied. See the License for the
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDTIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  **********************************************************************************************************************/
 

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/DriverStrategy.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/DriverStrategy.java
@@ -18,7 +18,6 @@ import eu.stratosphere.pact.runtime.task.chaining.ChainedCollectorMapDriver;
 import eu.stratosphere.pact.runtime.task.chaining.ChainedFlatMapDriver;
 import eu.stratosphere.pact.runtime.task.chaining.ChainedMapDriver;
 import eu.stratosphere.pact.runtime.task.chaining.SynchronousChainedCombineDriver;
-
 import static eu.stratosphere.pact.runtime.task.DamBehavior.*;
 
 /**
@@ -37,12 +36,16 @@ public enum DriverStrategy {
 	MAP(MapDriver.class, ChainedMapDriver.class, PIPELINED, false),
 	// the flat mapper
 	FLAT_MAP(FlatMapDriver.class, ChainedFlatMapDriver.class, PIPELINED, false),
-	// grouping the inputs
-	SORTED_GROUP(ReduceDriver.class, null, PIPELINED, true),
+	// grouping the inputs and apply the GroupReduce function
+	SORTED_GROUP(GroupReduceDriver.class, null, PIPELINED, true),
+	// grouping the inputs and apply the Reduce Function
+	SORTED_REDUCE(ReduceDriver.class, null, PIPELINED, true),
 	// partially grouping inputs (best effort resulting possibly in duplicates --> combiner)
-	PARTIAL_GROUP(CombineDriver.class, SynchronousChainedCombineDriver.class, MATERIALIZING, true),
-	// group everything together into one group
-	ALL_GROUP(AllReduceDriver.class, null, PIPELINED, false),
+	PARTIAL_GROUP_COMBINE(CombineDriver.class, SynchronousChainedCombineDriver.class, MATERIALIZING, true),
+	// group everything together into one group and apply the GroupReduce function
+	ALL_GROUP(AllGroupReduceDriver.class, null, PIPELINED, false),
+	// group everything together into one group and apply the Reduce function
+	ALL_REDUCE(AllReduceDriver.class, null, PIPELINED, false),
 	// already grouped input, within a key values are crossed in a nested loop fashion
 	GROUP_SELF_NESTEDLOOP(null, null, PIPELINED, true),	// Note: Self-Match currently inactive
 	// both inputs are merged, but materialized to the side for block-nested-loop-join among values with equal key

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/GroupReduceDriver.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/GroupReduceDriver.java
@@ -7,7 +7,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WTHOUT WARRANTIES OR CONDTIONS OF ANY KIND, either express or implied. See the License for the
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  **********************************************************************************************************************/
 
@@ -17,43 +17,41 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
-import eu.stratosphere.api.common.functions.GenericReduce;
 import eu.stratosphere.api.common.typeutils.TypeComparator;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.pact.runtime.task.util.TaskConfig;
 import eu.stratosphere.pact.runtime.util.KeyGroupedIterator;
-import eu.stratosphere.pact.runtime.util.KeyGroupedIterator.ValuesIterator;
 import eu.stratosphere.util.Collector;
 import eu.stratosphere.util.MutableObjectIterator;
 
 /**
- * Reduce task which is executed by a Nephele task manager. The task has a
- * single input and one or multiple outputs. It is provided with a ReduceFunction
+ * GroupReduce task which is executed by a Nephele task manager. The task has a
+ * single input and one or multiple outputs. It is provided with a GroupReduceFunction
  * implementation.
  * <p>
- * The ReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
- * key. The iterator is handed to the <code>reduce()</code> method of the ReduceFunction.
+ * The GroupReduceTask creates a iterator over all records from its input. The iterator returns all records grouped by their
+ * key. The iterator is handed to the <code>reduce()</code> method of the GroupReduceFunction.
  * 
  * @see GenericGroupReduce
  */
-public class ReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
+public class GroupReduceDriver<IT, OT> implements PactDriver<GenericGroupReduce<IT, OT>, OT> {
 	
-	private static final Log LOG = LogFactory.getLog(ReduceDriver.class);
+	private static final Log LOG = LogFactory.getLog(GroupReduceDriver.class);
 
-	private PactTaskContext<GenericReduce<T>, T> taskContext;
+	private PactTaskContext<GenericGroupReduce<IT, OT>, OT> taskContext;
 	
-	private MutableObjectIterator<T> input;
+	private MutableObjectIterator<IT> input;
 
-	private TypeSerializer<T> serializer;
+	private TypeSerializer<IT> serializer;
 
-	private TypeComparator<T> comparator;
+	private TypeComparator<IT> comparator;
 	
 	private volatile boolean running;
 
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void setup(PactTaskContext<GenericReduce<T>, T> context) {
+	public void setup(PactTaskContext<GenericGroupReduce<IT, OT>, OT> context) {
 		this.taskContext = context;
 		this.running = true;
 	}
@@ -64,9 +62,9 @@ public class ReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
 	}
 
 	@Override
-	public Class<GenericReduce<T>> getStubType() {
+	public Class<GenericGroupReduce<IT, OT>> getStubType() {
 		@SuppressWarnings("unchecked")
-		final Class<GenericReduce<T>> clazz = (Class<GenericReduce<T>>) (Class<?>) GenericReduce.class;
+		final Class<GenericGroupReduce<IT, OT>> clazz = (Class<GenericGroupReduce<IT, OT>>) (Class<?>) GenericGroupReduce.class;
 		return clazz;
 	}
 
@@ -80,8 +78,8 @@ public class ReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
 	@Override
 	public void prepare() throws Exception {
 		TaskConfig config = this.taskContext.getTaskConfig();
-		if (config.getDriverStrategy() != DriverStrategy.SORTED_REDUCE) {
-			throw new Exception("Unrecognized driver strategy for Reduce driver: " + config.getDriverStrategy().name());
+		if (config.getDriverStrategy() != DriverStrategy.SORTED_GROUP) {
+			throw new Exception("Unrecognized driver strategy for GroupReduce driver: " + config.getDriverStrategy().name());
 		}
 		this.serializer = this.taskContext.getInputSerializer(0);
 		this.comparator = this.taskContext.getInputComparator(0);
@@ -89,29 +87,21 @@ public class ReduceDriver<T> implements PactDriver<GenericReduce<T>, T> {
 	}
 
 	@Override
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public void run() throws Exception {
 		if (LOG.isDebugEnabled()) {
-			LOG.debug(this.taskContext.formatLogString("Reducer preprocessing done. Running Reducer code."));
+			LOG.debug(this.taskContext.formatLogString("GroupReducer preprocessing done. Running GroupReducer code."));
 		}
 
-		final KeyGroupedIterator<T> iter = new KeyGroupedIterator<T>(this.input, this.serializer, this.comparator);
+		final KeyGroupedIterator<IT> iter = new KeyGroupedIterator<IT>(this.input, this.serializer, this.comparator);
 
 		// cache references on the stack
-		final GenericReduce<T> stub = this.taskContext.getStub();
-		final Collector<T> output = this.taskContext.getOutputCollector();
+		final GenericGroupReduce<IT, OT> stub = this.taskContext.getStub();
+		final Collector<OT> output = this.taskContext.getOutputCollector();
 
-		// run stub implementation, iterate over different keys
+		// run stub implementation
 		while (this.running && iter.nextKey()) {
-			ValuesIterator vIter = iter.getValues();
-			// Reduce everything together for this key
-			T curr = (T) vIter.next();
-			while(running & vIter.hasNext()){
-				curr = stub.reduce(curr, (T)vIter.next());
-			}
-			output.collect(curr);
+			stub.reduce(iter.getValues(), output);
 		}
-		
 	}
 
 	@Override

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/ReduceDriver.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/ReduceDriver.java
@@ -7,7 +7,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WTHOUT WARRANTIES OR CONDTIONS OF ANY KIND, either express or implied. See the License for the
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDTIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  **********************************************************************************************************************/
 

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/RegularPactTask.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/RegularPactTask.java
@@ -25,7 +25,7 @@ import eu.stratosphere.api.common.accumulators.Accumulator;
 import eu.stratosphere.api.common.accumulators.AccumulatorHelper;
 import eu.stratosphere.api.common.distributions.DataDistribution;
 import eu.stratosphere.api.common.functions.Function;
-import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.functions.GenericCombine;
 import eu.stratosphere.api.common.typeutils.TypeComparator;
 import eu.stratosphere.api.common.typeutils.TypeComparatorFactory;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
@@ -674,6 +674,7 @@ public class RegularPactTask<S extends Function, OT> extends AbstractTask implem
 			S stub = config.<S>getStubWrapper(this.userCodeClassLoader).getUserCodeObject(stubSuperClass, this.userCodeClassLoader);
 			// check if the class is a subclass, if the check is required
 			if (stubSuperClass != null && !stubSuperClass.isAssignableFrom(stub.getClass())) {
+				Thread.dumpStack();
 				throw new RuntimeException("The class '" + stub.getClass().getName() + "' is not a subclass of '" + 
 						stubSuperClass.getName() + "' as is required.");
 			}
@@ -954,16 +955,16 @@ public class RegularPactTask<S extends Function, OT> extends AbstractTask implem
 				// this still breaks a bit of the abstraction!
 				// we should have nested configurations for the local strategies to solve that
 				if (inputNum != 0) {
-					throw new IllegalStateException("Performing combining sort outside a reduce task!");
+					throw new IllegalStateException("Performing combining sort outside a (group)reduce task!");
 				}
 				
 				// instantiate ourselves a combiner. we should not use the stub, because the sort and the
-				// subsequent reduce would otherwise share it multi-threaded
+				// subsequent (group)reduce would otherwise share it multi-threaded
 				final S localStub;
 				try {
 					final Class<S> userCodeFunctionType = this.driver.getStubType();
 					// if the class is null, the driver has no user code 
-					if (userCodeFunctionType != null && GenericGroupReduce.class.isAssignableFrom(userCodeFunctionType)) {
+					if (userCodeFunctionType != null && GenericCombine.class.isAssignableFrom(userCodeFunctionType)) {
 						localStub = initStub(userCodeFunctionType);
 					} else {
 						throw new IllegalStateException("Performing combining sort outside a reduce task!");
@@ -975,7 +976,7 @@ public class RegularPactTask<S extends Function, OT> extends AbstractTask implem
 
 				@SuppressWarnings({ "rawtypes", "unchecked" })
 				CombiningUnilateralSortMerger<?> cSorter = new CombiningUnilateralSortMerger(
-					(GenericGroupReduce) localStub, getMemoryManager(), getIOManager(), this.inputIterators[inputNum], 
+					(GenericCombine) localStub, getMemoryManager(), getIOManager(), this.inputIterators[inputNum], 
 					this, this.inputSerializers[inputNum], getLocalStrategyComparator(inputNum),
 					this.config.getMemoryInput(inputNum), this.config.getFilehandlesInput(inputNum),
 					this.config.getSpillingThresholdInput(inputNum));

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/ChainedCombineDriver.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/ChainedCombineDriver.java
@@ -82,7 +82,7 @@ public class ChainedCombineDriver<T> extends ChainedDriver<T, T> {
 			// The Input is combined using a sort-merge strategy. Before spilling on disk, the data volume is reduced using
 			// the combine() method of the ReduceFunction.
 			// An iterator on the sorted, grouped, and combined pairs is created and returned
-			case PARTIAL_GROUP:
+			case PARTIAL_GROUP_COMBINE:
 				this.sorter = new AsynchronousPartialSorterCollector<T>(memoryManager, this.parent,
 						serializer, comparator.duplicate(), availableMemory);
 				this.inputCollector = this.sorter.getInputCollector();

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/SynchronousChainedCombineDriver.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/chaining/SynchronousChainedCombineDriver.java
@@ -14,7 +14,7 @@
 package eu.stratosphere.pact.runtime.task.chaining;
 
 import eu.stratosphere.api.common.functions.Function;
-import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.functions.GenericCombine;
 import eu.stratosphere.api.common.typeutils.TypeComparator;
 import eu.stratosphere.api.common.typeutils.TypeComparatorFactory;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
@@ -45,7 +45,7 @@ public class SynchronousChainedCombineDriver<T> extends ChainedDriver<T, T> {
 
 	private InMemorySorter<T> sorter;
 
-	private GenericGroupReduce<T, ?> combiner;
+	private GenericCombine<T> combiner;
 
 	private TypeSerializer<T> serializer;
 
@@ -66,8 +66,8 @@ public class SynchronousChainedCombineDriver<T> extends ChainedDriver<T, T> {
 		this.parent = parent;
 
 		@SuppressWarnings("unchecked")
-		final GenericGroupReduce<T, ?> combiner =
-			RegularPactTask.instantiateUserCode(this.config, userCodeClassLoader, GenericGroupReduce.class);
+		final GenericCombine<T> combiner =
+			RegularPactTask.instantiateUserCode(this.config, userCodeClassLoader, GenericCombine.class);
 		this.combiner = combiner;
 		combiner.setRuntimeContext(getUdfRuntimeContext());
 	}
@@ -176,7 +176,7 @@ public class SynchronousChainedCombineDriver<T> extends ChainedDriver<T, T> {
 				this.comparator);
 
 			// cache references on the stack
-			final GenericGroupReduce<T, ?> stub = this.combiner;
+			final GenericCombine<T> stub = this.combiner;
 			final Collector<T> output = this.outputCollector;
 
 			// run stub implementation

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskExternalITCase.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskExternalITCase.java
@@ -55,7 +55,7 @@ public class CombineTaskExternalITCase extends DriverTestBase<GenericGroupReduce
 		addInputComparator(this.comparator);
 		setOutput(this.outList);
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		
@@ -108,7 +108,7 @@ public class CombineTaskExternalITCase extends DriverTestBase<GenericGroupReduce
 		addInputComparator(this.comparator);
 		setOutput(this.outList);
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskTest.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/CombineTaskTest.java
@@ -59,7 +59,7 @@ public class CombineTaskTest extends DriverTestBase<GenericGroupReduce<Record, ?
 		addInputComparator(this.comparator);
 		setOutput(this.outList);
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		
@@ -95,7 +95,7 @@ public class CombineTaskTest extends DriverTestBase<GenericGroupReduce<Record, ?
 		addInputComparator(this.comparator);
 		setOutput(new DiscardingOutputCollector());
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		
@@ -119,7 +119,7 @@ public class CombineTaskTest extends DriverTestBase<GenericGroupReduce<Record, ?
 		addInputComparator(this.comparator);
 		setOutput(new DiscardingOutputCollector());
 		
-		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+		getTaskConfig().setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 		getTaskConfig().setMemoryDriver(COMBINE_MEM);
 		getTaskConfig().setFilehandlesDriver(2);
 		

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/ReduceTaskExternalITCase.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/ReduceTaskExternalITCase.java
@@ -66,7 +66,7 @@ public class ReduceTaskExternalITCase extends DriverTestBase<GenericGroupReduce<
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt, valCnt, false), this.comparator.duplicate());
 			
-			ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 			
 			testDriver(testTask, MockReduceStub.class);
 		} catch (Exception e) {
@@ -98,7 +98,7 @@ public class ReduceTaskExternalITCase extends DriverTestBase<GenericGroupReduce<
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt, valCnt, false), this.comparator.duplicate());
 			
-			ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 			
 			testDriver(testTask, MockReduceStub.class);
 		} catch (Exception e) {
@@ -133,7 +133,7 @@ public class ReduceTaskExternalITCase extends DriverTestBase<GenericGroupReduce<
 				getOwningNepheleTask(), RecordSerializer.get(), this.comparator.duplicate(), this.perSortMem, 2, 0.8f);
 			addInput(sorter.getIterator());
 			
-			ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 		
 			testDriver(testTask, MockCombiningReduceStub.class);
 		} catch (Exception e) {
@@ -177,7 +177,7 @@ public class ReduceTaskExternalITCase extends DriverTestBase<GenericGroupReduce<
 				getOwningNepheleTask(), RecordSerializer.get(), this.comparator.duplicate(), this.perSortMem, 2, 0.8f);
 			addInput(sorter.getIterator());
 			
-			ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 		
 			testDriver(testTask, MockCombiningReduceStub.class);
 		} catch (Exception e) {

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/ReduceTaskTest.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/ReduceTaskTest.java
@@ -67,7 +67,7 @@ public class ReduceTaskTest extends DriverTestBase<GenericGroupReduce<Record, Re
 		try {
 			addInputSorted(new UniformRecordGenerator(keyCnt, valCnt, false), this.comparator.duplicate());
 			
-			ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 			
 			testDriver(testTask, MockReduceStub.class);
 		} catch (Exception e) {
@@ -94,7 +94,7 @@ public class ReduceTaskTest extends DriverTestBase<GenericGroupReduce<Record, Re
 		setOutput(this.outList);
 		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
 		
-		ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+		GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 		
 		try {
 			testDriver(testTask, MockReduceStub.class);
@@ -128,7 +128,7 @@ public class ReduceTaskTest extends DriverTestBase<GenericGroupReduce<Record, Re
 				getOwningNepheleTask(), RecordSerializer.get(), this.comparator.duplicate(), this.perSortMem, 4, 0.8f);
 			addInput(sorter.getIterator());
 			
-			ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+			GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 		
 			testDriver(testTask, MockCombiningReduceStub.class);
 		} catch (Exception e) {
@@ -165,7 +165,7 @@ public class ReduceTaskTest extends DriverTestBase<GenericGroupReduce<Record, Re
 		setOutput(this.outList);
 		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
 		
-		ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+		GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 		
 		try {
 			testDriver(testTask, MockFailingReduceStub.class);
@@ -187,7 +187,7 @@ public class ReduceTaskTest extends DriverTestBase<GenericGroupReduce<Record, Re
 		setOutput(new NirvanaOutputList());
 		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
 		
-		final ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+		final GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 		
 		try {
 			addInputSorted(new DelayingInfinitiveInputIterator(100), this.comparator.duplicate());
@@ -235,7 +235,7 @@ public class ReduceTaskTest extends DriverTestBase<GenericGroupReduce<Record, Re
 		setOutput(new NirvanaOutputList());
 		getTaskConfig().setDriverStrategy(DriverStrategy.SORTED_GROUP);
 		
-		final ReduceDriver<Record, Record> testTask = new ReduceDriver<Record, Record>();
+		final GroupReduceDriver<Record, Record> testTask = new GroupReduceDriver<Record, Record>();
 		
 		final AtomicBoolean success = new AtomicBoolean(false);
 		

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/chaining/ChainTaskTest.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/task/chaining/ChainTaskTest.java
@@ -84,7 +84,7 @@ public class ChainTaskTest extends TaskTestBase {
 				combineConfig.setOutputSerializer(serFact);
 				
 				// driver
-				combineConfig.setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+				combineConfig.setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 				combineConfig.setDriverComparator(compFact, 0);
 				combineConfig.setMemoryDriver(3 * 1024 * 1024);
 				
@@ -140,7 +140,7 @@ public class ChainTaskTest extends TaskTestBase {
 				combineConfig.setOutputSerializer(serFact);
 				
 				// driver
-				combineConfig.setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+				combineConfig.setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 				combineConfig.setDriverComparator(compFact, 0);
 				combineConfig.setMemoryDriver(3 * 1024 * 1024);
 				

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/test/util/DriverTestBase.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/test/util/DriverTestBase.java
@@ -140,13 +140,13 @@ public class DriverTestBase<S extends Function> implements PactTaskContext<S, Re
 		this.numFileHandles = numFileHandles;
 	}
 
-	public void testDriver(PactDriver<S, Record> driver, Class<? extends S> stubClass) throws Exception {
+	@SuppressWarnings({"unchecked","rawtypes"})
+	public void testDriver(PactDriver driver, Class stubClass) throws Exception {
 		
 		this.driver = driver;
 		driver.setup(this);
 		
-		// instantiate the stub
-		this.stub = stubClass.newInstance();
+		this.stub = (S)stubClass.newInstance();
 		
 		// regular running logic
 		this.running = true;

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/KMeansIterativeNepheleITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/broadcastvars/KMeansIterativeNepheleITCase.java
@@ -42,7 +42,7 @@ import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
 import eu.stratosphere.pact.runtime.task.CollectorMapDriver;
 import eu.stratosphere.pact.runtime.task.NoOpDriver;
-import eu.stratosphere.pact.runtime.task.ReduceDriver;
+import eu.stratosphere.pact.runtime.task.GroupReduceDriver;
 import eu.stratosphere.pact.runtime.task.chaining.ChainedCollectorMapDriver;
 import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
 import eu.stratosphere.pact.runtime.task.util.TaskConfig;
@@ -227,7 +227,7 @@ public class KMeansIterativeNepheleITCase extends TestBase2 {
 		tailConfig.setIsWorksetUpdate();
 		
 		// inputs and driver
-		tailConfig.setDriver(ReduceDriver.class);
+		tailConfig.setDriver(GroupReduceDriver.class);
 		tailConfig.setDriverStrategy(DriverStrategy.SORTED_GROUP);
 		tailConfig.addInputToGroup(0);
 		tailConfig.setInputSerializer(inputSerializer, 0);		

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/examples/KMeansSingleStepTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/examples/KMeansSingleStepTest.java
@@ -102,7 +102,7 @@ public class KMeansSingleStepTest extends CompilerTestBase {
 		Assert.assertNotNull(combiner);
 		assertEquals(ShipStrategyType.FORWARD, combiner.getInput().getShipStrategy());
 		assertEquals(LocalStrategy.NONE, combiner.getInput().getLocalStrategy());
-		assertEquals(DriverStrategy.PARTIAL_GROUP, combiner.getDriverStrategy());
+		assertEquals(DriverStrategy.PARTIAL_GROUP_COMBINE, combiner.getDriverStrategy());
 		assertNull(combiner.getInput().getLocalStrategyKeys());
 		assertNull(combiner.getInput().getLocalStrategySortOrder());
 		assertEquals(set0, combiner.getKeys());

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/examples/RelationalQueryCompilerTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/examples/RelationalQueryCompilerTest.java
@@ -232,7 +232,7 @@ public class RelationalQueryCompilerTest extends CompilerTestBase {
 		Assert.assertEquals(DriverStrategy.SORTED_GROUP, reducer.getDriverStrategy());
 		Assert.assertEquals(DriverStrategy.NONE, sink.getDriverStrategy());
 		if (combiner != null) {
-			Assert.assertEquals(DriverStrategy.PARTIAL_GROUP, combiner.getDriverStrategy());
+			Assert.assertEquals(DriverStrategy.PARTIAL_GROUP_COMBINE, combiner.getDriverStrategy());
 			Assert.assertEquals(LocalStrategy.NONE, combiner.getInput().getLocalStrategy());
 		}
 	}

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/examples/WordCountCompilerTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/examples/WordCountCompilerTest.java
@@ -90,7 +90,7 @@ public class WordCountCompilerTest extends CompilerTestBase {
 			
 			// check the combiner
 			SingleInputPlanNode combiner = (SingleInputPlanNode) reducer.getPredecessor();
-			Assert.assertEquals(DriverStrategy.PARTIAL_GROUP, combiner.getDriverStrategy());
+			Assert.assertEquals(DriverStrategy.PARTIAL_GROUP_COMBINE, combiner.getDriverStrategy());
 			Assert.assertEquals(l, combiner.getKeys());
 			Assert.assertEquals(ShipStrategyType.FORWARD, combiner.getInput().getShipStrategy());
 			
@@ -163,7 +163,7 @@ public class WordCountCompilerTest extends CompilerTestBase {
 			
 			// check the combiner
 			SingleInputPlanNode combiner = (SingleInputPlanNode) reducer.getPredecessor();
-			Assert.assertEquals(DriverStrategy.PARTIAL_GROUP, combiner.getDriverStrategy());
+			Assert.assertEquals(DriverStrategy.PARTIAL_GROUP_COMBINE, combiner.getDriverStrategy());
 			Assert.assertEquals(l, combiner.getKeys());
 			Assert.assertEquals(ShipStrategyType.FORWARD, combiner.getInput().getShipStrategy());
 		} catch (Exception e) {

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/iterations/IterativeKMeansTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/compiler/iterations/IterativeKMeansTest.java
@@ -131,7 +131,7 @@ public class IterativeKMeansTest extends CompilerTestBase {
 		assertTrue(combiner.getInput().isOnDynamicPath());
 		
 		assertEquals(LocalStrategy.NONE, combiner.getInput().getLocalStrategy());
-		assertEquals(DriverStrategy.PARTIAL_GROUP, combiner.getDriverStrategy());
+		assertEquals(DriverStrategy.PARTIAL_GROUP_COMBINE, combiner.getDriverStrategy());
 		assertNull(combiner.getInput().getLocalStrategyKeys());
 		assertNull(combiner.getInput().getLocalStrategySortOrder());
 		assertEquals(set0, combiner.getKeys());

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/iterative/nephele/ConnectedComponentsNepheleITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/iterative/nephele/ConnectedComponentsNepheleITCase.java
@@ -49,7 +49,7 @@ import eu.stratosphere.pact.runtime.task.BuildSecondCachedMatchDriver;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
 import eu.stratosphere.pact.runtime.task.CollectorMapDriver;
 import eu.stratosphere.pact.runtime.task.JoinWithSolutionSetSecondDriver;
-import eu.stratosphere.pact.runtime.task.ReduceDriver;
+import eu.stratosphere.pact.runtime.task.GroupReduceDriver;
 import eu.stratosphere.pact.runtime.task.chaining.ChainedCollectorMapDriver;
 import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
 import eu.stratosphere.pact.runtime.task.util.TaskConfig;
@@ -304,7 +304,7 @@ public class ConnectedComponentsNepheleITCase extends TestBase2 {
 			intermediateConfig.setOutputSerializer(serializer);
 			intermediateConfig.addOutputShipStrategy(ShipStrategyType.FORWARD);
 
-			intermediateConfig.setDriver(ReduceDriver.class);
+			intermediateConfig.setDriver(GroupReduceDriver.class);
 			intermediateConfig.setDriverStrategy(DriverStrategy.SORTED_GROUP);
 			intermediateConfig.setDriverComparator(comparator, 0);
 			intermediateConfig.setStubWrapper(

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/iterative/nephele/IterationWithChainingNepheleITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/iterative/nephele/IterationWithChainingNepheleITCase.java
@@ -32,7 +32,7 @@ import eu.stratosphere.pact.runtime.plugable.pactrecord.RecordSerializerFactory;
 import eu.stratosphere.pact.runtime.shipping.ShipStrategyType;
 import eu.stratosphere.pact.runtime.task.DriverStrategy;
 import eu.stratosphere.pact.runtime.task.CollectorMapDriver;
-import eu.stratosphere.pact.runtime.task.ReduceDriver;
+import eu.stratosphere.pact.runtime.task.GroupReduceDriver;
 import eu.stratosphere.pact.runtime.task.chaining.ChainedCollectorMapDriver;
 import eu.stratosphere.pact.runtime.task.util.LocalStrategy;
 import eu.stratosphere.pact.runtime.task.util.TaskConfig;
@@ -183,7 +183,7 @@ public class IterationWithChainingNepheleITCase extends TestBase2 {
             tailConfig.setOutputSerializer(serializer);
 
             // the driver
-            tailConfig.setDriver(ReduceDriver.class);
+            tailConfig.setDriver(GroupReduceDriver.class);
             tailConfig.setDriverStrategy(DriverStrategy.SORTED_GROUP);
             tailConfig.setDriverComparator(comparator, 0);
             tailConfig.setStubWrapper(new UserCodeClassWrapper<DummyReducer>(DummyReducer.class));

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/iterative/nephele/customdanglingpagerank/CustomCompensatableDanglingPageRankWithCombiner.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/iterative/nephele/customdanglingpagerank/CustomCompensatableDanglingPageRankWithCombiner.java
@@ -223,7 +223,7 @@ public class CustomCompensatableDanglingPageRankWithCombiner {
 		TaskConfig combinerConfig = new TaskConfig(new Configuration());
 		combinerConfig.addInputToGroup(0);
 		combinerConfig.setInputSerializer(vertexWithRankSerializer, 0);
-		combinerConfig.setDriverStrategy(DriverStrategy.PARTIAL_GROUP);
+		combinerConfig.setDriverStrategy(DriverStrategy.PARTIAL_GROUP_COMBINE);
 		combinerConfig.setDriverComparator(vertexWithRankComparator, 0);
 		combinerConfig.setMemoryDriver(coGroupSortMemory * JobGraphUtils.MEGABYTE);
 		combinerConfig.setOutputSerializer(vertexWithRankSerializer);


### PR DESCRIPTION
Divided the Reduce and the GroupReduce classes from each other. So far Reduce was just wrapped into a GroupReduce. Now there are OptimizerClasses, Pact-Driver,... for both. 

I only use the same drivers for the combine case (PARTIAL_GROUP_COMBINE), since the combine logic is exactly the same for both cases so far. (Therefore both Operators implement the new interface GenericCombine now)
