### PR TITLE
added ExecutionEnvironment.registerCachedFile()

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.Validate;
 
 import eu.stratosphere.api.common.InvalidProgramException;
 import eu.stratosphere.api.common.JobExecutionResult;
+import eu.stratosphere.api.common.Plan;
 import eu.stratosphere.api.common.io.InputFormat;
 import eu.stratosphere.api.java.io.CollectionInputFormat;
 import eu.stratosphere.api.java.io.CsvReader;
@@ -62,6 +63,8 @@ public abstract class ExecutionEnvironment {
 	private final List<DataSink<?>> sinks = new ArrayList<DataSink<?>>();
 	
 	private int degreeOfParallelism = -1;
+	
+	protected List<String> cacheFile = new ArrayList<String>();
 	
 	
 	// --------------------------------------------------------------------------------------------
@@ -246,6 +249,17 @@ public abstract class ExecutionEnvironment {
 	public abstract JobExecutionResult execute(String jobName) throws Exception;
 	
 	public abstract String getExecutionPlan() throws Exception;
+	
+	public void registerCachedFile(String filePath, String name){
+		this.cacheFile.add(filePath);
+		this.cacheFile.add(name);
+	}
+	
+	protected void registerCachedFiles(Plan p){
+		for(int x=0;x<cacheFile.size();x+=2){
+			p.registerCachedFile(cacheFile.get(x), cacheFile.get(x+1));
+		}
+	}
 	
 	public JavaPlan createProgramPlan() {
 		return createProgramPlan(null);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -39,6 +39,7 @@ import eu.stratosphere.api.java.operators.DataSink;
 import eu.stratosphere.api.java.operators.DataSource;
 import eu.stratosphere.api.java.operators.OperatorTranslation;
 import eu.stratosphere.api.java.operators.translation.JavaPlan;
+import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.api.java.typeutils.BasicTypeInfo;
 import eu.stratosphere.api.java.typeutils.TypeExtractor;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
@@ -64,7 +65,7 @@ public abstract class ExecutionEnvironment {
 	
 	private int degreeOfParallelism = -1;
 	
-	protected List<String> cacheFile = new ArrayList<String>();
+	protected List<Tuple2<String, String>> cacheFile = new ArrayList<Tuple2<String, String>>();
 	
 	
 	// --------------------------------------------------------------------------------------------
@@ -251,13 +252,12 @@ public abstract class ExecutionEnvironment {
 	public abstract String getExecutionPlan() throws Exception;
 	
 	public void registerCachedFile(String filePath, String name){
-		this.cacheFile.add(filePath);
-		this.cacheFile.add(name);
+		this.cacheFile.add(new Tuple2<String, String>(filePath, name));
 	}
 	
-	protected void registerCachedFiles(Plan p){
-		for(int x=0;x<cacheFile.size();x+=2){
-			p.registerCachedFile(cacheFile.get(x), cacheFile.get(x+1));
+	protected void registerCachedFiles(Plan p) {
+		for (Tuple2<String, String> entry : cacheFile) {
+			p.registerCachedFile((String) entry.getField(0), (String) entry.getField(1));
 		}
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/LocalEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/LocalEnvironment.java
@@ -30,6 +30,7 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
 		p.setDefaultParallelism(getDegreeOfParallelism());
+		registerCachedFiles(p);
 		
 		PlanExecutor executor = PlanExecutor.createLocalExecutor();
 		initLogging();
@@ -40,6 +41,7 @@ public class LocalEnvironment extends ExecutionEnvironment {
 	public String getExecutionPlan() throws Exception {
 		Plan p = createProgramPlan("unnamed job");
 		p.setDefaultParallelism(getDegreeOfParallelism());
+		registerCachedFiles(p);
 		
 		PlanExecutor executor = PlanExecutor.createLocalExecutor();
 		initLogging();

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/RemoteEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/RemoteEnvironment.java
@@ -47,6 +47,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
 		p.setDefaultParallelism(getDegreeOfParallelism());
+		registerCachedFiles(p);
 		
 		PlanExecutor executor = PlanExecutor.createRemoteExecutor(host, port, jarFiles);
 		return executor.executePlan(p);
@@ -56,6 +57,7 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 	public String getExecutionPlan() throws Exception {
 		Plan p = createProgramPlan("unnamed");
 		p.setDefaultParallelism(getDegreeOfParallelism());
+		registerCachedFiles(p);
 		
 		PlanExecutor executor = PlanExecutor.createRemoteExecutor(host, port, jarFiles);
 		return executor.getOptimizerPlanAsJSON(p);


### PR DESCRIPTION
Instead of

```
Plan p = env.CreateProgramPlan();
p.registerCachedFile(path, "name");
PlanExecutor l = new Local-/RemoteExecutor();
l.executePlan(p);
```

you can now write

```
env.registerCachedFile(path, "name");
env.execute();
```
