### PR TITLE
Cache: exists() called for files / relative path support

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/Plan.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/Plan.java
@@ -303,25 +303,23 @@ public class Plan implements Visitable<Operator> {
 	 *  register cache files in program level
 	 * @param filePath The files must be stored in a place that can be accessed from all workers (most commonly HDFS)
 	 * @param name user defined name of that file
+	 * @throws java.io.IOException
 	 */
-	public void registerCachedFile(String filePath, String name) throws RuntimeException {
+	public void registerCachedFile(String filePath, String name) throws RuntimeException, IOException {
 		if (!this.cacheFile.containsKey(name)) {
 			try {
-				FileSystem fs = FileSystem.get(new URI(filePath));
-				if (fs.exists(new Path(filePath))) {
-					this.cacheFile.put(name, filePath);
-				} else {
-					throw new RuntimeException("File "+filePath+" doesn't exist.");
+				URI u = new URI(filePath);
+				if (!u.getPath().startsWith("/")) {
+					u = new URI(new File(filePath).getAbsolutePath());
 				}
-			} catch (IOException ex) {
-				File f = new File(filePath);
-				if (f.exists()) {
-					this.cacheFile.put(name, f.getAbsolutePath());
+				FileSystem fs = FileSystem.get(u);
+				if (fs.exists(new Path(u.getPath()))) {
+					this.cacheFile.put(name, u.toString());
 				} else {
-					throw new RuntimeException("File "+f.getAbsolutePath()+" doesn't exist.");
+					throw new RuntimeException("File " + u.toString() + " oesn't exist.");
 				}
 			} catch (URISyntaxException ex) {
-				throw new RuntimeException("Invalid path.");
+				throw new RuntimeException("Invalid path: " + filePath);
 			}
 		} else {
 			throw new RuntimeException("cache file " + name + "already exists!");

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/Plan.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/Plan.java
@@ -316,10 +316,10 @@ public class Plan implements Visitable<Operator> {
 				if (fs.exists(new Path(u.getPath()))) {
 					this.cacheFile.put(name, u.toString());
 				} else {
-					throw new RuntimeException("File " + u.toString() + " oesn't exist.");
+					throw new RuntimeException("File " + u.toString() + " doesn't exist.");
 				}
 			} catch (URISyntaxException ex) {
-				throw new RuntimeException("Invalid path: " + filePath);
+				throw new RuntimeException("Invalid path: " + filePath, ex);
 			}
 		} else {
 			throw new RuntimeException("cache file " + name + "already exists!");

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/distributedCache/DistributedCacheTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/distributedCache/DistributedCacheTest.java
@@ -34,6 +34,8 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
@@ -136,8 +138,8 @@ public class DistributedCacheTest extends TestBase2 {
 		try {
 			plan.registerCachedFile(cachePath, "cache_test");
 		} catch (IOException ex) {
-			ex.printStackTrace();
-		}
+			throw new RuntimeException(ex);
+		}		
 		return plan;
 	}
 

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/distributedCache/DistributedCacheTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/distributedCache/DistributedCacheTest.java
@@ -133,7 +133,11 @@ public class DistributedCacheTest extends TestBase2 {
 	@Override
 	protected Plan getTestJob() {
 		Plan plan =  getPlan(1 , textPath, resultPath);
-		plan.registerCachedFile(cachePath, "cache_test");
+		try {
+			plan.registerCachedFile(cachePath, "cache_test");
+		} catch (IOException ex) {
+			ex.printStackTrace();
+		}
 		return plan;
 	}
 


### PR DESCRIPTION
The distributed cache now supports relative paths, and checks whether the file actually exists.
