### PR TITLE
Many small YARN improvements.

### DIFF
--- a/stratosphere-addons/yarn/pom.xml
+++ b/stratosphere-addons/yarn/pom.xml
@@ -26,7 +26,13 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
+		
+		<dependency>
+			<groupId>eu.stratosphere</groupId>
+			<artifactId>stratosphere-clients</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-yarn-client</artifactId>

--- a/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/ApplicationMaster.java
+++ b/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/ApplicationMaster.java
@@ -73,7 +73,6 @@ public class ApplicationMaster {
 		final String logDirs =  envs.get(Environment.LOG_DIRS.key());
 		final String ownHostname = envs.get(Environment.NM_HOST.key());
 		final String appId = envs.get(Client.ENV_APP_ID);
-		final String localDirs = envs.get(Environment.LOCAL_DIRS.key());
 		final String clientHomeDir = envs.get(Client.ENV_CLIENT_HOME_DIR);
 		final String applicationMasterHost = envs.get(Environment.NM_HOST.key());
 		final String remoteStratosphereJarPath = envs.get(Client.STRATOSPHERE_JAR_PATH);
@@ -108,8 +107,6 @@ public class ApplicationMaster {
 		    	output.append(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY+": "+ownHostname+"\n");
 		    } else if(line.contains(ConfigConstants.JOB_MANAGER_WEB_ROOT_PATH_KEY)) {
 		    	output.append(ConfigConstants.JOB_MANAGER_WEB_ROOT_PATH_KEY+": "+"\n");
-		    } else if(localDirs != null && line.contains(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY)) {
-		    	output.append(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY+": "+localDirs+"\n");
 		    } else {
 		    	output.append(line+"\n");
 		    }
@@ -118,9 +115,6 @@ public class ApplicationMaster {
 		output.append(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY+": "+ownHostname+"\n");
 		output.append(ConfigConstants.JOB_MANAGER_WEB_ROOT_PATH_KEY+": "+localWebInterfaceDir+"\n");
 		output.append(ConfigConstants.JOB_MANAGER_WEB_LOG_PATH_KEY+": "+logDirs+"\n");
-		if(localDirs != null) {
-			output.append(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY+": "+localDirs+"\n");
-		}
 		output.close();
 		br.close();
 		File newConf = new File(currDir+"/stratosphere-conf-modified.yaml");

--- a/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/Client.java
+++ b/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/Client.java
@@ -65,6 +65,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 
+import eu.stratosphere.client.CliFrontend;
 import eu.stratosphere.configuration.ConfigConstants;
 import eu.stratosphere.configuration.GlobalConfiguration;
 
@@ -288,6 +289,12 @@ public class Client {
 	    // Create a local resource to point to the destination jar path 
 	    final FileSystem fs = FileSystem.get(conf);
 	    
+	    if(fs.getScheme().startsWith("file")) {
+	    	LOG.warn("The file system scheme is '" + fs.getScheme() + "'. This indicates that the "
+	    			+ "specified Hadoop configuration path is wrong and the sytem is using the default Hadoop configuration values."
+	    			+ "The Stratosphere YARN client needs to store its files in a distributed file system");
+	    }
+	    
 	    // Create yarnClient
 		final YarnClient yarnClient = YarnClient.createYarnClient();
 		yarnClient.init(conf);
@@ -452,9 +459,11 @@ public class Client {
 				System.err.println("Stratosphere JobManager is now running on "+appReport.getHost()+":"+jmPort);
 				System.err.println("JobManager Web Interface: "+appReport.getTrackingUrl());
 				// write jobmanager connect information
-				PrintWriter out = new PrintWriter(confDirPath+".yarn-jobmanager");
+				File addrFile = new File(confDirPath + CliFrontend.JOBMANAGER_ADDRESS_FILE);
+				PrintWriter out = new PrintWriter(addrFile);
 				out.println(appReport.getHost()+":"+jmPort);
 				out.close();
+				addrFile.setReadable(true, false); // readable for all.
 				told = true;
 			}
 			if(!told) {

--- a/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/Utils.java
+++ b/stratosphere-addons/yarn/src/main/java/eu/stratosphere/yarn/Utils.java
@@ -104,7 +104,7 @@ public class Utils {
 		try {
 			 fileUrl = path.toURL();
 		} catch (MalformedURLException e) {
-			e.printStackTrace();
+			throw new RuntimeException("Erroneous config file path", e);
 		}
 		URL[] urls = {fileUrl};
 		ClassLoader cl = new URLClassLoader(urls, conf.getClassLoader());
@@ -120,6 +120,13 @@ public class Utils {
 	}
 	public static Configuration initializeYarnConfiguration() {
 		Configuration conf = new YarnConfiguration();
+		String configuredHadoopConfig = GlobalConfiguration.getString(ConfigConstants.PATH_HADOOP_CONFIG, null);
+		if(configuredHadoopConfig != null) {
+			LOG.info("Using hadoop configuration path from " + ConfigConstants.PATH_HADOOP_CONFIG + " setting.");
+			addPathToConfig(conf, new File(configuredHadoopConfig));
+			setDefaultConfValues(conf);
+			return conf;
+		}
 		String envs[] = { "YARN_CONF_DIR", "HADOOP_CONF_DIR", "HADOOP_CONF_PATH" };
 		for(int i = 0; i < envs.length; ++i) {
 			String confPath = System.getenv(envs[i]);

--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/CliFrontend.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/CliFrontend.java
@@ -105,6 +105,7 @@ public class CliFrontend {
 	private static final String ENV_CONFIG_DIRECTORY = "STRATOSPHERE_CONF_DIR";
 	private static final String CONFIG_DIRECTORY_FALLBACK_1 = "../conf";
 	private static final String CONFIG_DIRECTORY_FALLBACK_2 = "conf";
+	public static final String JOBMANAGER_ADDRESS_FILE = ".yarn-jobmanager";
 	
 
 	private CommandLineParser parser;
@@ -294,11 +295,11 @@ public class CliFrontend {
 		
 		// see if there is a file containing the jobManager address.
 		String loc = getConfigurationDirectory();
-		File jmAddressFile = new File(loc+"/.yarn-jobmanager");
+		File jmAddressFile = new File(loc + "/" + JOBMANAGER_ADDRESS_FILE);
 		if (jmAddressFile.exists()) {
 			try {
 				address = FileUtils.readFileToString(jmAddressFile).trim();
-				System.out.println("Found a .yarn-jobmanager file, using \""+address+"\" to connect to the JobManager");
+				System.out.println("Found a " + JOBMANAGER_ADDRESS_FILE + " file, using \""+address+"\" to connect to the JobManager");
 			} catch (IOException e) {}
 		}
 		

--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/CliFrontend.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/CliFrontend.java
@@ -14,6 +14,7 @@
 package eu.stratosphere.client;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.text.SimpleDateFormat;
@@ -296,10 +297,12 @@ public class CliFrontend {
 		// see if there is a file containing the jobManager address.
 		String loc = getConfigurationDirectory();
 		File jmAddressFile = new File(loc + "/" + JOBMANAGER_ADDRESS_FILE);
+		boolean yarnMode = false;
 		if (jmAddressFile.exists()) {
 			try {
 				address = FileUtils.readFileToString(jmAddressFile).trim();
 				System.out.println("Found a " + JOBMANAGER_ADDRESS_FILE + " file, using \""+address+"\" to connect to the JobManager");
+				yarnMode = true;
 			} catch (IOException e) {}
 		}
 		
@@ -350,16 +353,20 @@ public class CliFrontend {
 			}
 		}
 		else {
-			if (address != null && !address.isEmpty()) {
-				System.out.println("Job successfully submitted. Use -w (or --wait) option to track the progress here.\n"
+			if(!yarnMode) {
+				if (address != null && !address.isEmpty()) {
+					System.out.println("Job successfully submitted. Use -w (or --wait) option to track the progress here.\n"
+							+ "JobManager web interface: http://"
+							+ socket.getHostName()
+							+ ":" + configuration.getInteger(ConfigConstants.JOB_MANAGER_WEB_PORT_KEY, ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT));
+				} else {
+					System.out.println("Job successfully submitted. Use -w (or --wait) option to track the progress here.\n"
 						+ "JobManager web interface: http://"
-						+ socket.getHostName()
+						+ configuration.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null)
 						+ ":" + configuration.getInteger(ConfigConstants.JOB_MANAGER_WEB_PORT_KEY, ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT));
+				}
 			} else {
-				System.out.println("Job successfully submitted. Use -w (or --wait) option to track the progress here.\n"
-					+ "JobManager web interface: http://"
-					+ configuration.getString(ConfigConstants.JOB_MANAGER_IPC_ADDRESS_KEY, null)
-					+ ":" + configuration.getInteger(ConfigConstants.JOB_MANAGER_WEB_PORT_KEY, ConfigConstants.DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT));
+				System.out.println("Job successfully submitted. Use -w (or --wait) option to track the progress here.\n");
 			}
 		}
 		return 0;

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
@@ -417,9 +417,12 @@ public class TaskManager implements TaskOperationProtocol {
 		}
 		
 		// park the main thread to keep the JVM alive (all other threads may be daemon threads)
-		try {
-			new Object().wait();
-		} catch (InterruptedException ex) {}
+		Object mon = new Object();
+		synchronized (mon) {
+			try {
+				mon.wait();
+			} catch (InterruptedException ex) {}
+		}
 	}
 
 	/**


### PR DESCRIPTION
This pull request fixes some YARN-related bugs:
- Fix temporary directory behavior of YARN and .yarn-jobmanager permissions for different users. #736
- YARN session client should use "fs.hdfs.hadoopconf" if property set in conf #733
- warning if the user is using "file:" as the distributed file system
- Don't show JobManager URL in stratosphere-client if submitting to YARN. 
- Suggested fix for: IllegalMonitorStateException in TaskManager. #739
