### PR TITLE
StringComparator incompatible read/write

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
@@ -31,10 +31,6 @@ public final class StringComparator extends BasicTypeComparator<String> {
 	private static final int HIGH_BIT2 = 0x1 << 13;
 	
 	private static final int HIGH_BIT2_MASK = 0x3 << 6;
-
-	
-	private final StringValue holder1 = new StringValue();
-	private final StringValue holder2 = new StringValue();
 	
 	
 	public StringComparator(boolean ascending) {
@@ -43,9 +39,9 @@ public final class StringComparator extends BasicTypeComparator<String> {
 
 	@Override
 	public int compare(DataInputView firstSource, DataInputView secondSource) throws IOException {
-		holder1.read(firstSource);
-		holder2.read(secondSource);
-		int comp = holder1.compareTo(holder2); 
+		String s1 = StringValue.readString(firstSource);
+		String s2 = StringValue.readString(secondSource);
+		int comp = s1.compareTo(s2); 
 		return ascendingComparison ? comp : -comp;
 	}
 


### PR DESCRIPTION
The StringComparator uses a mixture of static and non-static read/write methods which are not compatible with each other due to different offsets.

This PR makes sure that it only uses the static methods (similar to the StringSerializer).

this fixes the issue mentioned in #748 .
