### PR TITLE
Fix for Tuple Comparator

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/postpass/JavaApiPostPass.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/postpass/JavaApiPostPass.java
@@ -105,6 +105,8 @@ public class JavaApiPostPass implements OptimizerPostPass {
 			
 			PlanDeltaIterationOperator<?, ?> operator = (PlanDeltaIterationOperator<?, ?>) iterationNode.getPactContract();
 			
+			operator.getSolutionsetType().setKeyPositions(iterationNode.getSolutionSetKeyFields());
+			
 			// set the serializers and comparators for the workset iteration
 			iterationNode.setSolutionSetSerializer(createSerializer(operator.getSolutionsetType()));
 			iterationNode.setWorksetSerializer(createSerializer(operator.getWorksetType()));
@@ -134,7 +136,7 @@ public class JavaApiPostPass implements OptimizerPostPass {
 			}
 			
 			UnaryJavaPlanNode<?, ?> javaNode = (UnaryJavaPlanNode<?, ?>) sn.getOptimizerNode().getPactContract();
-			
+
 			// parameterize the node's driver strategy
 			if (sn.getDriverStrategy().requiresComparator()) {
 				sn.setComparator(createComparator(javaNode.getInputType(), sn.getKeys(), 
@@ -244,6 +246,8 @@ public class JavaApiPostPass implements OptimizerPostPass {
 				type = javaNode.getReturnType();
 			}
 		}
+		
+		type.setKeyPositions(channel.getLocalStrategyKeys());
 		
 		// the serializer always exists
 		channel.setSerializer(createSerializer(type));

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
@@ -90,7 +90,7 @@ public class TupleTypeInfo<T extends Tuple> extends TypeInformation<T> implement
 		
 		Class<T> tupleClass = getTypeClass();
 		
-		return new TupleSerializer<T>(tupleClass, fieldSerializers);
+		return new TupleSerializer<T>(tupleClass, fieldSerializers, keyPositions);
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TypeInformation.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TypeInformation.java
@@ -17,6 +17,7 @@ package eu.stratosphere.api.java.typeutils;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import eu.stratosphere.api.common.operators.util.FieldList;
 import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.types.Value;
 
@@ -33,6 +34,14 @@ public abstract class TypeInformation<T> {
 	public abstract boolean isKeyType();
 	
 	public abstract TypeSerializer<T> createSerializer();
+	
+	public void setKeyPositions(FieldList keyPositions){
+		if(keyPositions!= null){
+			this.keyPositions = keyPositions.toArray();
+		}
+	}
+	
+	protected int[] keyPositions = null;
 	
 	// -------------------------------------------------------------------------
 	

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/GroupReduceITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/GroupReduceITCase.java
@@ -41,7 +41,7 @@ import eu.stratosphere.util.Collector;
 @RunWith(Parameterized.class)
 public class GroupReduceITCase extends JavaProgramTestBase {
 	
-	private static int NUM_PROGRAMS = 11;
+	private static int NUM_PROGRAMS = 12;
 	
 	private int curProgId = config.getInteger("ProgramId", -1);
 	private String resultPath;
@@ -370,32 +370,31 @@ public class GroupReduceITCase extends JavaProgramTestBase {
 //				// return expected result
 //				return "231,91,Hello World\n";
 //			}
-			// TODO: descending sort not working
-//			case 10: {
-//				
-//				/*
-//				 * check correctness of groupReduce on tuples with key field selector and group sorting
-//				 */
-//				
-//				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-//				env.setDegreeOfParallelism(1);
-//				
-//				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-//				DataSet<Tuple3<Integer, Long, String>> reduceDs = ds.
-//						groupBy(1).sortGroup(2,Order.DESCENDING).reduceGroup(new Tuple3SortedGroupReduce());
-//				
-//				reduceDs.writeAsCsv(resultPath);
-//				env.execute();
-//				
-//				// return expected result
-//				return "1,1,Hi\n" +
-//						"5,2,Hello world-Hello\n" +
-//						"15,3,Luke Skywalker-I am fine.-Hello world, how are you?\n" +
-//						"34,4,Comment#4-Comment#3-Comment#2-Comment#1\n" +
-//						"65,5,Comment#9-Comment#8-Comment#7-Comment#6-Comment#5\n" +
-//						"111,6,Comment#15-Comment#14-Comment#13-Comment#12-Comment#11-Comment#10\n";
-//				
-//			}
+			case 12: {
+				
+				/*
+				 * check correctness of groupReduce on tuples with key field selector and group sorting
+				 */
+				
+				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+				env.setDegreeOfParallelism(1);
+				
+				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
+				DataSet<Tuple3<Integer, Long, String>> reduceDs = ds.
+						groupBy(1).sortGroup(2,Order.DESCENDING).reduceGroup(new Tuple3SortedGroupReduce());
+				
+				reduceDs.writeAsCsv(resultPath);
+				env.execute();
+				
+				// return expected result
+				return "1,1,Hi\n" +
+						"5,2,Hello world-Hello\n" +
+						"15,3,Luke Skywalker-I am fine.-Hello world, how are you?\n" +
+						"34,4,Comment#4-Comment#3-Comment#2-Comment#1\n" +
+						"65,5,Comment#9-Comment#8-Comment#7-Comment#6-Comment#5\n" +
+						"111,6,Comment#15-Comment#14-Comment#13-Comment#12-Comment#11-Comment#10\n";
+				
+			}
 			default: 
 			throw new IllegalArgumentException("Invalid program id");
 			}


### PR DESCRIPTION
I thought about a fix for the bug in the TupleComparator (mentioned in https://github.com/stratosphere/stratosphere/issues/744#issuecomment-42018637) which currently leads to the wrong result in sorts. 

My idea was to change the TupleSeriailizer to serialize the fields in the same order as the comparator needs them. Then the current implementation of the TupleComparator runs without any changes and without any serializiation overhead at runtime. Since it wasn't much code I did just write and tested it and it seems to work. Or do you prefer an other fix?

If this fix is okay, I got an other question: I added the KeyPositions to the TypeInformation and set them in the JavaAPiPostPass. I get the KeyPositions over channel.getLocalStrategyKeys() and pass it to the TypeInformation, but there are also the channel.getShipStrategyKeys(). In my tests the ShipStrategyKeys were a subset of the LocalStrategyKeys therefore I took the LocalStrategyKeys, but is this always the case?
