### PR TITLE
Extension of the TypeExtractor to validate input type information and recognizing input mismatches.

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TypeExtractor.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TypeExtractor.java
@@ -36,83 +36,251 @@ import eu.stratosphere.api.java.tuple.Tuple;
 import eu.stratosphere.types.Value;
 
 public class TypeExtractor {
-
+	
 	public static <IN, OUT> TypeInformation<OUT> getMapReturnTypes(MapFunction<IN, OUT> mapFunction, TypeInformation<IN> inType) {
+		validateInputType(MapFunction.class, mapFunction.getClass(), 0, inType);
 		return createTypeInfo(MapFunction.class, mapFunction.getClass(), 1, inType, null);
 	}
-
+	
 	public static <IN, OUT> TypeInformation<OUT> getFlatMapReturnTypes(FlatMapFunction<IN, OUT> flatMapFunction, TypeInformation<IN> inType) {
+		validateInputType(FlatMapFunction.class, flatMapFunction.getClass(), 0, inType);
 		return createTypeInfo(FlatMapFunction.class, flatMapFunction.getClass(), 1, inType, null);
 	}
-
+	
 	public static <IN, OUT> TypeInformation<OUT> getGroupReduceReturnTypes(GroupReduceFunction<IN, OUT> groupReduceFunction,
 			TypeInformation<IN> inType) {
+		validateInputType(GroupReduceFunction.class, groupReduceFunction.getClass(), 0, inType);
 		return createTypeInfo(GroupReduceFunction.class, groupReduceFunction.getClass(), 1, inType, null);
 	}
-
+	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> getJoinReturnTypes(JoinFunction<IN1, IN2, OUT> joinFunction,
 			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
+		validateInputType(JoinFunction.class, joinFunction.getClass(), 0, in1Type);
+		validateInputType(JoinFunction.class, joinFunction.getClass(), 1, in2Type);
 		return createTypeInfo(JoinFunction.class, joinFunction.getClass(), 2, in1Type, in2Type);
 	}
-
+	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> getCoGroupReturnTypes(CoGroupFunction<IN1, IN2, OUT> coGroupFunction,
 			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
+		validateInputType(CoGroupFunction.class, coGroupFunction.getClass(), 0, in1Type);
+		validateInputType(CoGroupFunction.class, coGroupFunction.getClass(), 1, in2Type);
 		return createTypeInfo(CoGroupFunction.class, coGroupFunction.getClass(), 2, in1Type, in2Type);
 	}
-
+	
 	public static <IN1, IN2, OUT> TypeInformation<OUT> getCrossReturnTypes(CrossFunction<IN1, IN2, OUT> crossFunction,
 			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
+		validateInputType(CrossFunction.class, crossFunction.getClass(), 0, in1Type);
+		validateInputType(CrossFunction.class, crossFunction.getClass(), 1, in2Type);
 		return createTypeInfo(CrossFunction.class, crossFunction.getClass(), 2, in1Type, in2Type);
 	}
-
+	
 	public static <IN, OUT> TypeInformation<OUT> getKeyExtractorType(KeySelector<IN, OUT> selector, TypeInformation<IN> inType) {
+		validateInputType(KeySelector.class, selector.getClass(), 0, inType);
 		return createTypeInfo(KeySelector.class, selector.getClass(), 1, inType, null);
 	}
-
+	
 	public static <IN> TypeInformation<IN> extractInputFormatTypes(InputFormat<IN, ?> format) {
 		throw new UnsupportedOperationException("not implemented yet");
 	}
-
+	
 	// --------------------------------------------------------------------------------------------
 	//  Generic utility methods
 	// --------------------------------------------------------------------------------------------
-
+	
 	public static TypeInformation<?> createTypeInfo(Type t) {
 		ArrayList<Type> typeHierarchy = new ArrayList<Type>();
 		typeHierarchy.add(t);
 		return createTypeInfoWithTypeHierarchy(typeHierarchy, t, null, null);
 	}
-
+	
 	@SuppressWarnings("unchecked")
 	public static <IN1, IN2, OUT> TypeInformation<OUT> createTypeInfo(Class<?> baseClass, Class<?> clazz, int returnParamPos,
 			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
 		ArrayList<Type> typeHierarchy = new ArrayList<Type>();
 		Type returnType = getParameterType(baseClass, typeHierarchy, clazz, returnParamPos);
-
+		
 		TypeInformation<OUT> typeInfo = null;
-
+		
 		// return type is a variable -> try to get the type info from the input of the base class directly
 		if (returnType instanceof TypeVariable<?>) {
 			ParameterizedType immediateBaseChild = (ParameterizedType) typeHierarchy.get(typeHierarchy.size() - 1);
 			typeInfo = (TypeInformation<OUT>) createTypeInfoWithImmediateBaseChildInput(immediateBaseChild, (TypeVariable<?>) returnType,
 					in1Type, in2Type);
-
+			
 			if (typeInfo != null) {
 				return typeInfo;
 			}
 		}
-
+		
 		// get info from hierarchy
 		return (TypeInformation<OUT>) createTypeInfoWithTypeHierarchy(typeHierarchy, returnType, in1Type, in2Type);
 	}
-
+	
 	public static Type getParameterType(Class<?> baseClass, Class<?> clazz, int pos) {
 		return getParameterType(baseClass, null, clazz, pos);
 	}
-
+	
+	private static void validateInputType(Class<?> baseClass, Class<?> clazz, int inputParamPos, TypeInformation<?> inType) {
+		ArrayList<Type> typeHierarchy = new ArrayList<Type>();		
+		try {
+			validateInfo(typeHierarchy, getParameterType(baseClass, typeHierarchy, clazz, inputParamPos), inType);
+		}
+		catch(InvalidTypesException e) {
+			throw new InvalidTypesException("Input mismatch: " + e.getMessage());
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static void validateInfo(ArrayList<Type> typeHierarchy, Type type, TypeInformation<?> typeInfo) {
+		
+		if (type == null) {
+			throw new InvalidTypesException("Unknown Error. Type is null.");
+		}
+		
+		if (typeInfo == null) {
+			throw new InvalidTypesException("Unknown Error. TypeInformation is null.");
+		}
+		
+		if (!(type instanceof TypeVariable<?>)) {
+			// check for basic type
+			if (typeInfo.isBasicType()) {
+				
+				TypeInformation<?> actual = null;
+				// check if basic type at all
+				if (!(type instanceof Class<?>) || (actual = BasicTypeInfo.getInfoFor((Class<?>) type)) == null) {
+					throw new InvalidTypesException("Basic type expected.");
+				}
+				// check if correct basic type
+				if (!typeInfo.equals(actual)) {
+					throw new InvalidTypesException("Basic type '" + typeInfo + "' expected but was '" + actual + "'.");
+				}
+				
+			}
+			// check for tuple
+			else if (typeInfo.isTupleType()) {
+				// check if tuple at all
+				if (!(type instanceof Class<?> && Tuple.class.isAssignableFrom((Class<?>) type))
+						&& !(type instanceof ParameterizedType && Tuple.class.isAssignableFrom((Class<?>) ((ParameterizedType) type)
+								.getRawType()))) {
+					throw new InvalidTypesException("Tuple type expected.");
+				}
+				
+				// do not allow usage of Tuple as type
+				if (type instanceof Class<?> && ((Class<?>) type).equals(Tuple.class)) {
+					throw new InvalidTypesException("Concrete subclass of Tuple expected.");
+				}
+				
+				// go up the hierarchy until we reach immediate child of Tuple (with or without generics)
+				while (!(type instanceof ParameterizedType && ((Class<?>) ((ParameterizedType) type).getRawType()).getSuperclass().equals(
+						Tuple.class))
+						&& !(type instanceof Class<?> && ((Class<?>) type).getSuperclass().equals(Tuple.class))) {
+					typeHierarchy.add(type);
+					// parameterized type
+					if (type instanceof ParameterizedType) {
+						type = ((Class<?>) ((ParameterizedType) type).getRawType()).getGenericSuperclass();
+					}
+					// class
+					else {
+						type = ((Class<?>) type).getGenericSuperclass();
+					}
+				}
+				
+				// check if immediate child of Tuple has generics
+				if (type instanceof Class<?>) {
+					throw new InvalidTypesException("Parameterized Tuple type expected.");
+				}
+				
+				TupleTypeInfo<?> tti = (TupleTypeInfo<?>) typeInfo;
+				
+				Type[] subTypes = ((ParameterizedType) type).getActualTypeArguments();
+				
+				if (subTypes.length != tti.getArity()) {
+					throw new InvalidTypesException("Tuple arity '" + tti.getArity() + "' expected but was '"
+							+ subTypes.length + "'.");
+				}
+				
+				for (int i = 0; i < subTypes.length; i++) {
+					validateInfo(new ArrayList<Type>(typeHierarchy), subTypes[i], ((TupleTypeInfo<?>) typeInfo).getTypeAt(i));
+				}
+			}
+			// check for basic array
+			else if (typeInfo instanceof BasicArrayTypeInfo<?, ?>) {
+				Type component = null;
+				// check if array at all
+				if (!(type instanceof Class<?> && ((Class<?>) type).isArray() && (component = ((Class<?>) type).getComponentType()) != null)
+						&& !(type instanceof GenericArrayType && (component = ((GenericArrayType) type).getGenericComponentType()) != null)) {
+					throw new InvalidTypesException("Array type expected.");
+				}
+				
+				if (component instanceof TypeVariable<?>) {
+					component = materializeTypeVariable(typeHierarchy, (TypeVariable<?>) component);
+					if (component == null) {
+						return;
+					}
+				}
+				
+				validateInfo(typeHierarchy, component, ((BasicArrayTypeInfo<?, ?>) typeInfo).getComponentInfo());
+				
+			}
+			// check for object array
+			else if (typeInfo instanceof ObjectArrayTypeInfo<?, ?>) {
+				// check if array at all
+				if (!(type instanceof Class<?> && ((Class<?>) type).isArray()) && !(type instanceof GenericArrayType)) {
+					throw new InvalidTypesException("Object array type expected.");
+				}
+				
+				// check component
+				Type component = null;
+				if (type instanceof Class<?>) {
+					component = ((Class<?>) type).getComponentType();
+				} else {
+					component = ((GenericArrayType) type).getGenericComponentType();
+				}
+				
+				if (component instanceof TypeVariable<?>) {
+					component = materializeTypeVariable(typeHierarchy, (TypeVariable<?>) component);
+					if (component == null) {
+						return;
+					}
+				}
+				
+				validateInfo(typeHierarchy, component, ((ObjectArrayTypeInfo<?, ?>) typeInfo).getComponentInfo());
+			}
+			// check for value
+			else if (typeInfo instanceof ValueTypeInfo<?>) {
+				// check if value at all
+				if (!(type instanceof Class<?> && Value.class.isAssignableFrom((Class<?>) type))) {
+					throw new InvalidTypesException("Value type expected.");
+				}
+				
+				TypeInformation<?> actual = null;
+				// check value type contents
+				if (!((ValueTypeInfo<?>) typeInfo).equals(actual = ValueTypeInfo.getValueTypeInfo((Class<? extends Value>) type))) {
+					throw new InvalidTypesException("Value type '" + typeInfo + "' expected but was '" + actual + "'.");
+				}
+			}
+			// check for custom object
+			else if (typeInfo instanceof GenericTypeInfo<?>) {
+				Class<?> clazz = null;
+				if (!(type instanceof Class<?> && ((GenericTypeInfo<?>) typeInfo).getTypeClass() == (clazz = (Class<?>) type))
+						&& !(type instanceof ParameterizedType && (clazz = (Class<?>) ((ParameterizedType) type).getRawType()) == ((GenericTypeInfo<?>) typeInfo)
+								.getTypeClass())) {
+					throw new InvalidTypesException("Generic object type '"
+							+ ((GenericTypeInfo<?>) typeInfo).getTypeClass().getCanonicalName() + "' expected but was '"
+							+ clazz.getCanonicalName() + "'.");
+				}
+			}
+		} else {
+			type = materializeTypeVariable(typeHierarchy, (TypeVariable<?>) type);
+			if (type != null) {
+				validateInfo(typeHierarchy, type, typeInfo);
+			}
+		}
+	}
+	
 	private static Type getParameterType(Class<?> baseClass, ArrayList<Type> typeHierarchy, Class<?> clazz, int pos) {
 		Type t = clazz.getGenericSuperclass();
-
+		
 		// check if type is child of the base class
 		if (!(t instanceof Class<?> && baseClass.isAssignableFrom((Class<?>) t))
 				&& !(t instanceof ParameterizedType && baseClass.isAssignableFrom((Class<?>) ((ParameterizedType) t).getRawType()))) {
@@ -121,7 +289,7 @@ public class TypeExtractor {
 		if (typeHierarchy != null) {
 			typeHierarchy.add(t);
 		}
-
+		
 		Type curT = t;
 		// go up the hierarchy until we reach the base class (with or without generics)
 		// collect the types while moving up for a later top-down 
@@ -130,7 +298,7 @@ public class TypeExtractor {
 			if (typeHierarchy != null) {
 				typeHierarchy.add(curT);
 			}
-
+			
 			// parameterized type
 			if (curT instanceof ParameterizedType) {
 				curT = ((Class<?>) ((ParameterizedType) curT).getRawType()).getGenericSuperclass();
@@ -140,44 +308,44 @@ public class TypeExtractor {
 				curT = ((Class<?>) curT).getGenericSuperclass();
 			}
 		}
-
+		
 		// check if immediate child of base class has generics
 		if (curT instanceof Class<?>) {
 			throw new InvalidTypesException("Function needs to be parameterized by using generics.");
 		}
-
+		
 		if (typeHierarchy != null) {
 			typeHierarchy.add(curT);
 		}
-
+		
 		ParameterizedType baseClassChild = (ParameterizedType) curT;
-
+		
 		return baseClassChild.getActualTypeArguments()[pos];
 	}
-
+	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private static <IN1, IN2, OUT> TypeInformation<OUT> createTypeInfoWithTypeHierarchy(ArrayList<Type> typeHierarchy, Type t,
 			TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
-
+		
 		// check if type is a subclass of tuple
 		if ((t instanceof Class<?> && Tuple.class.isAssignableFrom((Class<?>) t))
 				|| (t instanceof ParameterizedType && Tuple.class.isAssignableFrom((Class<?>) ((ParameterizedType) t).getRawType()))) {
-
+			
 			Type curT = t;
-
+			
 			// do not allow usage of Tuple as type
 			if (curT instanceof Class<?> && ((Class<?>) curT).equals(Tuple.class)) {
 				throw new InvalidTypesException(
 						"Usage of class Tuple as a type is not allowed. Use a concrete subclass (e.g. Tuple1, Tuple2, etc.) instead.");
 			}
-
+			
 			// go up the hierarchy until we reach immediate child of Tuple (with or without generics)
 			// collect the types while moving up for a later top-down 
 			while (!(curT instanceof ParameterizedType && ((Class<?>) ((ParameterizedType) curT).getRawType()).getSuperclass().equals(
 					Tuple.class))
 					&& !(curT instanceof Class<?> && ((Class<?>) curT).getSuperclass().equals(Tuple.class))) {
 				typeHierarchy.add(curT);
-
+				
 				// parameterized type
 				if (curT instanceof ParameterizedType) {
 					curT = ((Class<?>) ((ParameterizedType) curT).getRawType()).getGenericSuperclass();
@@ -187,16 +355,16 @@ public class TypeExtractor {
 					curT = ((Class<?>) curT).getGenericSuperclass();
 				}
 			}
-
+			
 			// check if immediate child of Tuple has generics
 			if (curT instanceof Class<?>) {
 				throw new InvalidTypesException("Tuple needs to be parameterized by using generics.");
 			}
-
+			
 			ParameterizedType tupleChild = (ParameterizedType) curT;
-
+			
 			Type[] subtypes = new Type[tupleChild.getActualTypeArguments().length];
-
+			
 			// materialize possible type variables
 			for (int i = 0; i < subtypes.length; i++) {
 				// materialize immediate TypeVariables
@@ -216,7 +384,7 @@ public class TypeExtractor {
 					subtypes[i] = tupleChild.getActualTypeArguments()[i];
 				}
 			}
-
+			
 			TypeInformation<?>[] tupleSubTypes = new TypeInformation<?>[subtypes.length];
 			for (int i = 0; i < subtypes.length; i++) {
 				// sub type could not be determined with materializing
@@ -225,7 +393,7 @@ public class TypeExtractor {
 					ParameterizedType immediateBaseChild = (ParameterizedType) typeHierarchy.get(typeHierarchy.size() - 1);
 					tupleSubTypes[i] = createTypeInfoWithImmediateBaseChildInput(immediateBaseChild, (TypeVariable<?>) subtypes[i],
 							in1Type, in2Type);
-
+					
 					// variable could not be determined
 					if (tupleSubTypes[i] == null) {
 						throw new InvalidTypesException("Type of TypeVariable '" + ((TypeVariable<?>) t).getName() + "' in '"
@@ -233,14 +401,14 @@ public class TypeExtractor {
 								+ "' could not be determined. This is most likely a type erasure problem.");
 					}
 				} else {
-					tupleSubTypes[i] = createTypeInfoWithTypeHierarchy(typeHierarchy, subtypes[i], in1Type, in2Type);
+					tupleSubTypes[i] = createTypeInfoWithTypeHierarchy(new ArrayList<Type>(typeHierarchy), subtypes[i], in1Type, in2Type);
 				}
 			}
-
+			
 			// TODO: Check that type that extends Tuple does not have additional fields.
 			// Right now, these fields are not be serialized by the TupleSerializer. 
 			// We might want to add an ExtendedTupleSerializer for that. 
-
+			
 			if (t instanceof Class<?>) {
 				return new TupleTypeInfo(((Class<? extends Tuple>) t), tupleSubTypes);
 			} else if (t instanceof ParameterizedType) {
@@ -251,7 +419,7 @@ public class TypeExtractor {
 		// e.g. class MyMapper<E> extends MapFunction<String, E>
 		else if (t instanceof TypeVariable) {
 			Type typeVar = materializeTypeVariable(typeHierarchy, (TypeVariable<?>) t);
-
+			
 			if (typeVar != null) {
 				return createTypeInfoWithTypeHierarchy(typeHierarchy, typeVar, in1Type, in2Type);
 			}
@@ -264,9 +432,9 @@ public class TypeExtractor {
 					return typeInfo;
 				} else {
 					throw new InvalidTypesException("Type of TypeVariable '" + ((TypeVariable<?>) t).getName() + "' in '"
-							+ ((TypeVariable<?>) t).getGenericDeclaration() + "' could not be determined. " +
-							"The type extraction currently supports types with generic variables only in cases where " +
-							"all variables in the return type can be deduced from the input type(s).");
+							+ ((TypeVariable<?>) t).getGenericDeclaration() + "' could not be determined. "
+							+ "The type extraction currently supports types with generic variables only in cases where "
+							+ "all variables in the return type can be deduced from the input type(s).");
 				}
 			}
 		}
@@ -275,43 +443,43 @@ public class TypeExtractor {
 		// since the JVM classifies e.g. String[] as GenericArrayType instead of Class)
 		else if (t instanceof GenericArrayType) {
 			GenericArrayType genericArray = (GenericArrayType) t;
-
+			
 			TypeInformation<?> componentInfo = createTypeInfoWithTypeHierarchy(typeHierarchy, genericArray.getGenericComponentType(),
 					in1Type, in2Type);
 			return ObjectArrayTypeInfo.getInfoFor(t, componentInfo);
 		}
 		// objects with generics are treated as raw type
 		else if (t instanceof ParameterizedType) {
-			return getForClass((Class<OUT>)((ParameterizedType) t).getRawType());
+			return getForClass((Class<OUT>) ((ParameterizedType) t).getRawType());
 		}
 		// no tuple, no TypeVariable, no generic type
 		else if (t instanceof Class) {
 			return getForClass((Class<OUT>) t);
 		}
-
+		
 		throw new InvalidTypesException("Type Information could not be created.");
 	}
-
+	
 	private static <IN1, IN2> TypeInformation<?> createTypeInfoWithImmediateBaseChildInput(ParameterizedType baseChild,
 			TypeVariable<?> typeVar, TypeInformation<IN1> in1Type, TypeInformation<IN2> in2Type) {
 		Type[] baseChildArgs = baseChild.getActualTypeArguments();
-
+		
 		TypeInformation<?> info = null;
 		if (in1Type != null) {
 			info = findCorrespondingInfo(typeVar, baseChildArgs[0], in1Type);
 		}
-
+		
 		if (info == null && in2Type != null) {
 			info = findCorrespondingInfo(typeVar, baseChildArgs[1], in2Type);
 		}
-
+		
 		if (info != null) {
 			return info;
 		}
-
+		
 		return null;
 	}
-
+	
 	private static TypeInformation<?> findCorrespondingInfo(TypeVariable<?> typeVar, Type type, TypeInformation<?> corrInfo) {
 		if (type instanceof TypeVariable) {
 			TypeVariable<?> variable = (TypeVariable<?>) type;
@@ -321,7 +489,7 @@ public class TypeExtractor {
 		} else if (type instanceof ParameterizedType && Tuple.class.isAssignableFrom((Class<?>) ((ParameterizedType) type).getRawType())) {
 			ParameterizedType tuple = (ParameterizedType) type;
 			Type[] args = tuple.getActualTypeArguments();
-
+			
 			for (int i = 0; i < args.length; i++) {
 				TypeInformation<?> info = findCorrespondingInfo(typeVar, args[i], ((TupleTypeInfo<?>) corrInfo).getTypeAt(i));
 				if (info != null) {
@@ -331,27 +499,27 @@ public class TypeExtractor {
 		}
 		return null;
 	}
-
+	
 	private static Type materializeTypeVariable(ArrayList<Type> typeHierarchy, TypeVariable<?> typeVar) {
-
+		
 		TypeVariable<?> inTypeTypeVar = typeVar;
 		// iterate thru hierarchy from top to bottom until type variable gets a class assigned
 		for (int i = typeHierarchy.size() - 1; i >= 0; i--) {
 			Type curT = typeHierarchy.get(i);
-
+			
 			// parameterized type
 			if (curT instanceof ParameterizedType) {
 				Class<?> rawType = ((Class<?>) ((ParameterizedType) curT).getRawType());
-
+				
 				for (int paramIndex = 0; paramIndex < rawType.getTypeParameters().length; paramIndex++) {
-
+					
 					TypeVariable<?> curVarOfCurT = rawType.getTypeParameters()[paramIndex];
-
+					
 					// check if variable names match
 					if (curVarOfCurT.getName().equals(inTypeTypeVar.getName())
 							&& curVarOfCurT.getGenericDeclaration().equals(inTypeTypeVar.getGenericDeclaration())) {
 						Type curVarType = ((ParameterizedType) curT).getActualTypeArguments()[paramIndex];
-
+						
 						// another type variable level
 						if (curVarType instanceof TypeVariable<?>) {
 							inTypeTypeVar = (TypeVariable<?>) curVarType;
@@ -367,16 +535,16 @@ public class TypeExtractor {
 		// can not be materialized, most likely due to type erasure
 		return null;
 	}
-
+	
 	@SuppressWarnings("unchecked")
 	public static <X> TypeInformation<X> getForClass(Class<X> clazz) {
 		Validate.notNull(clazz);
-
+		
 		// check for abstract classes or interfaces
 		if (Modifier.isInterface(clazz.getModifiers()) || (Modifier.isAbstract(clazz.getModifiers()) && !clazz.isArray())) {
 			throw new InvalidTypesException("Interfaces and abstract classes are not valid types.");
 		}
-
+		
 		// check for arrays
 		if (clazz.isArray()) {
 			// basic arrays
@@ -388,55 +556,55 @@ public class TypeExtractor {
 				return ObjectArrayTypeInfo.getInfoFor(clazz);
 			}
 		}
-
+		
 		// check for basic types
 		TypeInformation<X> basicTypeInfo = BasicTypeInfo.getInfoFor(clazz);
 		if (basicTypeInfo != null) {
 			return basicTypeInfo;
 		}
-
+		
 		// check for subclasses of Value
 		if (Value.class.isAssignableFrom(clazz)) {
 			Class<? extends Value> valueClass = clazz.asSubclass(Value.class);
 			return (TypeInformation<X>) ValueTypeInfo.getValueTypeInfo(valueClass);
 		}
-
+		
 		// check for subclasses of Tuple
 		if (Tuple.class.isAssignableFrom(clazz)) {
 			throw new InvalidTypesException("Type information extraction for tuples cannot be done based on the class.");
 		}
-
+		
 		// return a generic type
 		return new GenericTypeInfo<X>(clazz);
 	}
-
+	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static <X> TypeInformation<X> getForObject(X value) {
 		Validate.notNull(value);
-
+		
 		// check if we can extract the types from tuples, otherwise work with the class
 		if (value instanceof Tuple) {
 			Tuple t = (Tuple) value;
 			int numFields = t.getArity();
-
+			
 			TypeInformation<?>[] infos = new TypeInformation[numFields];
 			for (int i = 0; i < numFields; i++) {
 				Object field = t.getField(i);
-
+				
 				if (field == null) {
 					throw new InvalidTypesException("Automatic type extraction is not possible on candidates with null values. "
 							+ "Please specify the types directly.");
 				}
-
+				
 				infos[i] = getForObject(field);
 			}
-
+			
 			return (TypeInformation<X>) new TupleTypeInfo(value.getClass(), infos);
 		} else {
 			return getForClass((Class<X>) value.getClass());
 		}
 	}
-
+	
 	private TypeExtractor() {
 	}
 }

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/type/extractor/TypeExtractorTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/type/extractor/TypeExtractorTest.java
@@ -48,6 +48,8 @@ import eu.stratosphere.util.Collector;
 
 public class TypeExtractorTest {
 
+	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testBasicType() {
 		// use getGroupReduceReturnTypes()
@@ -60,7 +62,7 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getGroupReduceReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getGroupReduceReturnTypes(function, (TypeInformation) TypeInformation.parse("Boolean"));
 
 		Assert.assertTrue(ti.isBasicType());
 		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
@@ -74,6 +76,7 @@ public class TypeExtractorTest {
 		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, TypeExtractor.getForObject(Boolean.valueOf(true)));
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testTupleWithBasicTypes() throws Exception {
 		// use getMapReturnTypes()
@@ -88,7 +91,7 @@ public class TypeExtractorTest {
 
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple9<Integer, Long, Double, Float, Boolean, String, Character, Short, Byte>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(9, ti.getArity());
@@ -138,6 +141,7 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testTupleWithTuples() {
 		// use getFlatMapReturnTypes()
@@ -151,7 +155,7 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple3<Tuple1<String>, Tuple1<Integer>, Tuple2<Long, Long>>"));
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(3, ti.getArity());
 		Assert.assertTrue(ti instanceof TupleTypeInfo);
@@ -192,19 +196,20 @@ public class TypeExtractorTest {
 		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(2)).getTypeAt(1));
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testSubclassOfTuple() {
 		// use getJoinReturnTypes()
-		JoinFunction<?, ?, ?> function = new JoinFunction<String, String, CustomTuple>() {
+		JoinFunction<?, ?, ?> function = new JoinFunction<CustomTuple, String, CustomTuple>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public CustomTuple join(String first, String second) throws Exception {
+			public CustomTuple join(CustomTuple first, String second) throws Exception {
 				return null;
-			}
+			}			
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getJoinReturnTypes(function, null, null);
+		TypeInformation<?> ti = TypeExtractor.getJoinReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<String, Integer>"), (TypeInformation) TypeInformation.parse("String"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(2, ti.getArity());
@@ -239,19 +244,20 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testCustomType() {
 		// use getCrossReturnTypes()
-		CrossFunction<?, ?, ?> function = new CrossFunction<Integer, Integer, CustomType>() {
+		CrossFunction<?, ?, ?> function = new CrossFunction<CustomType, Integer, CustomType>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public CustomType cross(Integer first, Integer second) throws Exception {
+			public CustomType cross(CustomType first, Integer second) throws Exception {
 				return null;
-			}
+			}			
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getCrossReturnTypes(function, null, null);
+		TypeInformation<?> ti = TypeExtractor.getCrossReturnTypes(function, (TypeInformation) TypeInformation.parse("eu.stratosphere.api.java.type.extractor.TypeExtractorTest$CustomType"), (TypeInformation) TypeInformation.parse("Integer"));
 
 		Assert.assertFalse(ti.isBasicType());
 		Assert.assertFalse(ti.isTupleType());
@@ -285,19 +291,21 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testTupleWithCustomType() {
 		// use getMapReturnTypes()
-		MapFunction<?, ?> function = new MapFunction<String, Tuple2<Long, CustomType>>() {
+		MapFunction<?, ?> function = new MapFunction<Tuple2<Long, CustomType>, Tuple2<Long, CustomType>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Tuple2<Long, CustomType> map(String value) throws Exception {
+			public Tuple2<Long, CustomType> map(Tuple2<Long, CustomType> value) throws Exception {
 				return null;
 			}
+
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<Long,eu.stratosphere.api.java.type.extractor.TypeExtractorTest$CustomType>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(2, ti.getArity());
@@ -323,19 +331,20 @@ public class TypeExtractorTest {
 		Assert.assertEquals(CustomType.class, tti2.getTypeAt(1).getTypeClass());
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testValue() {
 		// use getKeyExtractorType()
-		KeySelector<?, ?> function = new KeySelector<String, StringValue>() {
+		KeySelector<?, ?> function = new KeySelector<StringValue, StringValue>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public StringValue getKey(String value) {
+			public StringValue getKey(StringValue value) {
 				return null;
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getKeyExtractorType(function, null);
+		TypeInformation<?> ti = TypeExtractor.getKeyExtractorType(function, (TypeInformation) TypeInformation.parse("StringValue"));
 
 		Assert.assertFalse(ti.isBasicType());
 		Assert.assertFalse(ti.isTupleType());
@@ -352,19 +361,20 @@ public class TypeExtractorTest {
 		Assert.assertEquals(TypeExtractor.getForObject(v).getTypeClass(), ti.getTypeClass());
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testTupleOfValues() {
 		// use getMapReturnTypes()
-		MapFunction<?, ?> function = new MapFunction<String, Tuple2<StringValue, IntValue>>() {
+		MapFunction<?, ?> function = new MapFunction<Tuple2<StringValue, IntValue>, Tuple2<StringValue, IntValue>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Tuple2<StringValue, IntValue> map(String value) throws Exception {
+			public Tuple2<StringValue, IntValue> map(Tuple2<StringValue, IntValue> value) throws Exception {
 				return null;
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<StringValue, IntValue>"));
 
 		Assert.assertFalse(ti.isBasicType());
 		Assert.assertTrue(ti.isTupleType());
@@ -390,19 +400,20 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testGenericsNotInSuperclass() {
 		// use getMapReturnTypes()
-		MapFunction<?, ?> function = new MapFunction<String, LongKeyValue<String>>() {
+		MapFunction<?, ?> function = new MapFunction<LongKeyValue<String>, LongKeyValue<String>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public LongKeyValue<String> map(String value) throws Exception {
+			public LongKeyValue<String> map(LongKeyValue<String> value) throws Exception {
 				return null;
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<Long, String>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(2, ti.getArity());
@@ -432,19 +443,20 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testChainedGenericsNotInSuperclass() {
 		// use TypeExtractor
-		MapFunction<?, ?> function = new MapFunction<String, ChainedTwo<Integer>>() {
+		MapFunction<?, ?> function = new MapFunction<ChainedTwo<Integer>, ChainedTwo<Integer>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public ChainedTwo<Integer> map(String value) throws Exception {
+			public ChainedTwo<Integer> map(ChainedTwo<Integer> value) throws Exception {
 				return null;
-			}
+			}			
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple3<String, Long, Integer>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(3, ti.getArity());
@@ -473,19 +485,20 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testGenericsInDirectSuperclass() {
 		// use TypeExtractor
-		MapFunction<?, ?> function = new MapFunction<String, ChainedThree>() {
+		MapFunction<?, ?> function = new MapFunction<ChainedThree, ChainedThree>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public ChainedFour map(String value) throws Exception {
+			public ChainedThree map(ChainedThree value) throws Exception {
 				return null;
-			}
+			}			
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple3<String, Long, String>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(3, ti.getArity());
@@ -498,19 +511,20 @@ public class TypeExtractorTest {
 		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(2));
 	}
 	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testGenericsNotInSuperclassWithNonGenericClassAtEnd() {
 		// use TypeExtractor
-		MapFunction<?, ?> function = new MapFunction<String, ChainedFour>() {
+		MapFunction<?, ?> function = new MapFunction<ChainedFour, ChainedFour>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public ChainedFour map(String value) throws Exception {
+			public ChainedFour map(ChainedFour value) throws Exception {
 				return null;
-			}
+			}			
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple3<String, Long, String>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(3, ti.getArity());
@@ -523,8 +537,8 @@ public class TypeExtractorTest {
 		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(2));
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
-	@SuppressWarnings("rawtypes")
 	public void testMissingTupleGenericsException() {
 		MapFunction<?, ?> function = new MapFunction<String, Tuple2>() {
 			private static final long serialVersionUID = 1L;
@@ -536,13 +550,14 @@ public class TypeExtractorTest {
 		};
 
 		try {
-			TypeExtractor.getMapReturnTypes(function, null);
+			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("String"));
 			Assert.fail("exception expected");
 		} catch (InvalidTypesException e) {
 			// right
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testTupleSupertype() {
 		MapFunction<?, ?> function = new MapFunction<String, Tuple>() {
@@ -555,7 +570,7 @@ public class TypeExtractorTest {
 		};
 
 		try {
-			TypeExtractor.getMapReturnTypes(function, null);
+			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("String"));
 			Assert.fail("exception expected");
 		} catch (InvalidTypesException e) {
 			// right
@@ -570,18 +585,19 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testSameGenericVariable() {
-		MapFunction<?, ?> function = new MapFunction<String, SameTypeVariable<String>>() {
+		MapFunction<?, ?> function = new MapFunction<SameTypeVariable<String>, SameTypeVariable<String>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public SameTypeVariable<String> map(String value) throws Exception {
+			public SameTypeVariable<String> map(SameTypeVariable<String> value) throws Exception {
 				return null;
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<String, String>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(2, ti.getArity());
@@ -601,18 +617,19 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testNestedTupleGenerics() {
-		MapFunction<?, ?> function = new MapFunction<String, Nested<String, Integer>>() {
+		MapFunction<?, ?> function = new MapFunction<Nested<String, Integer>, Nested<String, Integer>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Nested<String, Integer> map(String value) throws Exception {
+			public Nested<String, Integer> map(Nested<String, Integer> value) throws Exception {
 				return null;
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<String, Tuple2<Integer, Integer>>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(2, ti.getArity());
@@ -639,18 +656,19 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testNestedTupleGenerics2() {
-		MapFunction<?, ?> function = new MapFunction<String, Nested2<Boolean>>() {
+		MapFunction<?, ?> function = new MapFunction<Nested2<Boolean>, Nested2<Boolean>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Nested2<Boolean> map(String value) throws Exception {
+			public Nested2<Boolean> map(Nested2<Boolean> value) throws Exception {
 				return null;
 			}
 		};
-
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<Boolean, Tuple2<Tuple2<Integer, Tuple2<Boolean, Boolean>>, Tuple2<Integer, Tuple2<Boolean, Boolean>>>>"));
 
 		// Should be 
 		// Tuple2<Boolean, Tuple2<Tuple2<Integer, Tuple2<Boolean, Boolean>>, Tuple2<Integer, Tuple2<Boolean, Boolean>>>>
@@ -691,20 +709,21 @@ public class TypeExtractorTest {
 		};
 
 		try {
-			TypeExtractor.getMapReturnTypes(function, null);
+			TypeExtractor.getMapReturnTypes(function, TypeInformation.parse("String"));
 			Assert.fail("exception expected");
 		} catch (InvalidTypesException e) {
 			// right
 		}
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testFunctionDependingOnInputAsSuperclass() {
 		IdentityMapper<Boolean> function = new IdentityMapper<Boolean>() {
 			private static final long serialVersionUID = 1L;
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Boolean"));
 
 		Assert.assertTrue(ti.isBasicType());
 		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
@@ -763,16 +782,12 @@ public class TypeExtractorTest {
 		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testFunctionDependingOnInputWithCustomTupleInput() {
 		IdentityMapper<SameTypeVariable<String>> function = new IdentityMapper<SameTypeVariable<String>>();
 
-		// input (without type erasure)
-		IdentityMapper<SameTypeVariable<String>> input = new IdentityMapper<SameTypeVariable<String>>() {
-			private static final long serialVersionUID = 1L;
-		};
-
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, TypeExtractor.getMapReturnTypes(input, null));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<String, String>"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(2, ti.getArity());
@@ -851,11 +866,12 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testFunctionWithNoGenericSuperclass() {
 		MapFunction<?, ?> function = new Mapper2();
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("String"));
 
 		Assert.assertTrue(ti.isBasicType());
 		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
@@ -869,13 +885,14 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testFunctionDependingPartialOnInput() {
 		MapFunction<?, ?> function = new OneAppender<DoubleValue>() {
 			private static final long serialVersionUID = 1L;
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("DoubleValue"));
 
 		Assert.assertTrue(ti.isTupleType());
 		Assert.assertEquals(2, ti.getArity());
@@ -959,7 +976,7 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testAbstractAndInterfaceTypesException() {
-		MapFunction<?, ?> function = new MapFunction<String, Testable>() {
+		MapFunction<String, ?> function = new MapFunction<String, Testable>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -969,13 +986,13 @@ public class TypeExtractorTest {
 		};
 		
 		try {
-			TypeExtractor.getMapReturnTypes(function, null);
+			TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.STRING_TYPE_INFO);
 			Assert.fail("exception expected");
 		} catch (InvalidTypesException e) {
 			// good
 		}
 
-		MapFunction<?, ?> function2 = new MapFunction<String, AbstractClass>() {
+		MapFunction<String, ?> function2 = new MapFunction<String, AbstractClass>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -985,45 +1002,47 @@ public class TypeExtractorTest {
 		};
 
 		try {
-			TypeExtractor.getMapReturnTypes(function2, null);
+			TypeExtractor.getMapReturnTypes(function2, BasicTypeInfo.STRING_TYPE_INFO);
 			Assert.fail("exception expected");
 		} catch (InvalidTypesException e) {
 			// slick!
 		}
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testValueSupertypeException() {
-		MapFunction<?, ?> function = new MapFunction<Value, Value>() {
+		MapFunction<?, ?> function = new MapFunction<StringValue, Value>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Value map(Value value) throws Exception {
+			public Value map(StringValue value) throws Exception {
 				return null;
 			}
 		};
 
 		try {
-			TypeExtractor.getMapReturnTypes(function, null);
+			TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInformation.parse("StringValue"));
 			Assert.fail("exception expected");
 		} catch (InvalidTypesException e) {
 			// bam! go type extractor!
 		}
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testBasicArray() {
 		// use getCoGroupReturnTypes()
-		CoGroupFunction<?, ?, ?> function = new CoGroupFunction<String, String, String[]>() {
+		CoGroupFunction<?, ?, ?> function = new CoGroupFunction<String[], String[], String[]>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void coGroup(Iterator<String> first, Iterator<String> second, Collector<String[]> out) throws Exception {
+			public void coGroup(Iterator<String[]> first, Iterator<String[]> second, Collector<String[]> out) throws Exception {
 				// nothing to do
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getCoGroupReturnTypes(function, null, null);
+		TypeInformation<?> ti = TypeExtractor.getCoGroupReturnTypes(function, (TypeInformation) TypeInformation.parse("String[]"), (TypeInformation) TypeInformation.parse("String[]"));
 
 		Assert.assertFalse(ti.isBasicType());
 		Assert.assertFalse(ti.isTupleType());
@@ -1051,37 +1070,39 @@ public class TypeExtractorTest {
 		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, bati.getComponentInfo());
 	}
 
-	public class CustomArrayObject {}
+	public static class CustomArrayObject {}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testCustomArray() {
-		MapFunction<?, ?> function = new MapFunction<String, CustomArrayObject[]>() {
+		MapFunction<?, ?> function = new MapFunction<CustomArrayObject[], CustomArrayObject[]>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public CustomArrayObject[] map(String value) throws Exception {
+			public CustomArrayObject[] map(CustomArrayObject[] value) throws Exception {
 				return null;
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("eu.stratosphere.api.java.type.extractor.TypeExtractorTest$CustomArrayObject[]"));
 
 		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
 		Assert.assertEquals(CustomArrayObject.class, ((ObjectArrayTypeInfo<?, ?>) ti).getComponentType());
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testTupleArray() {
-		MapFunction<?, ?> function = new MapFunction<String, Tuple2<String, String>[]>() {
+		MapFunction<?, ?> function = new MapFunction<Tuple2<String, String>[], Tuple2<String, String>[]>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public Tuple2<String, String>[] map(String value) throws Exception {
+			public Tuple2<String, String>[] map(Tuple2<String, String>[] value) throws Exception {
 				return null;
 			}
 		};
-
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<String, String>[]"));
 
 		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
 		ObjectArrayTypeInfo<?, ?> oati = (ObjectArrayTypeInfo<?, ?>) ti;
@@ -1096,16 +1117,12 @@ public class TypeExtractorTest {
 
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testCustomArrayWithTypeVariable() {
 		MapFunction<CustomArrayObject2<Boolean>[], ?> function = new IdentityMapper<CustomArrayObject2<Boolean>[]>();
 
-		// input (without type erasure)
-		IdentityMapper<CustomArrayObject2<Boolean>[]> input = new IdentityMapper<CustomArrayObject2<Boolean>[]>() {
-			private static final long serialVersionUID = 1L;
-		};
-
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, TypeExtractor.getMapReturnTypes(input, null));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple1<Boolean>[]"));
 
 		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
 		ObjectArrayTypeInfo<?, ?> oati = (ObjectArrayTypeInfo<?, ?>) ti;
@@ -1114,44 +1131,123 @@ public class TypeExtractorTest {
 		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(0));
 	}
 	
-	public class GenericArrayClass<T> extends MapFunction<String, T[]> {
+	public class GenericArrayClass<T> extends MapFunction<T[], T[]> {
 		private static final long serialVersionUID = 1L;
 
 		@Override
-		public T[] map(String value) throws Exception {
+		public T[] map(T[] value) throws Exception {
 			return null;
 		}		
 	}
 	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testParameterizedArrays() {
 		GenericArrayClass<Boolean> function = new GenericArrayClass<Boolean>(){
 			private static final long serialVersionUID = 1L;			
 		};
 		
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Boolean[]"));
 		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?,?>);
 		ObjectArrayTypeInfo<?, ?> oati = (ObjectArrayTypeInfo<?, ?>) ti;
 		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, oati.getComponentInfo());
 	}
 	
-	public class MyObject<T> {
+	public static class MyObject<T> {
 		public T myField;
 	}
 	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testParamertizedCustomObject() {
-		MapFunction<?, ?> function = new MapFunction<Boolean, MyObject<String>>() {
+		MapFunction<?, ?> function = new MapFunction<MyObject<String>, MyObject<String>>() {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public MyObject<String> map(Boolean value) throws Exception {
+			public MyObject<String> map(MyObject<String> value) throws Exception {
 				return null;
 			}
 		};
 		
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, null);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("eu.stratosphere.api.java.type.extractor.TypeExtractorTest$MyObject"));
 		Assert.assertTrue(ti instanceof GenericTypeInfo<?>);
 	}
+	
+	@Test
+	public void testFunctionDependingOnInputWithTupleInputWithTypeMismatch() {
+	    IdentityMapper2<Boolean> function = new IdentityMapper2<Boolean>();
 
+	    TypeInformation<Tuple2<Boolean, String>> inputType = new TupleTypeInfo<Tuple2<Boolean, String>>(BasicTypeInfo.BOOLEAN_TYPE_INFO,
+	            BasicTypeInfo.INT_TYPE_INFO);
+	    
+	    // input is: Tuple2<Boolean, Integer>
+	    // allowed: Tuple2<?, String>
+
+	    try {
+	    	TypeExtractor.getMapReturnTypes(function, inputType);
+			Assert.fail("exception expected");
+		} catch (InvalidTypesException e) {
+			// right
+		}
+	}
+	
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testInputMismatchExceptions() {
+		
+		MapFunction<?, ?> function = new MapFunction<Tuple2<String, String>, String>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String map(Tuple2<String, String> value) throws Exception {
+				return null;
+			}
+		};
+		
+		try {
+	    	TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple2<Integer, String>"));
+			Assert.fail("exception expected");
+		} catch (InvalidTypesException e) {
+			// right
+		}
+		
+		try {
+	    	TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInformation.parse("Tuple3<String, String, String>"));
+			Assert.fail("exception expected");
+		} catch (InvalidTypesException e) {
+			// right
+		}
+		
+		MapFunction<?, ?> function2 = new MapFunction<StringValue, String>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String map(StringValue value) throws Exception {
+				return null;
+			}
+		};
+		
+		try {
+	    	TypeExtractor.getMapReturnTypes(function2, (TypeInformation) TypeInformation.parse("IntValue"));
+			Assert.fail("exception expected");
+		} catch (InvalidTypesException e) {
+			// right
+		}
+		
+		MapFunction<?, ?> function3 = new MapFunction<Tuple1<Integer>[], String>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public String map(Tuple1<Integer>[] value) throws Exception {
+				return null;
+			}
+		};
+		
+		try {
+	    	TypeExtractor.getMapReturnTypes(function3, (TypeInformation) TypeInformation.parse("Integer[]"));
+			Assert.fail("exception expected");
+		} catch (InvalidTypesException e) {
+			// right
+		}
+	}
 }


### PR DESCRIPTION
With this PR the TypeExtractor also validates the input parameters of a Function and compares them with the given TypeInformation. If there is an input mismatch, an Exception is thrown which helps the user to identify the problem e.g. "Basic type expected" etc.

See also #683

The PR also corrects the whitespace format and fixes a small TypeExtractor bug.

Test cases are also included.
