### PR TITLE
Add count method to DataSet and implement CountOperator

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/DataSet.java
@@ -14,6 +14,7 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java;
 
+import eu.stratosphere.api.java.operators.CountOperator;
 import org.apache.commons.lang3.Validate;
 
 import eu.stratosphere.api.common.io.FileOutputFormat;
@@ -213,6 +214,17 @@ public abstract class DataSet<T> {
 	 */
 	public AggregateOperator<T> aggregate(Aggregations agg, int field) {
 		return new AggregateOperator<T>(this, agg, field);
+	}
+
+	/**
+	 * Counts the number of elements in the DataSet.
+	 * <p>
+	 * The transformation returns a new data set of type DataSet<Long> with the count of elements.
+	 *
+	 * @return A CountOperator that represents the count of
+	 */
+	public CountOperator<T> count() {
+		return new CountOperator<T>(this);
 	}
 	
 	/**

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CountOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CountOperator.java
@@ -1,0 +1,68 @@
+/***********************************************************************************************************************
+ *
+ * Copyright (C) 2010-2014 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ **********************************************************************************************************************/
+package eu.stratosphere.api.java.operators;
+
+import eu.stratosphere.api.common.operators.Operator;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.functions.ReduceFunction;
+import eu.stratosphere.api.java.operators.translation.PlanMapOperator;
+import eu.stratosphere.api.java.operators.translation.PlanReduceOperator;
+import eu.stratosphere.api.java.typeutils.BasicTypeInfo;
+
+/**
+ * The CountOperator will be translated to a map and reduce function.
+ * <p/>
+ * The map function will map every input element to a 1 and the following reduce will sum up all ones.
+ *
+ * @param <IN> The type of the data set filtered by the operator.
+ */
+public class CountOperator<IN> extends SingleInputUdfOperator<IN, Long, CountOperator<IN>> {
+
+	public CountOperator(DataSet<IN> input) {
+		super(input, BasicTypeInfo.LONG_TYPE_INFO);
+	}
+
+	@Override
+	protected Operator translateToDataFlow(Operator input) {
+		PlanMapOperator<IN, Long> countMapOperator = new PlanMapOperator<IN, Long>(
+				new CountingMapUdf<IN>(), "Count: map to ones", getInputType(), BasicTypeInfo.LONG_TYPE_INFO);
+		countMapOperator.setInput(input);
+
+		PlanReduceOperator<Long> countReduceOperator = new PlanReduceOperator<Long>(
+				new CountingReduceUdf(), new int[0], "Count: sum up ones", BasicTypeInfo.LONG_TYPE_INFO);
+		countReduceOperator.setInput(countMapOperator);
+
+		return countReduceOperator;
+	}
+
+	// -----------------------------------------------------------------------------------------------------------------
+
+	public static class CountingMapUdf<IN> extends MapFunction<IN, Long> {
+
+		@Override
+		public Long map(IN value) throws Exception {
+			return 1L;
+		}
+	}
+
+	public static class CountingReduceUdf extends ReduceFunction<Long> {
+
+		@Override
+		public Long reduce(Long value1, Long value2) throws Exception {
+			return value1 + value2;
+		}
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CountOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CountOperator.java
@@ -40,10 +40,12 @@ public class CountOperator<IN> extends SingleInputUdfOperator<IN, Long, CountOpe
 		PlanMapOperator<IN, Long> countMapOperator = new PlanMapOperator<IN, Long>(
 				new CountingMapUdf<IN>(), "Count: map to ones", getInputType(), BasicTypeInfo.LONG_TYPE_INFO);
 		countMapOperator.setInput(input);
+		countMapOperator.setDegreeOfParallelism(input.getDegreeOfParallelism());
 
 		PlanReduceOperator<Long> countReduceOperator = new PlanReduceOperator<Long>(
 				new CountingReduceUdf(), new int[0], "Count: sum up ones", BasicTypeInfo.LONG_TYPE_INFO);
 		countReduceOperator.setInput(countMapOperator);
+		countReduceOperator.setDegreeOfParallelism(input.getDegreeOfParallelism());
 
 		return countReduceOperator;
 	}
@@ -52,6 +54,8 @@ public class CountOperator<IN> extends SingleInputUdfOperator<IN, Long, CountOpe
 
 	public static class CountingMapUdf<IN> extends MapFunction<IN, Long> {
 
+		private static final long serialVersionUID = 1L;
+
 		@Override
 		public Long map(IN value) throws Exception {
 			return 1L;
@@ -59,6 +63,8 @@ public class CountOperator<IN> extends SingleInputUdfOperator<IN, Long, CountOpe
 	}
 
 	public static class CountingReduceUdf extends ReduceFunction<Long> {
+
+		private static final long serialVersionUID = 1L;
 
 		@Override
 		public Long reduce(Long value1, Long value2) throws Exception {

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/CountITCase.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/javaApiOperators/CountITCase.java
@@ -1,0 +1,76 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2014 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.test.javaApiOperators;
+
+import eu.stratosphere.api.common.io.OutputFormat;
+import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.ExecutionEnvironment;
+import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.io.LocalCollectionOutputFormat;
+import eu.stratosphere.test.util.JavaProgramTestBase;
+import eu.stratosphere.util.Collector;
+import junit.framework.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CountITCase extends JavaProgramTestBase {
+
+	@Override
+	protected void testProgram() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		List<Long> countResults = new ArrayList<Long>();
+		OutputFormat<Long> localOutputFormat = new LocalCollectionOutputFormat<Long>(countResults);
+
+		DataSet<String> text = env.fromElements(
+				"Who's there?",
+				"I think I hear them. Stand, ho! Who's there?");
+
+		//  2 elements
+		text.count().output(localOutputFormat);
+
+		// 11 elements
+		text.flatMap(new LineSplitter()).count().output(localOutputFormat);
+
+//		Notice: Empty DataSets DO NOT WORK at the moment
+//
+//		If the DataSet on which count() is called is empty, there will be no call to the count operator (because there
+//      won't be anything emitted into the count operator in the translated data flow).
+//
+//		// 0 elements
+//		text.filter(new FilterAll()).output(localOutputFormat);
+
+		env.execute();
+
+		Assert.assertEquals(2, countResults.remove(0).longValue());
+		Assert.assertEquals(11, countResults.remove(0).longValue());
+	}
+
+	private static class LineSplitter extends FlatMapFunction<String, String> {
+		@Override
+		public void flatMap(String value, Collector<String> out) throws Exception {
+			for (String word : value.split(" ")) {
+				out.collect(word);
+			}
+		}
+	}
+
+//	private static class FilterAll extends FilterFunction<String> {
+//		@Override
+//		public boolean filter(String value) throws Exception {
+//			return false;
+//		}
+//	}
+}


### PR DESCRIPTION
At the request of @twalthr. This is the count operator I've implemented some time ago to get the to know the new Java API. It introduces `DataSet.count()`, which is executed as a map (to ones) and reduce (sum up the ones). I initially didn't do the PR, because of the following problem: empty DataSets don't work as the first map won't have any input to operate on.

If more people think that we should include this operator we can think about a possible solution to the problem.
