### PR TITLE
Generalised the name of the expected InputSplit class in HadoopDataSource.

### DIFF
--- a/stratosphere-addons/hadoop-compatibility/src/main/java/eu/stratosphere/hadoopcompatibility/HadoopInputSplitWrapper.java
+++ b/stratosphere-addons/hadoop-compatibility/src/main/java/eu/stratosphere/hadoopcompatibility/HadoopInputSplitWrapper.java
@@ -43,7 +43,7 @@ public class HadoopInputSplitWrapper implements InputSplit {
 	
 	public HadoopInputSplitWrapper(org.apache.hadoop.mapred.InputSplit hInputSplit, JobConf jobconf) {
 		this.hadoopInputSplit = hInputSplit;
-		this.hadoopInputSplitTypeName = hInputSplit.getClass().getCanonicalName();
+		this.hadoopInputSplitTypeName = hInputSplit.getClass().getName();
 		this.jobConf=jobconf;
 	}
 	


### PR DESCRIPTION
In order to get the name of an `InputSplit` class  `getCanonicalName()` has been used so far in `HadoopInputSplitWrapper`. This is ok for most cases, except for the case when the `InputSplit` is a nested class inside its `InputFormat` class. 

Specifically, here is an exact case:  https://github.com/Parquet/parquet-mr/blob/master/parquet-hadoop/src/main/java/parquet/hadoop/mapred/DeprecatedParquetInputFormat.java

This fixes https://github.com/stratosphere/stratosphere-experimental/issues/3
