### PR TITLE
TupleComparator fixed

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
@@ -105,7 +105,7 @@ public class TupleTypeInfo<T extends Tuple> extends TypeInformation<T> implement
 		if (logicalKeyFields.length == 1) {
 			return createSinglefieldComparator(logicalKeyFields[0], orders[0], types[logicalKeyFields[0]]);
 		}
-		
+				
 		int maxKey = logicalKeyFields[0];
 		for(int key : logicalKeyFields){
 			if (key > maxKey){
@@ -113,21 +113,21 @@ public class TupleTypeInfo<T extends Tuple> extends TypeInformation<T> implement
 			}
 		}
 		
-		boolean[] isKey = new boolean[maxKey];
+		boolean[] isKey = new boolean[maxKey + 1];
 		for(int key:logicalKeyFields){
 			isKey[key]=true;
 		}
 		
 		// create the comparators for the individual fields
 		TypeComparator<?>[] fieldComparators = new TypeComparator<?>[logicalKeyFields.length];
-		TypeSerializer<?>[] fieldSerializers = new TypeSerializer<?>[maxKey-logicalKeyFields.length];
+		TypeSerializer<?>[] fieldSerializers = new TypeSerializer<?>[maxKey + 1 -logicalKeyFields.length];
 		
 		int cIndex=0;
 		int sIndex=0;
-		for (int i = 0; i < maxKey; i++) {
+		for (int i = 0; i < maxKey + 1; i++) {
 			if(isKey[i]){
 				if (types[i].isKeyType() && types[i] instanceof AtomicType) {
-				fieldComparators[cIndex] = ((AtomicType<?>) types[i]).createComparator(orders[i]);
+				fieldComparators[cIndex] = ((AtomicType<?>) types[i]).createComparator(orders[cIndex]);
 				cIndex++;
 			} else {
 				throw new IllegalArgumentException("The field at position " + i + " (" + types[i] + ") is no atomic key type.");

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TupleTypeInfo.java
@@ -106,23 +106,38 @@ public class TupleTypeInfo<T extends Tuple> extends TypeInformation<T> implement
 			return createSinglefieldComparator(logicalKeyFields[0], orders[0], types[logicalKeyFields[0]]);
 		}
 		
-		// create the comparators for the individual fields
-		TypeComparator<?>[] fieldComparators = new TypeComparator<?>[logicalKeyFields.length];
-		
-		for (int i = 0; i < logicalKeyFields.length; i++) {
-			int field = logicalKeyFields[i];
-			
-			if (field < 0 || field >= types.length) {
-				throw new IllegalArgumentException("The field position " + field + " is out of range [0," + types.length + ")");
-			}
-			if (types[field].isKeyType() && types[field] instanceof AtomicType) {
-				fieldComparators[i] = ((AtomicType<?>) types[field]).createComparator(orders[i]);
-			} else {
-				throw new IllegalArgumentException("The field at position " + field + " (" + types[field] + ") is no atomic key type.");
+		int maxKey = logicalKeyFields[0];
+		for(int key : logicalKeyFields){
+			if (key > maxKey){
+				maxKey = key;
 			}
 		}
 		
-		return new TupleComparator<T>(logicalKeyFields, fieldComparators);
+		boolean[] isKey = new boolean[maxKey];
+		for(int key:logicalKeyFields){
+			isKey[key]=true;
+		}
+		
+		// create the comparators for the individual fields
+		TypeComparator<?>[] fieldComparators = new TypeComparator<?>[logicalKeyFields.length];
+		TypeSerializer<?>[] fieldSerializers = new TypeSerializer<?>[maxKey-logicalKeyFields.length];
+		
+		int cIndex=0;
+		int sIndex=0;
+		for (int i = 0; i < maxKey; i++) {
+			if(isKey[i]){
+				if (types[i].isKeyType() && types[i] instanceof AtomicType) {
+				fieldComparators[cIndex] = ((AtomicType<?>) types[i]).createComparator(orders[i]);
+				cIndex++;
+			} else {
+				throw new IllegalArgumentException("The field at position " + i + " (" + types[i] + ") is no atomic key type.");
+			}
+			}else{
+				fieldSerializers[sIndex] = types[i].createSerializer();
+				sIndex++;
+			}
+		}		
+		return new TupleComparator<T>(logicalKeyFields, fieldComparators, fieldSerializers);
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
@@ -132,7 +132,7 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 		try {
 			int code = 0;
 			for (; i < this.keyPositions.length; i++) {
-				code ^= this.comparators[i].hash(value.getField(i));
+				code ^= this.comparators[i].hash(value.getField(keyPositions[i]));
 				code *= HASH_SALT[i & 0x1F]; // salt code with (i % HASH_SALT.length)-th salt component
 			}
 			return code;
@@ -255,9 +255,9 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 			}
 			return 0;
 		} catch (NullPointerException npex) {
-			throw new NullKeyFieldException(this.keyPositions[fieldIndex]);
+			throw new NullKeyFieldException(fieldIndex);
 		} catch (IndexOutOfBoundsException iobex) {
-			throw new KeyFieldOutOfBoundsException(this.keyPositions[fieldIndex]);
+			throw new KeyFieldOutOfBoundsException(fieldIndex);
 		}
 	}
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
@@ -17,6 +17,7 @@ package eu.stratosphere.api.java.typeutils.runtime;
 import java.io.IOException;
 
 import eu.stratosphere.api.common.typeutils.TypeComparator;
+import eu.stratosphere.api.common.typeutils.TypeSerializer;
 import eu.stratosphere.api.java.tuple.Tuple;
 import eu.stratosphere.core.memory.DataInputView;
 import eu.stratosphere.core.memory.DataOutputView;
@@ -34,6 +35,8 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 	
 	private final TypeComparator<Object>[] comparators;
 	
+	private TypeSerializer<Object>[] serializer;
+	
 	private final int[] normalizedKeyLengths;
 	
 	private final int numLeadingNormalizableKeys;
@@ -42,9 +45,14 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 	
 	private final boolean invertNormKey;
 	
+	@SuppressWarnings("unchecked")
+	public TupleComparator(int[] keyPositions, TypeComparator<?>[] comparators, TypeSerializer<?>[] serializer) {
+		this(keyPositions, comparators);
+		this.serializer = (TypeSerializer<Object>[]) serializer;
+	}
 		
 	@SuppressWarnings("unchecked")
-	public TupleComparator(int[] keyPositions, TypeComparator<?>[] comparators) {
+	private TupleComparator(int[] keyPositions, TypeComparator<?>[] comparators) {
 		this.keyPositions = keyPositions;
 		this.comparators = (TypeComparator<Object>[]) comparators;
 		
@@ -54,7 +62,7 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 		int nKeyLen = 0;
 		boolean inverted = false;
 		
-		for (int i = 0; i < this.comparators.length; i++) {
+		for (int i = 0; i < this.keyPositions.length; i++) {
 			TypeComparator<?> k = this.comparators[i];
 			
 			// as long as the leading keys support normalized keys, we can build up the composite key
@@ -93,9 +101,15 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 	private TupleComparator(TupleComparator<T> toClone) {
 		this.keyPositions = toClone.keyPositions;
 		this.comparators = new TypeComparator[toClone.comparators.length];
+		this.serializer = new TypeSerializer[toClone.serializer.length];
 		
 		for (int i = 0; i < toClone.comparators.length; i++) {
 			this.comparators[i] = toClone.comparators[i].duplicate();
+		}
+		
+		for (int i = 0; i < toClone.serializer.length; i++) {
+			//this aint good
+			this.serializer[i] = toClone.serializer[i];
 		}
 		
 		this.normalizedKeyLengths = toClone.normalizedKeyLengths;
@@ -118,16 +132,16 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 		try {
 			int code = 0;
 			for (; i < this.keyPositions.length; i++) {
-				code ^= this.comparators[i].hash(value.getField(this.keyPositions[i]));
+				code ^= this.comparators[i].hash(value.getField(i));
 				code *= HASH_SALT[i & 0x1F]; // salt code with (i % HASH_SALT.length)-th salt component
 			}
 			return code;
 		}
 		catch (NullPointerException npex) {
-			throw new NullKeyFieldException(this.keyPositions[i]);
+			throw new NullKeyFieldException(i);
 		}
 		catch (IndexOutOfBoundsException iobex) {
-			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+			throw new KeyFieldOutOfBoundsException(i);
 		}
 	}
 
@@ -140,10 +154,10 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 			}
 		}
 		catch (NullPointerException npex) {
-			throw new NullKeyFieldException(this.keyPositions[i]);
+			throw new NullKeyFieldException(i);
 		}
 		catch (IndexOutOfBoundsException iobex) {
-			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+			throw new KeyFieldOutOfBoundsException(i);
 		}
 	}
 
@@ -159,10 +173,10 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 			return true;
 		}
 		catch (NullPointerException npex) {
-			throw new NullKeyFieldException(this.keyPositions[i]);
+			throw new NullKeyFieldException(i);
 		}
 		catch (IndexOutOfBoundsException iobex) {
-			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+			throw new KeyFieldOutOfBoundsException(i);
 		}
 	}
 
@@ -181,33 +195,72 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 			return 0;
 		}
 		catch (NullPointerException npex) {
-			throw new NullKeyFieldException(this.keyPositions[i]);
+			throw new NullKeyFieldException(i);
 		}
 		catch (IndexOutOfBoundsException iobex) {
-			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+			throw new KeyFieldOutOfBoundsException(i);
 		}
 	}
 
 	@Override
 	public int compare(DataInputView firstSource, DataInputView secondSource) throws IOException {
-		int i = 0;
+		boolean[] fieldUsedAsKey = new boolean[this.comparators.length + this.serializer.length];
+		for (int keyPosition : keyPositions) {
+			fieldUsedAsKey[keyPosition] = true;
+		}
+
+		int nextKeyPositionIndex = 0;
+		int totalLength = this.comparators.length + this.serializer.length;
+		int[] cmpCache = new int[totalLength];
+		boolean[] cmpWasCached = new boolean[totalLength];
+
+		int comparatorIndex = 0;
+		int serializerIndex = 0;
+
+		int fieldIndex = 0;
 		try {
-			for (; i < this.keyPositions.length; i++) {
-				int cmp = this.comparators[i].compare(firstSource, secondSource);
-				if (cmp != 0) {
-					return cmp;
+			for (; fieldIndex < totalLength; fieldIndex++) {
+				if (fieldUsedAsKey[fieldIndex]) {
+					int cmp = this.comparators[comparatorIndex].compare(firstSource, secondSource);
+					comparatorIndex++;
+					if (fieldIndex == keyPositions[nextKeyPositionIndex]) {
+						if (cmp != 0) {
+							return cmp;
+						}
+						nextKeyPositionIndex++;
+						if (nextKeyPositionIndex == this.comparators.length) {
+							return 0;
+						}
+						while (cmpWasCached[keyPositions[nextKeyPositionIndex]]) {
+							if (cmpCache[keyPositions[nextKeyPositionIndex]] != 0) {
+								return cmpCache[keyPositions[nextKeyPositionIndex]];
+							}
+							nextKeyPositionIndex++;
+							if (nextKeyPositionIndex == this.comparators.length) {
+								return 0;
+							}
+						}
+					} else {
+						cmpCache[fieldIndex] = cmp;
+						cmpWasCached[fieldIndex] = true;
+					}
+					if (nextKeyPositionIndex == keyPositions.length) {
+						return 0;
+					}
+				} else {
+					this.serializer[serializerIndex].deserialize(this.serializer[serializerIndex].createInstance(), firstSource);
+					this.serializer[serializerIndex].deserialize(this.serializer[serializerIndex].createInstance(), secondSource);
+					serializerIndex++;
 				}
 			}
 			return 0;
-		}
-		catch (NullPointerException npex) {
-			throw new NullKeyFieldException(this.keyPositions[i]);
-		}
-		catch (IndexOutOfBoundsException iobex) {
-			throw new KeyFieldOutOfBoundsException(this.keyPositions[i]);
+		} catch (NullPointerException npex) {
+			throw new NullKeyFieldException(this.keyPositions[fieldIndex]);
+		} catch (IndexOutOfBoundsException iobex) {
+			throw new KeyFieldOutOfBoundsException(this.keyPositions[fieldIndex]);
 		}
 	}
-
+	
 	@Override
 	public boolean supportsNormalizedKey() {
 		return this.numLeadingNormalizableKeys > 0;


### PR DESCRIPTION
The TupleComparator now:
- actually uses the key positions passed
- can skip positions
- supports any ordering ( you can compare on the second, and afterward on the first field )
