### PR TITLE
Disable LocalExecutor when using Client

### DIFF
--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/LocalExecutor.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/LocalExecutor.java
@@ -17,10 +17,12 @@ import java.util.List;
 
 import org.apache.log4j.Level;
 
+import eu.stratosphere.api.common.InvalidProgramException;
 import eu.stratosphere.api.common.JobExecutionResult;
 import eu.stratosphere.api.common.Plan;
 import eu.stratosphere.api.common.PlanExecutor;
 import eu.stratosphere.api.common.Program;
+import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.client.minicluster.NepheleMiniCluster;
 import eu.stratosphere.compiler.DataStatistics;
 import eu.stratosphere.compiler.PactCompiler;
@@ -65,6 +67,9 @@ public class LocalExecutor extends PlanExecutor {
 	public LocalExecutor() {
 		if (System.getProperty("log4j.configuration") == null) {
 			setLoggingLevel(Level.INFO);
+		}
+		if(!ExecutionEnvironment.localExecutionIsAllowed()) {
+			throw new InvalidProgramException("You cannot start a job in local execution mode when submitting a job from a client.");
 		}
 	}
 

--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/program/Client.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/program/Client.java
@@ -68,7 +68,7 @@ public class Client {
 		this.compiler = new PactCompiler(new DataStatistics(), new DefaultCostEstimator(), jobManagerAddress);
 		
 		//  Disable Local Execution when using a Client
-		ExecutionEnvironment.disableLocalExecution();
+		ContextEnvironment.disableLocalExecution();
 	}
 
 	/**
@@ -95,7 +95,7 @@ public class Client {
 		this.compiler = new PactCompiler(new DataStatistics(), new DefaultCostEstimator(), jobManagerAddress);
 		
 		//  Disable Local Execution when using a Client
-		ExecutionEnvironment.disableLocalExecution();
+		ContextEnvironment.disableLocalExecution();
 	}
 	
 	public void setPrintStatusDuringExecution(boolean print) {

--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/program/Client.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/program/Client.java
@@ -66,6 +66,9 @@ public class Client {
 		configuration.setInteger(ConfigConstants.JOB_MANAGER_IPC_PORT_KEY, jobManagerAddress.getPort());
 		
 		this.compiler = new PactCompiler(new DataStatistics(), new DefaultCostEstimator(), jobManagerAddress);
+		
+		//  Disable Local Execution when using a Client
+		ExecutionEnvironment.disableLocalExecution();
 	}
 
 	/**
@@ -90,6 +93,9 @@ public class Client {
 
 		final InetSocketAddress jobManagerAddress = new InetSocketAddress(address, port);
 		this.compiler = new PactCompiler(new DataStatistics(), new DefaultCostEstimator(), jobManagerAddress);
+		
+		//  Disable Local Execution when using a Client
+		ExecutionEnvironment.disableLocalExecution();
 	}
 	
 	public void setPrintStatusDuringExecution(boolean print) {

--- a/stratosphere-clients/src/main/java/eu/stratosphere/client/program/ContextEnvironment.java
+++ b/stratosphere-clients/src/main/java/eu/stratosphere/client/program/ContextEnvironment.java
@@ -65,4 +65,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	public void setAsContext() {
 		initializeContextEnvironment(this);
 	}
+	
+	protected static void disableLocalExecution() {
+		ExecutionEnvironment.disableLocalExecution();
+	}
 }

--- a/stratosphere-clients/src/test/java/eu/stratosphere/client/program/ClientTest.java
+++ b/stratosphere-clients/src/test/java/eu/stratosphere/client/program/ClientTest.java
@@ -29,7 +29,9 @@ import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import eu.stratosphere.api.common.InvalidProgramException;
 import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.client.LocalExecutor;
 import eu.stratosphere.compiler.DataStatistics;
 import eu.stratosphere.compiler.PactCompiler;
 import eu.stratosphere.compiler.costs.CostEstimator;
@@ -130,5 +132,17 @@ public class ClientTest {
 		program.deleteExtractedLibraries();
 		
 		verify(this.jobClientMock).submitJob();
+	}
+	
+	/**
+	 * @throws Exception
+	 */
+	@Test(expected=InvalidProgramException.class)
+	public void tryLocalExecution() throws Exception
+	{
+		when(jobSubmissionResultMock.getReturnCode()).thenReturn(ReturnCode.ERROR);
+		
+		Client out = new Client(configMock);
+		LocalExecutor.execute(planMock);
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -68,6 +68,8 @@ public abstract class ExecutionEnvironment {
 	
 	protected List<Tuple2<String, String>> cacheFile = new ArrayList<Tuple2<String, String>>();
 	
+	private static boolean allowLocalExecution = true;
+	
 	
 	// --------------------------------------------------------------------------------------------
 	//  Constructor and Properties
@@ -95,6 +97,14 @@ public abstract class ExecutionEnvironment {
 	
 	public String getIdString() {
 		return this.executionId.toString();
+	}
+	
+	public static boolean localExecutionIsAllowed() {
+		return allowLocalExecution;
+	}
+	
+	public static void disableLocalExecution() {
+		allowLocalExecution = false;
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -103,7 +103,7 @@ public abstract class ExecutionEnvironment {
 		return allowLocalExecution;
 	}
 	
-	public static void disableLocalExecution() {
+	protected static void disableLocalExecution() {
 		allowLocalExecution = false;
 	}
 	


### PR DESCRIPTION
If you submit a job using the Client, but use the LocalExecutor in your job by accident you can get weird results.
This pull requests makes the LocalExecutor throw an exception if an instance of Client was created before.
I'm not 100% happy with this implementation, since it absolutely prevents you from using LocalExecutor when you also want to create an Client instance, and perhaps there are some cases when you want to do this. What do you think?
