### PR TITLE
Small fix to get test to run under windows

### DIFF
--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/cache/FileCacheDeleteValidationTest.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/cache/FileCacheDeleteValidationTest.java
@@ -35,6 +35,7 @@ import eu.stratosphere.nephele.jobgraph.JobID;
 public class FileCacheDeleteValidationTest {
 	FileCache fileCache = new FileCache();
 	LocalFileSystem lfs = new LocalFileSystem();
+	File f;
 
 
 	String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
@@ -54,7 +55,7 @@ public class FileCacheDeleteValidationTest {
 
 	@Before
 	public void createTmpCacheFile() {
-		File f = new File(System.getProperty("java.io.tmpdir"), "cacheFile");
+		f = new File(System.getProperty("java.io.tmpdir"), "cacheFile");
 		try {
 			Files.write(testFileContent, f, Charsets.UTF_8);
 		} catch (IOException e) {
@@ -65,7 +66,7 @@ public class FileCacheDeleteValidationTest {
 	@Test
 	public void testFileReuseForNextTask() {
 		JobID jobID = new JobID();
-		String filePath = "file://" + new Path(System.getProperty("java.io.tmpdir"), "cacheFile").toString();
+		String filePath = f.toURI().toString();
 		fileCache.createTmpFile("test_file", filePath, jobID);
 		try {
 			Thread.sleep(1000);


### PR DESCRIPTION
This is a small fix to get the current version of stratosphere compiled under windows. I'm using the toUri() method instead of hardcoding the file URI.
