### PR TITLE
Serialized String comparison, Unicode support

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringComparator.java
@@ -39,9 +39,7 @@ public final class StringComparator extends BasicTypeComparator<String> {
 
 	@Override
 	public int compare(DataInputView firstSource, DataInputView secondSource) throws IOException {
-		String s1 = StringValue.readString(firstSource);
-		String s2 = StringValue.readString(secondSource);
-		int comp = s1.compareTo(s2); 
+		int comp = StringValue.compareUnicode(firstSource, secondSource);
 		return ascendingComparison ? comp : -comp;
 	}
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringSerializer.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/typeutils/base/StringSerializer.java
@@ -57,16 +57,16 @@ public class StringSerializer extends TypeSerializer<String> {
 
 	@Override
 	public void serialize(String record, DataOutputView target) throws IOException {
-		StringValue.writeString(record, target);
+		StringValue.writeUnicode(record, target);
 	}
 
 	@Override
 	public String deserialize(String record, DataInputView source) throws IOException {
-		return StringValue.readString(source);
+		return StringValue.readUnicode(source);
 	}
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		StringValue.copyString(source, target);
+		StringValue.copyUnicode(source, target);
 	}
 }

--- a/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
+++ b/stratosphere-core/src/test/java/eu/stratosphere/api/common/typeutils/base/StringSerializerTest.java
@@ -39,6 +39,6 @@ public class StringSerializerTest extends SerializerTestBase<String> {
 	
 	@Override
 	protected String[] getTestData() {
-		return new String[] {"a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
+		return new String[] {new String(Character.toChars(127315)), "a", "", "bcd", "jbmbmner8 jhk hj \n \t üäßß@µ", "", "non-empty"};
 	}
 }


### PR DESCRIPTION
The StringComparator now works on serialized data.

To this end new string read/write/copy/compare methods were introduced, which use a variable-length encoding for the characters. 

key-points:
- The most significant bits are written/read first.
- The first 2 bits of the character are used to encode the size of the character. 
- A character is at most 3 Bytes big.

Additionally, the StringSerializer now has full unicode support. i couldn't find a unicode character that uses more than 22 bits, as such 3 Bytes should be sufficient.
