### PR TITLE
JAPI String Annotations

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
@@ -13,71 +13,63 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.functions;
 
+import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.Retention;
 import java.util.HashSet;
 import java.util.Set;
-
-import com.google.common.primitives.Ints;
-
-import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
-import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
-import eu.stratosphere.api.common.operators.util.FieldSet;
-import eu.stratosphere.api.common.operators.util.UserCodeWrapper;
-import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 
 /**
  * This class defines the semantic assertions that can be added to functions.
  * The assertions are realized as java annotations, to be added to the class declaration of
- * the class that realized the user function. For example, to declare the <i>ConstantFieldsExcept</i> 
- * annotation for a map-type function that realizes a simple absolute function,
+ * the class that realized the user function. For example, to declare the <i>ConstantFields</i>
+ * annotation for a map-type function that simply copies some fields,
  * use it the following way:
- * 
+ *
  * <pre><blockquote>
- * \@ConstantFieldsExcept(value={1,2}, outTuplePos={2,1})
- * public class MyMapper extends FlatMapFunction<Tuple3<String, Integer, Integer>, Tuple3<String, Integer, Integer>>
+ * \@ConstantFields({"0->0,1", "1->2"})
+ * public class MyMapper extends FlatMapFunction<Tuple3<String, Integer, Integer>, Tuple3<String, String, Integer>>
  * {
- *     public void flatMap(Tuple3<String, Integer, Integer> value, Collector<Tuple3<String, Integer, Integer>> out) {
-			Integer tmp = value.f2;
-			value.f2 = value.f1;
-			value.f1 = tmp;
+ *     public void flatMap(Tuple3<String, Integer, Integer> value, Collector<Tuple3<String, String, Integer>> out) {
+			value.f2 = value.f1
+            value.f1 = value.f0;
 			out.collect(value);
 		}
  * }
  * </blockquote></pre>
- * 
- * Be aware that some annotations should only be used for functions with as single input 
- * ({@link MapFunction}, {@link ReduceFunction}) and some only for stubs with two inputs 
+ *
+ * Be aware that some annotations should only be used for functions with as single input
+ * ({@link MapFunction}, {@link ReduceFunction}) and some only for stubs with two inputs
  * ({@link CrossFunction}, {@link JoinFunction}, {@link CoGroupFunction}).
  */
 public class FunctionAnnotation {
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object that are unchanged in the output of 
+	 * Specifies the fields of an input tuple or custom object that are unchanged in the output of
 	 * a stub with a single input ( {@link MapFunction}, {@link ReduceFunction}).
-	 * 
-	 * A field is considered to be constant if its value is not changed and copied to the same position of 
+	 *
+	 * A field is considered to be constant if its value is not changed and copied to the same position of
 	 * output record.
-	 * 
-	 * The annotation takes two int or String arrays. For correct use, one or two parameters should be set. The
-	 * first array contains either integer positions of constant fields if tuples are used or the names of the fields
-	 * for custom types. If only input positions are specified, it is assumed that the positions in the output remain identical. If
-	 * a second parameter is set, it specifies the position of the values in the output data.
-	 * 
+	 *
+	 * The annotation takes one String array. The Strings represent the source and destination fields
+     * of the constant fields. The transition is represented by the string "->". The following would be a
+     * valid annotation "1->2,3".
+	 *
 	 * <b>
 	 * It is very important to follow a conservative strategy when specifying constant fields.
-	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be 
+	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be
 	 * inserted! Otherwise, the correct execution of a program can not be guaranteed.
 	 * So if in doubt, do not add a field to this set.
 	 * </b>
-	 * 
+	 *
 	 * This annotation is mutually exclusive with the {@link ConstantFieldsExcept} annotation.
-	 * 
-	 * If this annotation and the {@link ConstantFieldsExcept} annotation is not set, it is 
+	 *
+	 * If this annotation and the {@link ConstantFieldsExcept} annotation is not set, it is
 	 * assumed that <i>no</i> field is constant.
 	 *
 	 */
@@ -86,31 +78,30 @@ public class FunctionAnnotation {
 	public @interface ConstantFields {
 		String[] value();
 	}
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object of the first input that are unchanged in 
+	 * Specifies the fields of an input tuple or custom object of the first input that are unchanged in
 	 * the output of a stub with two inputs ( {@link CrossFunction}, {@link JoinFunction}, {@link CoGroupFunction})
-	 * 
-	 * A field is considered to be constant if its value is not changed and copied to the same position of 
+	 *
+	 * A field is considered to be constant if its value is not changed and copied to the same position of
 	 * output record.
-	 * 
-	 * The annotation takes two int or String arrays. For correct use, one or two parameters should be set. The
-	 * first array contains either integer positions of constant fields if tuples are used or the names of the fields
-	 * for custom types. If only input positions are specified, it is assumed that the positions in the output remain identical. If
-	 * a second parameter is set, it specifies the position of the values in the output data.
-	 * 
+	 *
+     * The annotation takes one String array. The Strings represent the source and destination fields
+     * of the constant fields. The transition is represented by the string "->". The following would be a
+     * valid annotation "1->2,3".
+	 *
 	 * <b>
 	 * It is very important to follow a conservative strategy when specifying constant fields.
-	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be 
+	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be
 	 * inserted! Otherwise, the correct execution of a program can not be guaranteed.
 	 * So if in doubt, do not add a field to this set.
 	 * </b>
 	 *
 	 * This annotation is mutually exclusive with the {@link ConstantFieldsFirstExcept} annotation.
-	 * 
-	 * If this annotation and the {@link ConstantFieldsFirstExcept} annotation is not set, it is 
+	 *
+	 * If this annotation and the {@link ConstantFieldsFirstExcept} annotation is not set, it is
 	 * assumed that <i>no</i> field is constant.
-	 * 
+	 *
 	 *
 	 */
 	@Target(ElementType.TYPE)
@@ -118,61 +109,59 @@ public class FunctionAnnotation {
 	public @interface ConstantFieldsFirst {
 		String[] value();
 	}
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object of the second input that are unchanged in 
+	 * Specifies the fields of an input tuple or custom object of the second input that are unchanged in
 	 * the output of a stub with two inputs ( {@link CrossFunction}, {@link JoinFunction}, {@link CoGroupFunction})
-	 * 
-	 * A field is considered to be constant if its value is not changed and copied to the same position of 
+	 *
+	 * A field is considered to be constant if its value is not changed and copied to the same position of
 	 * output record.
-	 * 
-	 * The annotation takes two int or String arrays. For correct use, one or two parameters should be set. The
-	 * first array contains either integer positions of constant fields if tuples are used or the names of the fields
-	 * for custom types. If only input positions are specified, it is assumed that the positions in the output remain identical. If
-	 * a second parameter is set, it specifies the position of the values in the output data.
-	 * 
+	 *
+     * The annotation takes one String array. The Strings represent the source and destination fields
+     * of the constant fields. The transition is represented by the string "->". The following would be a
+     * valid annotation "1->2,3".
+	 *
 	 * <b>
 	 * It is very important to follow a conservative strategy when specifying constant fields.
-	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be 
+	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be
 	 * inserted! Otherwise, the correct execution of a program can not be guaranteed.
 	 * So if in doubt, do not add a field to this set.
 	 * </b>
 	 *
 	 * This annotation is mutually exclusive with the {@link ConstantFieldsSecondExcept} annotation.
-	 * 
-	 * If this annotation and the {@link ConstantFieldsSecondExcept} annotation is not set, it is 
+	 *
+	 * If this annotation and the {@link ConstantFieldsSecondExcept} annotation is not set, it is
 	 * assumed that <i>no</i> field is constant.
-	 * 
+	 *
 	 */
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsSecond {
 		String[] value();
 	}
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object that are changed in the output of 
-	 * a stub with a single input ( {@link MapFunction}, {@link ReduceFunction}). All other 
+	 * Specifies the fields of an input tuple or custom object that are changed in the output of
+	 * a stub with a single input ( {@link MapFunction}, {@link ReduceFunction}). All other
 	 * fields are assumed to be constant.
-	 * 
-	 * A field is considered to be constant if its value is not changed and copied to the same position of 
+	 *
+	 * A field is considered to be constant if its value is not changed and copied to the same position of
 	 * output record.
-	 * 
-	 * The annotation takes one array specifying the positions of the input types that do not remain constant. This
-	 * is possible for custom types using the 'inCustomPos' parameter and for tuples using the 'inTuplePos' parameter.
+	 *
+	 * The annotation takes one String array specifying the positions of the input types that do not remain constant.
 	 * When this annotation is used, it is assumed that all other values remain at the same position in input and output. To model
 	 * more complex situations use the \@ConstantFields annotation.
-	 * 
+	 *
 	 * <b>
 	 * It is very important to follow a conservative strategy when specifying constant fields.
-	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be 
+	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be
 	 * inserted! Otherwise, the correct execution of a program can not be guaranteed.
 	 * So if in doubt, do not add a field to this set.
 	 * </b>
-	 * 
+	 *
 	 * This annotation is mutually exclusive with the {@link ConstantFields} annotation.
-	 * 
-	 * If this annotation and the {@link ConstantFields} annotation is not set, it is 
+	 *
+	 * If this annotation and the {@link ConstantFields} annotation is not set, it is
 	 * assumed that <i>no</i> field is constant.
 	 *
 	 */
@@ -181,99 +170,97 @@ public class FunctionAnnotation {
 	public @interface ConstantFieldsExcept {
 		String value();
 	}
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object of the first input that are changed in 
+	 * Specifies the fields of an input tuple or custom object of the first input that are changed in
 	 * the output of a stub with two inputs ( {@link CrossFunction}, {@link JoinFunction}, {@link CoGroupFunction})
 	 * All other fields are assumed to be constant.
-	 * 
-	 * A field is considered to be constant if its value is not changed and copied to the same position of 
+	 *
+	 * A field is considered to be constant if its value is not changed and copied to the same position of
 	 * output record.
-	 * 
-	 * The annotation takes one array specifying the positions of the input types that do not remain constant. This
-	 * is possible for custom types using the 'inCustomPos' parameter and for tuples using the 'inTuplePos' parameter.
-	 * When this annotation is used, it is assumed that all other values remain at the same position in input and output. To model
-	 * more complex situations use the \@ConstantFields annotation.
-	 * 
+	 *
+     * The annotation takes one String array specifying the positions of the input types that do not remain constant.
+     * When this annotation is used, it is assumed that all other values remain at the same position in input and output. To model
+     * more complex situations use the \@ConstantFields annotation.
+	 *
 	 * <b>
 	 * It is very important to follow a conservative strategy when specifying constant fields.
-	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be 
+	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be
 	 * inserted! Otherwise, the correct execution of a program can not be guaranteed.
 	 * So if in doubt, do not add a field to this set.
 	 * </b>
 	 *
 	 * This annotation is mutually exclusive with the {@link ConstantFieldsFirst} annotation.
-	 * 
-	 * If this annotation and the {@link ConstantFieldsFirst} annotation is not set, it is 
+	 *
+	 * If this annotation and the {@link ConstantFieldsFirst} annotation is not set, it is
 	 * assumed that <i>no</i> field is constant.
-	 * 
+	 *
 	 */
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsFirstExcept {
 		String value();
 	}
-	
-	
+
+
 	/**
-	 * Specifies the fields of an input tuple or custom object of the second input that are changed in 
+	 * Specifies the fields of an input tuple or custom object of the second input that are changed in
 	 * the output of a stub with two inputs ( {@link CrossFunction}, {@link JoinFunction}, {@link CoGroupFunction})
 	 * All other fields are assumed to be constant.
-	 * 
-	 * A field is considered to be constant if its value is not changed and copied to the same position of 
+	 *
+	 * A field is considered to be constant if its value is not changed and copied to the same position of
 	 * output record.
-	 * 
-	 * The annotation takes one array specifying the positions of the input types that do not remain constant. This
-	 * is possible for custom types using the 'inCustomPos' parameter and for tuples using the 'inTuplePos' parameter.
-	 * When this annotation is used, it is assumed that all other values remain at the same position in input and output. To model
-	 * more complex situations use the \@ConstantFields annotation.
-	 * 
+	 *
+     * The annotation takes one String array specifying the positions of the input types that do not remain constant.
+     * When this annotation is used, it is assumed that all other values remain at the same position in input and output. To model
+     * more complex situations use the \@ConstantFields annotation.
+	 *
 	 * <b>
 	 * It is very important to follow a conservative strategy when specifying constant fields.
-	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be 
+	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be
 	 * inserted! Otherwise, the correct execution of a program can not be guaranteed.
 	 * So if in doubt, do not add a field to this set.
 	 * </b>
 	 *
 	 * This annotation is mutually exclusive with the {@link ConstantFieldsSecond} annotation.
-	 * 
-	 * If this annotation and the {@link ConstantFieldsSecond} annotation is not set, it is 
+	 *
+	 * If this annotation and the {@link ConstantFieldsSecond} annotation is not set, it is
 	 * assumed that <i>no</i> field is constant.
-	 * 
+	 *
 	 */
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsSecondExcept {
 		String value();
 	}
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object that are accessed in the function. This annotation should be used
+	 * Specifies the fields of an input tuple that are accessed in the function. This annotation should be used
 	 * with user defined functions with one input.
 	 */
-	
+
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFields {
 		String value();
 	}
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object that are accessed in the function. This annotation should be used
+	 * Specifies the fields of an input tuple that are accessed in the function. This annotation should be used
 	 * with user defined functions with two inputs.
 	 */
-	
+
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFieldsSecond {
 		String value();
 	}
-	
+
 	/**
-	 * Specifies the fields of an input tuple or custom object that are accessed in the function. This annotation should be used
+	 * Specifies the fields of an input tuple that are accessed in the function. This annotation should be used
 	 * with user defined functions with two inputs.
 	 */
-	
+
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFieldsFirst {
@@ -283,106 +270,95 @@ public class FunctionAnnotation {
 	 * Private constructor to prevent instantiation. This class is intended only as a container.
 	 */
 	private FunctionAnnotation() {}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//                                   Function Annotation Handling
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Reads the annotations of a user defined function with one input and returns semantic properties according to the constant fields annotated.
 	 * @param udf	The user defined function.
-	 * @param input	Type information of the operator input.
-	 * @param output	Type information of the operator output.
 	 * @return	The DualInputSemanticProperties containing the constant fields.
 	 */
-	
-	public static Set<Annotation> readSingleConstantAnnotations(UserCodeWrapper<?> udf) {		
+
+	public static Set<Annotation> readSingleConstantAnnotations(UserCodeWrapper<?> udf) {
 		ConstantFields constantSet = udf.getUserCodeAnnotation(ConstantFields.class);
 		ConstantFieldsExcept notConstantSet = udf.getUserCodeAnnotation(ConstantFieldsExcept.class);
 		ReadFields readfieldSet = udf.getUserCodeAnnotation(ReadFields.class);
 
 		Set<Annotation> result = null;
-		
+
 		if (notConstantSet != null && constantSet != null) {
 			throw new RuntimeException("Either ConstantFields or ConstantFieldsExcept can be specified, not both.");
 		}
-		
+
 		if (notConstantSet != null) {
-			if (result == null) {
 				result = new HashSet<Annotation>();
-			}
+
 			result.add(notConstantSet);
 		}
 		if (constantSet != null) {
-			if (result == null) {
 				result = new HashSet<Annotation>();
-			}
+
 			result.add(constantSet);
 		}
-		
+
 		if (readfieldSet != null) {
 			if (result == null) {
 				result = new HashSet<Annotation>();
 			}
 			result.add(readfieldSet);
 		}
-		
+
 		return result;
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	/**
 	 * Reads the annotations of a user defined function with two inputs and returns semantic properties according to the constant fields annotated.
 	 * @param udf	The user defined function.
-	 * @param input1	Type information of the first operator input.
-	 * @param input2	Type information of the second operator input.
-	 * @param output	Type information of the operator output.
 	 * @return	The DualInputSemanticProperties containing the constant fields.
 	 */
-	
+
 	public static Set<Annotation> readDualConstantAnnotations(UserCodeWrapper<?> udf) {
 
 		// get readSet annotation from stub
 		ConstantFieldsFirst constantSet1 = udf.getUserCodeAnnotation(ConstantFieldsFirst.class);
 		ConstantFieldsSecond constantSet2= udf.getUserCodeAnnotation(ConstantFieldsSecond.class);
-			
+
 		// get readSet annotation from stub
 		ConstantFieldsFirstExcept notConstantSet1 = udf.getUserCodeAnnotation(ConstantFieldsFirstExcept.class);
 		ConstantFieldsSecondExcept notConstantSet2 = udf.getUserCodeAnnotation(ConstantFieldsSecondExcept.class);
-			
+
 		ReadFieldsFirst readfieldSet1 = udf.getUserCodeAnnotation(ReadFieldsFirst.class);
 		ReadFieldsSecond readfieldSet2 = udf.getUserCodeAnnotation(ReadFieldsSecond.class);
-		
+
 		if (notConstantSet1 != null && constantSet1 != null) {
 			throw new RuntimeException("Either ConstantFieldsFirst or ConstantFieldsFirstExcept can be specified, not both.");
 		}
-		
+
 		if (constantSet2 != null && notConstantSet2 != null) {
 			throw new RuntimeException("Either ConstantFieldsSecond or ConstantFieldsSecondExcept can be specified, not both.");
 		}
-		
+
 		Set<Annotation> result = null;
-		
+
 		if (notConstantSet2 != null) {
-			if (result == null) {
-				result = new HashSet<Annotation>();
-			}
+			result = new HashSet<Annotation>();
 			result.add(notConstantSet2);
 		}
 		if (constantSet2 != null) {
-			if (result == null) {
-				result = new HashSet<Annotation>();
-			}
+			result = new HashSet<Annotation>();
 			result.add(constantSet2);
 		}
-		
+
 		if (readfieldSet2 != null) {
 			if (result == null) {
 				result = new HashSet<Annotation>();
 			}
 			result.add(readfieldSet2);
 		}
-		
+
 		if (notConstantSet1 != null) {
 			if (result == null) {
 				result = new HashSet<Annotation>();
@@ -395,19 +371,19 @@ public class FunctionAnnotation {
 			}
 			result.add(constantSet1);
 		}
-		
+
 		if (readfieldSet1 != null) {
 			if (result == null) {
 				result = new HashSet<Annotation>();
 			}
 			result.add(readfieldSet1);
 		}
-		
+
 		return result;
 	}
-	
-	
-		
-		
+
+
+
+
 	}
 

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
@@ -179,7 +179,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsExcept {
-		String[] value();
+		String value();
 	}
 	
 	/**
@@ -211,7 +211,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsFirstExcept {
-		String[] value();
+		String value();
 	}
 	
 	
@@ -244,7 +244,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsSecondExcept {
-		String[] value();
+		String value();
 	}
 	
 	/**
@@ -255,7 +255,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFields {
-		String[] value();
+		String value();
 	}
 	
 	/**
@@ -266,7 +266,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFieldsSecond {
-		String[] value();
+		String value();
 	}
 	
 	/**
@@ -277,7 +277,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFieldsFirst {
-		String[] value();
+		String value();
 	}
 	/**
 	 * Private constructor to prevent instantiation. This class is intended only as a container.

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/FunctionAnnotation.java
@@ -13,10 +13,13 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.functions;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.google.common.primitives.Ints;
 
@@ -81,34 +84,8 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFields {
-		int[] value() default {};
-		int[] outTuplePos() default {};
-		String[] inCustomPos() default {};
-		String[] outCustomPos() default {};
+		String[] value();
 	}
-	
-	/**
-	 * Specifies that all fields of an input tuple or custom object that are unchanged in the output of 
-	 * a {@link MapFunction}, or {@link ReduceFunction}).
-	 * 
-	 * A field is considered to be constant if its value is not changed and copied to the same position of 
-	 * output record.
-	 * 
-	 * <b>
-	 * It is very important to follow a conservative strategy when specifying constant fields.
-	 * Only fields that are always constant (regardless of value, stub call, etc.) to the output may be 
-	 * inserted! Otherwise, the correct execution of a program can not be guaranteed.
-	 * So if in doubt, do not add a field to this set.
-	 * </b>
-	 * 
-	 * This annotation is mutually exclusive with the {@link ConstantFieldsExcept} annotation.
-	 * 
-	 * If this annotation and the {@link ConstantFieldsExcept} annotation is not set, it is 
-	 * assumed that <i>no</i> field is constant.
-	 */
-	@Target(ElementType.TYPE)
-	@Retention(RetentionPolicy.RUNTIME)
-	public @interface AllFieldsConstants {}
 	
 	/**
 	 * Specifies the fields of an input tuple or custom object of the first input that are unchanged in 
@@ -139,10 +116,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsFirst {
-		int[] value() default {};
-		int[] outTuplePos() default {};
-		String[] inCustomPos() default {};
-		String[] outCustomPos() default {};
+		String[] value();
 	}
 	
 	/**
@@ -173,10 +147,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsSecond {
-		int[] value() default {};
-		int[] outTuplePos() default {};
-		String[] outCustomPos() default {};
-		String[] inCustomPos() default {};
+		String[] value();
 	}
 	
 	/**
@@ -208,8 +179,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsExcept {
-		int[] value() default {};
-		String[] inCustomPos() default {};
+		String[] value();
 	}
 	
 	/**
@@ -241,8 +211,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsFirstExcept {
-		int[] value() default {};
-		String[] inCustomPos() default {};
+		String[] value();
 	}
 	
 	
@@ -275,8 +244,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ConstantFieldsSecondExcept {
-		int[] value() default {};
-		String[] inCustomPos() default {};
+		String[] value();
 	}
 	
 	/**
@@ -287,8 +255,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFields {
-		int[] value() default {};
-		String[] inCustomPos() default {};
+		String[] value();
 	}
 	
 	/**
@@ -299,8 +266,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFieldsSecond {
-		int[] value() default {};
-		String[] inCustomPos() default {};
+		String[] value();
 	}
 	
 	/**
@@ -311,8 +277,7 @@ public class FunctionAnnotation {
 	@Target(ElementType.TYPE)
 	@Retention(RetentionPolicy.RUNTIME)
 	public @interface ReadFieldsFirst {
-		int[] value() default {};
-		String[] inCustomPos() default {};
+		String[] value();
 	}
 	/**
 	 * Private constructor to prevent instantiation. This class is intended only as a container.
@@ -322,77 +287,6 @@ public class FunctionAnnotation {
 	// --------------------------------------------------------------------------------------------
 	//                                   Function Annotation Handling
 	// --------------------------------------------------------------------------------------------
-	private static boolean checkValidity(ConstantFields constantSet) {
-		int counter = 0;
-		if (constantSet.value().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.outTuplePos().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.outCustomPos().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.inCustomPos().length > 0) {
-			counter++;
-		};
-		
-		if (counter > 2) {
-			return false;
-		}
-		return true;
-	}
-	
-	private static boolean checkValidity(ConstantFieldsFirst constantSet) {
-		int counter = 0;
-		if (constantSet.value().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.outTuplePos().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.outCustomPos().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.inCustomPos().length > 0) {
-			counter++;
-		};
-		
-		if (counter > 2) {
-			return false;
-		}
-		return true;
-	}
-	
-	private static boolean checkValidity(ConstantFieldsSecond constantSet) {
-		int counter = 0;
-		if (constantSet.value().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.outTuplePos().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.outCustomPos().length > 0) {
-			counter++;
-		};
-		
-		if (constantSet.inCustomPos().length > 0) {
-			counter++;
-		};
-		
-		if (counter > 2) {
-			return false;
-		}
-		return true;
-	}
 	
 	/**
 	 * Reads the annotations of a user defined function with one input and returns semantic properties according to the constant fields annotated.
@@ -402,68 +296,38 @@ public class FunctionAnnotation {
 	 * @return	The DualInputSemanticProperties containing the constant fields.
 	 */
 	
-	public static SingleInputSemanticProperties readSingleConstantAnnotations(UserCodeWrapper<?> udf, TypeInformation<?> input, TypeInformation<?> output) {
-		if (!input.isTupleType() || !output.isTupleType()) {
-			return null;
-		}
-
-		
-		AllFieldsConstants allConstants = udf.getUserCodeAnnotation(AllFieldsConstants.class);
+	public static Set<Annotation> readSingleConstantAnnotations(UserCodeWrapper<?> udf) {		
 		ConstantFields constantSet = udf.getUserCodeAnnotation(ConstantFields.class);
 		ConstantFieldsExcept notConstantSet = udf.getUserCodeAnnotation(ConstantFieldsExcept.class);
 		ReadFields readfieldSet = udf.getUserCodeAnnotation(ReadFields.class);
-		
-		
-		int inputArity = input.getArity();
-		int outputArity = output.getArity();
 
-		if (notConstantSet != null && (constantSet != null || allConstants != null)) {
+		Set<Annotation> result = null;
+		
+		if (notConstantSet != null && constantSet != null) {
 			throw new RuntimeException("Either ConstantFields or ConstantFieldsExcept can be specified, not both.");
 		}
 		
-		if (constantSet != null && !checkValidity(constantSet)) {
-			throw new RuntimeException("Only two parameters of the annotation should be used at once.");
-		}
-		
-		SingleInputSemanticProperties semanticProperties = new SingleInputSemanticProperties();
-
-		if (readfieldSet != null && readfieldSet.value().length > 0) {
-			semanticProperties.setReadFields(new FieldSet(readfieldSet.value()));
-		}
-		
-		// extract notConstantSet from annotation
-		if (notConstantSet != null && notConstantSet.value().length > 0) {
-			for (int i = 0; i < inputArity && i < outputArity; i++) {
-				if (!Ints.contains(notConstantSet.value(), i)) {
-					semanticProperties.addForwardedField(i, i);
-				};
+		if (notConstantSet != null) {
+			if (result == null) {
+				result = new HashSet<Annotation>();
 			}
+			result.add(notConstantSet);
 		}
-		
-		if (allConstants != null) {
-			for (int i = 0; i < inputArity && i < outputArity; i++) {
-					semanticProperties.addForwardedField(i, i);
-			}
-		}
-		
-		
-		// extract constantSet from annotation
 		if (constantSet != null) {
-			if (constantSet.outTuplePos().length == 0 && constantSet.value().length > 0) {
-				for (int value: constantSet.value()) {
-					semanticProperties.addForwardedField(value,value);
-				}
-			} else if (constantSet.value().length == constantSet.outTuplePos().length && constantSet.value().length > 0) {
-				for (int i = 0; i < constantSet.value().length; i++) {
-					semanticProperties.addForwardedField(constantSet.value()[i], constantSet.outTuplePos()[i]);
-				}
-			} else {
-				throw new RuntimeException("Field 'from' and 'to' of the annotation should have the same length.");
+			if (result == null) {
+				result = new HashSet<Annotation>();
 			}
+			result.add(constantSet);
 		}
 		
-		return semanticProperties;
+		if (readfieldSet != null) {
+			if (result == null) {
+				result = new HashSet<Annotation>();
+			}
+			result.add(readfieldSet);
+		}
 		
+		return result;
 	}
 	
 	// --------------------------------------------------------------------------------------------
@@ -476,15 +340,8 @@ public class FunctionAnnotation {
 	 * @return	The DualInputSemanticProperties containing the constant fields.
 	 */
 	
-	public static DualInputSemanticProperties readDualConstantAnnotations(UserCodeWrapper<?> udf, TypeInformation<?> input1, TypeInformation<?> input2, TypeInformation<?> output) {
-		if (!input1.isTupleType() || !input2.isTupleType() || !output.isTupleType()) {
-			return null;
-		}
-		
-		int input1Arity = input1.getArity();
-		int input2Arity = input2.getArity();
-		int outputArity = output.getArity();
-				
+	public static Set<Annotation> readDualConstantAnnotations(UserCodeWrapper<?> udf) {
+
 		// get readSet annotation from stub
 		ConstantFieldsFirst constantSet1 = udf.getUserCodeAnnotation(ConstantFieldsFirst.class);
 		ConstantFieldsSecond constantSet2= udf.getUserCodeAnnotation(ConstantFieldsSecond.class);
@@ -504,67 +361,49 @@ public class FunctionAnnotation {
 			throw new RuntimeException("Either ConstantFieldsSecond or ConstantFieldsSecondExcept can be specified, not both.");
 		}
 		
-		if (constantSet1 != null && constantSet2 != null && (!checkValidity(constantSet1) || !checkValidity(constantSet2))) {
-			throw new RuntimeException("Only two parameters of the annotation should be used at once.");
-		}
+		Set<Annotation> result = null;
 		
-		DualInputSemanticProperties semanticProperties = new DualInputSemanticProperties();
-		
-		if (readfieldSet1 != null && readfieldSet2.value().length > 0) {
-			semanticProperties.setReadFields1(new FieldSet(readfieldSet1.value()));
-		}
-		
-		if (readfieldSet2 != null && readfieldSet2.value().length > 0) {
-			semanticProperties.setReadFields2(new FieldSet(readfieldSet2.value()));
-		}
-		
-		// extract readSets from annotations
-		if(notConstantSet1 != null && notConstantSet1.value().length > 0) {
-			for (int i = 0; i < input1Arity && i < outputArity; i++) {
-				if (!Ints.contains(notConstantSet1.value(), i)) {
-					semanticProperties.addForwardedField1(i, i);;
-				};
+		if (notConstantSet2 != null) {
+			if (result == null) {
+				result = new HashSet<Annotation>();
 			}
+			result.add(notConstantSet2);
 		}
-			
-		if(notConstantSet2 != null && notConstantSet2.value().length > 0) {
-			for (int i = 0; i < input2Arity && i < outputArity; i++) {
-				if (!Ints.contains(notConstantSet2.value(), i)) {
-					semanticProperties.addForwardedField2(i, i);;
-				};
-			}		
-		}
-				
-		// extract readSets from annotations
-		if (constantSet1 != null) {
-			if (constantSet1.outTuplePos().length == 0 && constantSet1.value().length > 0) {
-				for (int value: constantSet1.value()) {
-					semanticProperties.addForwardedField1(value,value);
-				}
-			} else if (constantSet1.value().length == constantSet1.outTuplePos().length && constantSet1.value().length > 0) {
-				for (int i = 0; i < constantSet1.value().length; i++) {
-					semanticProperties.addForwardedField1(constantSet1.value()[i], constantSet1.outTuplePos()[i]);
-				}
-			} else {
-				throw new RuntimeException("Field 'from' and 'to' of the annotation should have the same length.");
-			}
-		}
-				
 		if (constantSet2 != null) {
-			if (constantSet2.outTuplePos().length == 0 && constantSet1.value().length > 0) {
-				for (int value: constantSet2.value()) {
-					semanticProperties.addForwardedField1(value,value);
-				}
-			} else if (constantSet2.value().length == constantSet2.outTuplePos().length && constantSet2.value().length > 0) {
-				for (int i = 0; i < constantSet2.value().length; i++) {
-					semanticProperties.addForwardedField2(constantSet2.value()[i], constantSet2.outTuplePos()[i]);
-				}
-			} else {
-				throw new RuntimeException("Field 'from' and 'to' of the ConstantFields annotation should have the same length.");
+			if (result == null) {
+				result = new HashSet<Annotation>();
 			}
+			result.add(constantSet2);
 		}
-				
-		return semanticProperties;
+		
+		if (readfieldSet2 != null) {
+			if (result == null) {
+				result = new HashSet<Annotation>();
+			}
+			result.add(readfieldSet2);
+		}
+		
+		if (notConstantSet1 != null) {
+			if (result == null) {
+				result = new HashSet<Annotation>();
+			}
+			result.add(notConstantSet1);
+		}
+		if (constantSet1 != null) {
+			if (result == null) {
+				result = new HashSet<Annotation>();
+			}
+			result.add(constantSet1);
+		}
+		
+		if (readfieldSet1 != null) {
+			if (result == null) {
+				result = new HashSet<Annotation>();
+			}
+			result.add(readfieldSet1);
+		}
+		
+		return result;
 	}
 	
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
@@ -1,0 +1,52 @@
+package eu.stratosphere.api.java.functions;
+
+import java.lang.annotation.Annotation;
+import java.util.Iterator;
+import java.util.Set;
+
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFields;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFieldsExcept;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ReadFields;
+import eu.stratosphere.api.java.typeutils.TypeInformation;
+
+public class SemanticPropUtil {
+	public SingleInputSemanticProperties getSemanticPropsSingle(Set<Annotation> set, TypeInformation<?> inType, TypeInformation<?> outType) {
+		Iterator<Annotation> it = set.iterator();
+		SingleInputSemanticProperties result = null;
+		
+		while (it.hasNext()) {
+			if (result == null) {
+				result = new SingleInputSemanticProperties();
+			}
+			
+			Annotation ann = it.next();
+			
+			if (ann instanceof ConstantFields) {
+				ConstantFields cf = (ConstantFields) ann;
+			} else if (ann instanceof ConstantFieldsExcept) {
+				ConstantFieldsExcept cfe = (ConstantFieldsExcept) ann;
+			} else if (ann instanceof ReadFields) {
+				ReadFields rf = (ReadFields) ann;
+			}
+		}
+		return null;
+	}
+	
+	private void parseConstantFields(ConstantFields cf, SingleInputSemanticProperties sm) {
+		
+	}
+	
+	private void parseConstantFieldsExcept(ConstantFieldsExcept cfe, SingleInputSemanticProperties sm) {
+		
+	}
+	
+	private void parseReadFields(ReadFields rf, SingleInputSemanticProperties sm) {
+	
+	}
+	
+	public DualInputSemanticProperties getSemanticPropsDua(Set<Annotation> set, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
+		return null;
+	}
+}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
@@ -3,19 +3,37 @@ package eu.stratosphere.api.java.functions;
 import java.lang.annotation.Annotation;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SemanticProperties;
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
+import eu.stratosphere.api.common.operators.util.FieldSet;
 import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFields;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFieldsFirst;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFieldsSecond;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFieldsFirstExcept;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFieldsSecondExcept;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ReadFieldsFirst;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ReadFieldsSecond;
 import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFieldsExcept;
 import eu.stratosphere.api.java.functions.FunctionAnnotation.ReadFields;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class SemanticPropUtil {
-	public SingleInputSemanticProperties getSemanticPropsSingle(Set<Annotation> set, TypeInformation<?> inType, TypeInformation<?> outType) {
+
+    private final static String REGEX_ANNOTATION = "\\s*(\\d+)\\s*->(\\s*(\\d+\\s*,\\s*)*(\\d+\\s*))";
+
+    public static SingleInputSemanticProperties getSemanticPropsSingle(Set<Annotation> set, TypeInformation<?> inType, TypeInformation<?> outType) {
 		Iterator<Annotation> it = set.iterator();
 		SingleInputSemanticProperties result = null;
-		
+
+        //non tuple types are not yet supported for annotations
+        if (!inType.isTupleType() || !outType.isTupleType()) {
+            return null;
+        }
+
 		while (it.hasNext()) {
 			if (result == null) {
 				result = new SingleInputSemanticProperties();
@@ -25,28 +43,185 @@ public class SemanticPropUtil {
 			
 			if (ann instanceof ConstantFields) {
 				ConstantFields cf = (ConstantFields) ann;
-			} else if (ann instanceof ConstantFieldsExcept) {
+                parseConstantFields(cf.value(), result, inType, outType);
+            } else if (ann instanceof ConstantFieldsExcept) {
 				ConstantFieldsExcept cfe = (ConstantFieldsExcept) ann;
+                parseConstantFieldsExcept(cfe.value(), result, inType, outType);
 			} else if (ann instanceof ReadFields) {
 				ReadFields rf = (ReadFields) ann;
+                parseReadFields(rf.value(), result, inType, outType);
 			}
 		}
-		return null;
+		return result;
 	}
 	
-	private void parseConstantFields(ConstantFields cf, SingleInputSemanticProperties sm) {
-		
+	private static void parseConstantFields(String[] cf, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
+       for (String s: cf) {
+            readConstantSet(sm, s, inType, outType, 0);
+       }
+    }
+
+    private static void readConstantSet(SemanticProperties sp, String s, TypeInformation<?> inType, TypeInformation<?> outType, int input) {
+        Pattern check = Pattern.compile(REGEX_ANNOTATION);
+        Matcher matcher = check.matcher(s);
+        int sourceField = 0;
+
+        if (!matcher.matches()) {
+            throw new RuntimeException("Wrong annotation String format. Please read the documentation.");
+        }
+
+        sourceField = Integer.valueOf(matcher.group(1));
+        if (!isValidField(inType, sourceField)) {
+            throw new IndexOutOfBoundsException("Annotation: Field " + sourceField + " not available in the input tuple.");
+        }
+        FieldSet fs = readFieldSetFromString(matcher.group(2), inType, outType);
+
+        if (sp instanceof SingleInputSemanticProperties) {
+            ((SingleInputSemanticProperties) sp).addForwardedField(sourceField, fs);
+        } else if (sp instanceof  DualInputSemanticProperties) {
+            if (input == 0) {
+                ((DualInputSemanticProperties) sp).addForwardedField1(sourceField, fs);
+            } else if (input == 1) {
+                ((DualInputSemanticProperties) sp).addForwardedField2(sourceField, fs);
+            }
+        }
+    }
+
+    private static void parseConstantFieldsFirst(String[] cff,  DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        Pattern check = Pattern.compile(REGEX_ANNOTATION);
+        for (String s: cff) {
+            readConstantSet(dm, s, inType, outType, 0);
+        }
+    }
+
+    private static void parseConstantFieldsSecond(String[] cfs,  DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        Pattern check = Pattern.compile(REGEX_ANNOTATION);
+        for (String s: cfs) {
+            readConstantSet(dm, s, inType, outType, 1);
+        }
+    }
+
+    private static void parseConstantFieldsFirstExcept(String cffe, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        FieldSet fs = readFieldSetFromString(cffe, inType, outType);
+
+        for (int i = 0; i < outType.getArity(); i++) {
+            if (!fs.contains(i)) {
+                dm.addForwardedField1(i, i);
+            }
+        }
+    }
+
+    private static void parseConstantFieldsSecondExcept(String cfse, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        FieldSet fs = readFieldSetFromString(cfse, inType, outType);
+
+        for (int i = 0; i < outType.getArity(); i++) {
+            if (!fs.contains(i)) {
+                dm.addForwardedField2(i, i);
+            }
+        }
+    }
+
+    private static void parseReadFieldsFirst(String rf, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        FieldSet fs = readFieldSetFromString(rf, inType, outType);
+        dm.addReadFields1(fs);
+    }
+
+    private static void parseReadFieldsSecond(String rf, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        FieldSet fs = readFieldSetFromString(rf, inType, outType);
+        dm.addReadFields2(fs);
+    }
+
+
+    private static boolean isValidField(TypeInformation<?> type, int field) {
+        if (field > type.getArity() || field < 0) {
+            return false;
+        }
+        return true;
+    }
+
+	private static void parseConstantFieldsExcept(String cfe, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        FieldSet fs = readFieldSetFromString(cfe, inType, outType);
+
+        for (int i = 0; i < outType.getArity(); i++) {
+            if (!fs.contains(i)) {
+                sm.addForwardedField(i,i);
+            }
+        }
+    }
+
+    private static FieldSet readFieldSetFromString(String s, TypeInformation<?> inType, TypeInformation<?> outType) {
+        Pattern check = Pattern.compile("\\s*(\\d+\\s*,\\s*)*(\\d+\\s*)");
+        Pattern digit = Pattern.compile("\\d+");
+
+        Matcher matcher = check.matcher(s);
+
+        if (!matcher.matches()) {
+            throw new RuntimeException("Wrong annotation String format. Please read the documentation.");
+        }
+
+        matcher = digit.matcher(s);
+        FieldSet fs = new FieldSet();
+
+        while (matcher.find()) {
+            int field = Integer.valueOf(matcher.group());
+            if (!isValidField(outType, field) || !isValidField(inType, field)) {
+                throw new IndexOutOfBoundsException("Annotation: Field " + field + " not available in the output tuple.");
+            }
+            fs.add(field);
+        }
+        return fs;
+    }
+
+	private static void parseReadFields(String rf, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
+        FieldSet fs = readFieldSetFromString(rf, inType, outType);
+        sm.addReadFields(fs);
 	}
-	
-	private void parseConstantFieldsExcept(ConstantFieldsExcept cfe, SingleInputSemanticProperties sm) {
-		
-	}
-	
-	private void parseReadFields(ReadFields rf, SingleInputSemanticProperties sm) {
-	
-	}
-	
-	public DualInputSemanticProperties getSemanticPropsDua(Set<Annotation> set, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
-		return null;
+
+    public static SingleInputSemanticProperties getSemanticPropsSingleFromString(String[] ConstantSet, String constantSetExcept, String ReadSet, TypeInformation<?> inType, TypeInformation<?> outType) {
+        return null;
+    }
+
+    public static DualInputSemanticProperties getSemanticPropsDualFromString(String[] constantSetFirst, String[] constantSetSecond, String constantSetFirstExcept,
+                                                                             String constantSetSecondExcept, String readFieldsFirst, String readFieldsSecond, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
+        return null;
+    }
+
+	public static DualInputSemanticProperties getSemanticPropsDual(Set<Annotation> set, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
+        Iterator<Annotation> it = set.iterator();
+        DualInputSemanticProperties result = null;
+
+        //non tuple types are not yet supported for annotations
+        if (!inType1.isTupleType() || !inType2.isTupleType() || !outType.isTupleType()) {
+            return null;
+        }
+
+        while (it.hasNext()) {
+            if (result == null) {
+                result = new DualInputSemanticProperties();
+            }
+
+            Annotation ann = it.next();
+
+            if (ann instanceof ConstantFieldsFirst) {
+                ConstantFieldsFirst cff = (ConstantFieldsFirst) ann;
+                parseConstantFieldsFirst(cff.value(), result, inType1, outType);
+            } else  if (ann instanceof ConstantFieldsSecond) {
+                ConstantFieldsSecond cfs = (ConstantFieldsSecond) ann;
+                parseConstantFieldsSecond(cfs.value(), result, inType2, outType);
+            } else if (ann instanceof ConstantFieldsFirstExcept) {
+                ConstantFieldsFirstExcept cffe = (ConstantFieldsFirstExcept) ann;
+                parseConstantFieldsFirstExcept(cffe.value(), result, inType1, outType);
+            }  else if (ann instanceof ConstantFieldsSecondExcept) {
+                ConstantFieldsSecondExcept cfse = (ConstantFieldsSecondExcept) ann;
+                parseConstantFieldsSecondExcept(cfse.value(), result, inType2, outType);
+            } else if (ann instanceof ReadFieldsFirst) {
+                ReadFieldsFirst rff = (ReadFieldsFirst) ann;
+                parseReadFieldsFirst(rff.value(), result, inType1, outType);
+            } else if (ann instanceof ReadFieldsSecond) {
+                ReadFieldsSecond rfs = (ReadFieldsSecond) ann;
+                parseReadFieldsSecond(rfs.value(), result, inType2, outType);
+            }
+        }
+        return result;
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
@@ -1,3 +1,16 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
 package eu.stratosphere.api.java.functions;
 
 import java.lang.annotation.Annotation;
@@ -23,205 +36,257 @@ import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class SemanticPropUtil {
 
-    private final static String REGEX_ANNOTATION = "\\s*(\\d+)\\s*->(\\s*(\\d+\\s*,\\s*)*(\\d+\\s*))";
+	private final static String REGEX_ANNOTATION = "\\s*(\\d+)\\s*->(\\s*(\\d+\\s*,\\s*)*(\\d+\\s*))";
 
-    public static SingleInputSemanticProperties getSemanticPropsSingle(Set<Annotation> set, TypeInformation<?> inType, TypeInformation<?> outType) {
+	public static SingleInputSemanticProperties getSemanticPropsSingle(Set<Annotation> set, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (set == null) {
+			return null;
+		}
 		Iterator<Annotation> it = set.iterator();
 		SingleInputSemanticProperties result = null;
 
-        //non tuple types are not yet supported for annotations
-        if (!inType.isTupleType() || !outType.isTupleType()) {
-            return null;
-        }
+		//non tuple types are not yet supported for annotations
+		if (!inType.isTupleType() || !outType.isTupleType()) {
+			return null;
+		}
 
 		while (it.hasNext()) {
 			if (result == null) {
 				result = new SingleInputSemanticProperties();
 			}
-			
+
 			Annotation ann = it.next();
-			
+
 			if (ann instanceof ConstantFields) {
 				ConstantFields cf = (ConstantFields) ann;
-                parseConstantFields(cf.value(), result, inType, outType);
-            } else if (ann instanceof ConstantFieldsExcept) {
+				parseConstantFields(cf.value(), result, inType, outType);
+			} else if (ann instanceof ConstantFieldsExcept) {
 				ConstantFieldsExcept cfe = (ConstantFieldsExcept) ann;
-                parseConstantFieldsExcept(cfe.value(), result, inType, outType);
+				parseConstantFieldsExcept(cfe.value(), result, inType, outType);
 			} else if (ann instanceof ReadFields) {
 				ReadFields rf = (ReadFields) ann;
-                parseReadFields(rf.value(), result, inType, outType);
+				parseReadFields(rf.value(), result, inType, outType);
 			}
 		}
 		return result;
 	}
-	
+
 	private static void parseConstantFields(String[] cf, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
-       for (String s: cf) {
-            readConstantSet(sm, s, inType, outType, 0);
-       }
-    }
-
-    private static void readConstantSet(SemanticProperties sp, String s, TypeInformation<?> inType, TypeInformation<?> outType, int input) {
-        Pattern check = Pattern.compile(REGEX_ANNOTATION);
-        Matcher matcher = check.matcher(s);
-        int sourceField = 0;
-
-        if (!matcher.matches()) {
-            throw new RuntimeException("Wrong annotation String format. Please read the documentation.");
-        }
-
-        sourceField = Integer.valueOf(matcher.group(1));
-        if (!isValidField(inType, sourceField)) {
-            throw new IndexOutOfBoundsException("Annotation: Field " + sourceField + " not available in the input tuple.");
-        }
-        FieldSet fs = readFieldSetFromString(matcher.group(2), inType, outType);
-
-        if (sp instanceof SingleInputSemanticProperties) {
-            ((SingleInputSemanticProperties) sp).addForwardedField(sourceField, fs);
-        } else if (sp instanceof  DualInputSemanticProperties) {
-            if (input == 0) {
-                ((DualInputSemanticProperties) sp).addForwardedField1(sourceField, fs);
-            } else if (input == 1) {
-                ((DualInputSemanticProperties) sp).addForwardedField2(sourceField, fs);
-            }
-        }
-    }
-
-    private static void parseConstantFieldsFirst(String[] cff,  DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        Pattern check = Pattern.compile(REGEX_ANNOTATION);
-        for (String s: cff) {
-            readConstantSet(dm, s, inType, outType, 0);
-        }
-    }
-
-    private static void parseConstantFieldsSecond(String[] cfs,  DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        Pattern check = Pattern.compile(REGEX_ANNOTATION);
-        for (String s: cfs) {
-            readConstantSet(dm, s, inType, outType, 1);
-        }
-    }
-
-    private static void parseConstantFieldsFirstExcept(String cffe, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        FieldSet fs = readFieldSetFromString(cffe, inType, outType);
-
-        for (int i = 0; i < outType.getArity(); i++) {
-            if (!fs.contains(i)) {
-                dm.addForwardedField1(i, i);
-            }
-        }
-    }
-
-    private static void parseConstantFieldsSecondExcept(String cfse, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        FieldSet fs = readFieldSetFromString(cfse, inType, outType);
-
-        for (int i = 0; i < outType.getArity(); i++) {
-            if (!fs.contains(i)) {
-                dm.addForwardedField2(i, i);
-            }
-        }
-    }
-
-    private static void parseReadFieldsFirst(String rf, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        FieldSet fs = readFieldSetFromString(rf, inType, outType);
-        dm.addReadFields1(fs);
-    }
-
-    private static void parseReadFieldsSecond(String rf, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        FieldSet fs = readFieldSetFromString(rf, inType, outType);
-        dm.addReadFields2(fs);
-    }
-
-
-    private static boolean isValidField(TypeInformation<?> type, int field) {
-        if (field > type.getArity() || field < 0) {
-            return false;
-        }
-        return true;
-    }
-
-	private static void parseConstantFieldsExcept(String cfe, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        FieldSet fs = readFieldSetFromString(cfe, inType, outType);
-
-        for (int i = 0; i < outType.getArity(); i++) {
-            if (!fs.contains(i)) {
-                sm.addForwardedField(i,i);
-            }
-        }
-    }
-
-    private static FieldSet readFieldSetFromString(String s, TypeInformation<?> inType, TypeInformation<?> outType) {
-        Pattern check = Pattern.compile("\\s*(\\d+\\s*,\\s*)*(\\d+\\s*)");
-        Pattern digit = Pattern.compile("\\d+");
-
-        Matcher matcher = check.matcher(s);
-
-        if (!matcher.matches()) {
-            throw new RuntimeException("Wrong annotation String format. Please read the documentation.");
-        }
-
-        matcher = digit.matcher(s);
-        FieldSet fs = new FieldSet();
-
-        while (matcher.find()) {
-            int field = Integer.valueOf(matcher.group());
-            if (!isValidField(outType, field) || !isValidField(inType, field)) {
-                throw new IndexOutOfBoundsException("Annotation: Field " + field + " not available in the output tuple.");
-            }
-            fs.add(field);
-        }
-        return fs;
-    }
-
-	private static void parseReadFields(String rf, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
-        FieldSet fs = readFieldSetFromString(rf, inType, outType);
-        sm.addReadFields(fs);
+		if (cf == null) {
+			return;
+		}
+		for (String s : cf) {
+			readConstantSet(sm, s, inType, outType, 0);
+		}
 	}
 
-    public static SingleInputSemanticProperties getSemanticPropsSingleFromString(String[] ConstantSet, String constantSetExcept, String ReadSet, TypeInformation<?> inType, TypeInformation<?> outType) {
-        return null;
-    }
+	private static void readConstantSet(SemanticProperties sp, String s, TypeInformation<?> inType, TypeInformation<?> outType, int input) {
+		Pattern check = Pattern.compile(REGEX_ANNOTATION);
+		Matcher matcher = check.matcher(s);
+		int sourceField = 0;
 
-    public static DualInputSemanticProperties getSemanticPropsDualFromString(String[] constantSetFirst, String[] constantSetSecond, String constantSetFirstExcept,
-                                                                             String constantSetSecondExcept, String readFieldsFirst, String readFieldsSecond, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
-        return null;
-    }
+		if (!matcher.matches()) {
+			throw new RuntimeException("Wrong annotation String format. Please read the documentation.");
+		}
+
+		sourceField = Integer.valueOf(matcher.group(1));
+		if (!isValidField(inType, sourceField)) {
+			throw new IndexOutOfBoundsException("Annotation: Field " + sourceField + " not available in the input tuple.");
+		}
+		FieldSet fs = readFieldSetFromString(matcher.group(2), inType, outType);
+
+		if (sp instanceof SingleInputSemanticProperties) {
+			((SingleInputSemanticProperties) sp).addForwardedField(sourceField, fs);
+		} else if (sp instanceof DualInputSemanticProperties) {
+			if (input == 0) {
+				((DualInputSemanticProperties) sp).addForwardedField1(sourceField, fs);
+			} else if (input == 1) {
+				((DualInputSemanticProperties) sp).addForwardedField2(sourceField, fs);
+			}
+		}
+	}
+
+	private static void parseConstantFieldsFirst(String[] cff, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (cff == null) {
+			return;
+		}
+
+		Pattern check = Pattern.compile(REGEX_ANNOTATION);
+		for (String s : cff) {
+			readConstantSet(dm, s, inType, outType, 0);
+		}
+	}
+
+	private static void parseConstantFieldsSecond(String[] cfs, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (cfs == null) {
+			return;
+		}
+		Pattern check = Pattern.compile(REGEX_ANNOTATION);
+		for (String s : cfs) {
+			readConstantSet(dm, s, inType, outType, 1);
+		}
+	}
+
+	private static void parseConstantFieldsFirstExcept(String cffe, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (cffe == null) {
+			return;
+		}
+
+		FieldSet fs = readFieldSetFromString(cffe, inType, outType);
+
+		for (int i = 0; i < outType.getArity(); i++) {
+			if (!fs.contains(i)) {
+				dm.addForwardedField1(i, i);
+			}
+		}
+	}
+
+	private static void parseConstantFieldsSecondExcept(String cfse, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (cfse == null) {
+			return;
+		}
+
+		FieldSet fs = readFieldSetFromString(cfse, inType, outType);
+
+		for (int i = 0; i < outType.getArity(); i++) {
+			if (!fs.contains(i)) {
+				dm.addForwardedField2(i, i);
+			}
+		}
+	}
+
+	private static void parseReadFieldsFirst(String rf, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (rf == null) {
+			return;
+		}
+
+		FieldSet fs = readFieldSetFromString(rf, inType, outType);
+		dm.addReadFields1(fs);
+	}
+
+	private static void parseReadFieldsSecond(String rf, DualInputSemanticProperties dm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (rf == null) {
+			return;
+		}
+
+		FieldSet fs = readFieldSetFromString(rf, inType, outType);
+		dm.addReadFields2(fs);
+	}
+
+
+	private static boolean isValidField(TypeInformation<?> type, int field) {
+		if (field > type.getArity() || field < 0) {
+			return false;
+		}
+		return true;
+	}
+
+	private static void parseConstantFieldsExcept(String cfe, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (cfe == null) {
+			return;
+		}
+
+		FieldSet fs = readFieldSetFromString(cfe, inType, outType);
+
+		for (int i = 0; i < outType.getArity(); i++) {
+			if (!fs.contains(i)) {
+				sm.addForwardedField(i, i);
+			}
+		}
+	}
+
+	private static FieldSet readFieldSetFromString(String s, TypeInformation<?> inType, TypeInformation<?> outType) {
+		Pattern check = Pattern.compile("\\s*(\\d+\\s*,\\s*)*(\\d+\\s*)");
+		Pattern digit = Pattern.compile("\\d+");
+
+		Matcher matcher = check.matcher(s);
+
+		if (!matcher.matches()) {
+			throw new RuntimeException("Wrong annotation String format. Please read the documentation.");
+		}
+
+		matcher = digit.matcher(s);
+		FieldSet fs = new FieldSet();
+
+		while (matcher.find()) {
+			int field = Integer.valueOf(matcher.group());
+			if (!isValidField(outType, field) || !isValidField(inType, field)) {
+				throw new IndexOutOfBoundsException("Annotation: Field " + field + " not available in the output tuple.");
+			}
+			fs.add(field);
+		}
+		return fs;
+	}
+
+	private static void parseReadFields(String rf, SingleInputSemanticProperties sm, TypeInformation<?> inType, TypeInformation<?> outType) {
+		if (rf == null) {
+			return;
+		}
+
+		FieldSet fs = readFieldSetFromString(rf, inType, outType);
+		sm.addReadFields(fs);
+	}
+
+	public static SingleInputSemanticProperties getSemanticPropsSingleFromString(String[] constantSet, String constantSetExcept, String readSet, TypeInformation<?> inType, TypeInformation<?> outType) {
+		SingleInputSemanticProperties result = new SingleInputSemanticProperties();
+		parseConstantFields(constantSet, result, inType, outType);
+		parseConstantFieldsExcept(constantSetExcept, result, inType, outType);
+		parseReadFields(readSet, result, inType, outType);
+		return result;
+	}
+
+	public static DualInputSemanticProperties getSemanticPropsDualFromString(String[] constantSetFirst, String[] constantSetSecond, String constantSetFirstExcept,
+					String constantSetSecondExcept, String readFieldsFirst, String readFieldsSecond, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
+		DualInputSemanticProperties result = new DualInputSemanticProperties();
+		parseConstantFieldsFirst(constantSetFirst, result, inType1, outType);
+		parseConstantFieldsSecond(constantSetSecond, result, inType2, outType);
+		parseConstantFieldsFirstExcept(constantSetFirstExcept, result, inType1, outType);
+		parseConstantFieldsSecondExcept(constantSetSecondExcept, result, inType2, outType);
+		parseReadFieldsFirst(readFieldsFirst, result, inType1, outType);
+		parseReadFieldsSecond(readFieldsSecond, result, inType2, outType);
+		return result;
+	}
 
 	public static DualInputSemanticProperties getSemanticPropsDual(Set<Annotation> set, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
-        Iterator<Annotation> it = set.iterator();
-        DualInputSemanticProperties result = null;
+		if (set == null) {
+			return null;
+		}
 
-        //non tuple types are not yet supported for annotations
-        if (!inType1.isTupleType() || !inType2.isTupleType() || !outType.isTupleType()) {
-            return null;
-        }
+		Iterator<Annotation> it = set.iterator();
+		DualInputSemanticProperties result = null;
 
-        while (it.hasNext()) {
-            if (result == null) {
-                result = new DualInputSemanticProperties();
-            }
+		//non tuple types are not yet supported for annotations
+		if (!inType1.isTupleType() || !inType2.isTupleType() || !outType.isTupleType()) {
+			return null;
+		}
 
-            Annotation ann = it.next();
+		while (it.hasNext()) {
+			if (result == null) {
+				result = new DualInputSemanticProperties();
+			}
 
-            if (ann instanceof ConstantFieldsFirst) {
-                ConstantFieldsFirst cff = (ConstantFieldsFirst) ann;
-                parseConstantFieldsFirst(cff.value(), result, inType1, outType);
-            } else  if (ann instanceof ConstantFieldsSecond) {
-                ConstantFieldsSecond cfs = (ConstantFieldsSecond) ann;
-                parseConstantFieldsSecond(cfs.value(), result, inType2, outType);
-            } else if (ann instanceof ConstantFieldsFirstExcept) {
-                ConstantFieldsFirstExcept cffe = (ConstantFieldsFirstExcept) ann;
-                parseConstantFieldsFirstExcept(cffe.value(), result, inType1, outType);
-            }  else if (ann instanceof ConstantFieldsSecondExcept) {
-                ConstantFieldsSecondExcept cfse = (ConstantFieldsSecondExcept) ann;
-                parseConstantFieldsSecondExcept(cfse.value(), result, inType2, outType);
-            } else if (ann instanceof ReadFieldsFirst) {
-                ReadFieldsFirst rff = (ReadFieldsFirst) ann;
-                parseReadFieldsFirst(rff.value(), result, inType1, outType);
-            } else if (ann instanceof ReadFieldsSecond) {
-                ReadFieldsSecond rfs = (ReadFieldsSecond) ann;
-                parseReadFieldsSecond(rfs.value(), result, inType2, outType);
-            }
-        }
-        return result;
+			Annotation ann = it.next();
+
+			if (ann instanceof ConstantFieldsFirst) {
+				ConstantFieldsFirst cff = (ConstantFieldsFirst) ann;
+				parseConstantFieldsFirst(cff.value(), result, inType1, outType);
+			} else if (ann instanceof ConstantFieldsSecond) {
+				ConstantFieldsSecond cfs = (ConstantFieldsSecond) ann;
+				parseConstantFieldsSecond(cfs.value(), result, inType2, outType);
+			} else if (ann instanceof ConstantFieldsFirstExcept) {
+				ConstantFieldsFirstExcept cffe = (ConstantFieldsFirstExcept) ann;
+				parseConstantFieldsFirstExcept(cffe.value(), result, inType1, outType);
+			} else if (ann instanceof ConstantFieldsSecondExcept) {
+				ConstantFieldsSecondExcept cfse = (ConstantFieldsSecondExcept) ann;
+				parseConstantFieldsSecondExcept(cfse.value(), result, inType2, outType);
+			} else if (ann instanceof ReadFieldsFirst) {
+				ReadFieldsFirst rff = (ReadFieldsFirst) ann;
+				parseReadFieldsFirst(rff.value(), result, inType1, outType);
+			} else if (ann instanceof ReadFieldsSecond) {
+				ReadFieldsSecond rfs = (ReadFieldsSecond) ann;
+				parseReadFieldsSecond(rfs.value(), result, inType2, outType);
+			}
+		}
+		return result;
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
@@ -36,7 +36,7 @@ import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 public class SemanticPropUtil {
 
-	private final static String REGEX_ANNOTATION = "\\s*(\\d+)\\s*->(\\s*(\\d+\\s*,\\s*)*(\\d+\\s*))";
+	private final static String REGEX_ANNOTATION = "\\s*(\\d+)\\s*->((\\s*(\\d+\\s*,\\s*)*(\\d+\\s*))|(\\*))";
 
 	public static SingleInputSemanticProperties getSemanticPropsSingle(Set<Annotation> set, TypeInformation<?> inType, TypeInformation<?> outType) {
 		if (set == null) {
@@ -81,6 +81,23 @@ public class SemanticPropUtil {
 	}
 
 	private static void readConstantSet(SemanticProperties sp, String s, TypeInformation<?> inType, TypeInformation<?> outType, int input) {
+		if (s.equals("*")) {
+			if (sp instanceof SingleInputSemanticProperties) {
+				for (int i = 0; i < inType.getArity() && i < outType.getArity(); i++) {
+					((SingleInputSemanticProperties) sp).addForwardedField(i, i);
+				}
+			} else if (sp instanceof DualInputSemanticProperties) {
+				for (int i = 0; i < inType.getArity() && i < outType.getArity(); i++) {
+					if (input == 0) {
+						((DualInputSemanticProperties) sp).addForwardedField1(i, i);
+					} else if (input == 1) {
+						((DualInputSemanticProperties) sp).addForwardedField2(i, i);
+					}
+				}
+			}
+			return;
+		}
+
 		Pattern check = Pattern.compile(REGEX_ANNOTATION);
 		Matcher matcher = check.matcher(s);
 		int sourceField = 0;
@@ -93,7 +110,25 @@ public class SemanticPropUtil {
 		if (!isValidField(inType, sourceField)) {
 			throw new IndexOutOfBoundsException("Annotation: Field " + sourceField + " not available in the input tuple.");
 		}
-		FieldSet fs = readFieldSetFromString(matcher.group(2), inType, outType);
+
+		if (matcher.group(6) != null) {
+			if (sp instanceof SingleInputSemanticProperties) {
+				for (int i = 0; i < outType.getArity(); i++) {
+					((SingleInputSemanticProperties) sp).addForwardedField(sourceField, i);
+				}
+			} else if (sp instanceof DualInputSemanticProperties) {
+				for (int i = 0; i < outType.getArity(); i++) {
+					if (input == 0) {
+						((DualInputSemanticProperties) sp).addForwardedField1(sourceField, i);
+					} else if (input == 1) {
+						((DualInputSemanticProperties) sp).addForwardedField2(sourceField, i);
+					}
+				}
+			}
+			return;
+		}
+
+		FieldSet fs = readFieldSetFromString(matcher.group(3), inType, outType);
 
 		if (sp instanceof SingleInputSemanticProperties) {
 			((SingleInputSemanticProperties) sp).addForwardedField(sourceField, fs);
@@ -236,7 +271,7 @@ public class SemanticPropUtil {
 	}
 
 	public static DualInputSemanticProperties getSemanticPropsDualFromString(String[] constantSetFirst, String[] constantSetSecond, String constantSetFirstExcept,
-					String constantSetSecondExcept, String readFieldsFirst, String readFieldsSecond, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
+																			 String constantSetSecondExcept, String readFieldsFirst, String readFieldsSecond, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
 		DualInputSemanticProperties result = new DualInputSemanticProperties();
 		parseConstantFieldsFirst(constantSetFirst, result, inType1, outType);
 		parseConstantFieldsSecond(constantSetSecond, result, inType2, outType);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/functions/SemanticPropUtil.java
@@ -271,7 +271,7 @@ public class SemanticPropUtil {
 	}
 
 	public static DualInputSemanticProperties getSemanticPropsDualFromString(String[] constantSetFirst, String[] constantSetSecond, String constantSetFirstExcept,
-																			 String constantSetSecondExcept, String readFieldsFirst, String readFieldsSecond, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
+	String constantSetSecondExcept, String readFieldsFirst, String readFieldsSecond, TypeInformation<?> inType1, TypeInformation<?> inType2, TypeInformation<?> outType) {
 		DualInputSemanticProperties result = new DualInputSemanticProperties();
 		parseConstantFieldsFirst(constantSetFirst, result, inType1, outType);
 		parseConstantFieldsSecond(constantSetSecond, result, inType2, outType);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/CrossOperator.java
@@ -56,9 +56,9 @@ import eu.stratosphere.api.java.typeutils.TypeInformation;
  *
  * @see DataSet
  */
-public class CrossOperator<I1, I2, OUT> 
+public class CrossOperator<I1, I2, OUT>
 	extends TwoInputUdfOperator<I1, I2, OUT, CrossOperator<I1, I2, OUT>> {
-	
+
 	private final CrossFunction<I1, I2, OUT> function;
 
 	protected CrossOperator(DataSet<I1> input1, DataSet<I2> input2,
@@ -69,40 +69,44 @@ public class CrossOperator<I1, I2, OUT>
 
 		this.function = function;
 	}
-	
+
 	@Override
 	protected Operator translateToDataFlow(Operator input1, Operator input2) {
-		
+
 		String name = getName() != null ? getName() : function.getClass().getName();
 		// create operator
 		PlanCrossOperator<I1, I2, OUT> po = new PlanCrossOperator<I1, I2, OUT>(function, name, getInput1Type(), getInput2Type(), getResultType());
 		// set inputs
 		po.setFirstInput(input1);
 		po.setSecondInput(input2);
+		//set semantic properties
+		if (this.getSematicProperties() != null) {
+			po.setSemanticProperties(this.getSematicProperties());
+		}
 		// set dop
 		po.setDegreeOfParallelism(this.getParallelism());
-		
+
 		return po;
 	}
-	
+
 
 	// --------------------------------------------------------------------------------------------
 	// Builder classes for incremental construction
 	// --------------------------------------------------------------------------------------------
-	
+
 	public static final class DefaultCross<I1, I2> extends CrossOperator<I1, I2, Tuple2<I1, I2>>  {
-		
+
 		private final DataSet<I1> input1;
 		private final DataSet<I2> input2;
-		
+
 		public DefaultCross(DataSet<I1> input1, DataSet<I2> input2) {
-			super(input1, input2, (CrossFunction<I1, I2, Tuple2<I1, I2>>) new DefaultCrossFunction<I1, I2>(), 
+			super(input1, input2, (CrossFunction<I1, I2, Tuple2<I1, I2>>) new DefaultCrossFunction<I1, I2>(),
 					new TupleTypeInfo<Tuple2<I1, I2>>(input1.getType(), input2.getType()));
-			
+
 			if (input1 == null || input2 == null) {
 				throw new NullPointerException();
 			}
-			
+
 			this.input1 = input1;
 			this.input2 = input2;
 		}
@@ -192,16 +196,16 @@ public class CrossOperator<I1, I2, OUT>
 		/**
 		 * Instantiates and configures a ProjectCrossFunction.
 		 * Creates output tuples by copying fields of crossed input tuples (or a full input object) into an output tuple.
-		 * 
-		 * @param fields List of indexes fields that should be copied to the output tuple. 
-		 * 					If the full input object should be copied (for example in case of a non-tuple input) the index should be -1. 
+		 *
+		 * @param fields List of indexes fields that should be copied to the output tuple.
+		 * 					If the full input object should be copied (for example in case of a non-tuple input) the index should be -1.
 		 * @param isFromFirst List of flags indicating whether the field should be copied from the first (true) or the second (false) input.
 		 * @param outTupleInstance An instance of an output tuple.
 		 */
 		private ProjectCrossFunction(int[] fields, boolean[] isFromFirst, R outTupleInstance) {
-			
+
 			if(fields.length != isFromFirst.length) {
-				throw new IllegalArgumentException("Fields and isFromFirst arrays must have same length!"); 
+				throw new IllegalArgumentException("Fields and isFromFirst arrays must have same length!");
 			}
 			this.fields = fields;
 			this.isFromFirst = isFromFirst;
@@ -243,7 +247,7 @@ public class CrossOperator<I1, I2, OUT>
 
 			this.ds1 = ds1;
 			this.ds2 = ds2;
-			
+
 			boolean isFirstTuple;
 			boolean isSecondTuple;
 
@@ -300,7 +304,7 @@ public class CrossOperator<I1, I2, OUT>
 
 			if(isTuple) {
 				this.isFieldInFirst = new boolean[this.fieldIndexes.length];
-				
+
 				// check field indexes and adapt to position in tuple
 				int maxFieldIndex = firstInput ? numFieldsDs1 : numFieldsDs2;
 				for(int i=0; i<this.fieldIndexes.length; i++) {
@@ -461,12 +465,12 @@ public class CrossOperator<I1, I2, OUT>
 		// GENERATED FROM eu.stratosphere.api.java.tuple.TupleGenerator.
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -475,7 +479,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple1<T0>> tType = new TupleTypeInfo<Tuple1<T0>>(fTypes);
 
@@ -483,13 +487,13 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -498,7 +502,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple2<T0, T1>> tType = new TupleTypeInfo<Tuple2<T0, T1>>(fTypes);
 
@@ -506,14 +510,14 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -522,7 +526,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple3<T0, T1, T2>> tType = new TupleTypeInfo<Tuple3<T0, T1, T2>>(fTypes);
 
@@ -530,15 +534,15 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
 		 * @param type3 The class of field '3' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -547,7 +551,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple4<T0, T1, T2, T3>> tType = new TupleTypeInfo<Tuple4<T0, T1, T2, T3>>(fTypes);
 
@@ -555,16 +559,16 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
 		 * @param type3 The class of field '3' of the result tuples.
 		 * @param type4 The class of field '4' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -573,7 +577,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>> tType = new TupleTypeInfo<Tuple5<T0, T1, T2, T3, T4>>(fTypes);
 
@@ -581,9 +585,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -591,7 +595,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type4 The class of field '4' of the result tuples.
 		 * @param type5 The class of field '5' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -600,7 +604,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>> tType = new TupleTypeInfo<Tuple6<T0, T1, T2, T3, T4, T5>>(fTypes);
 
@@ -608,9 +612,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -619,7 +623,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type5 The class of field '5' of the result tuples.
 		 * @param type6 The class of field '6' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -628,7 +632,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>> tType = new TupleTypeInfo<Tuple7<T0, T1, T2, T3, T4, T5, T6>>(fTypes);
 
@@ -636,9 +640,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -648,7 +652,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type6 The class of field '6' of the result tuples.
 		 * @param type7 The class of field '7' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -657,7 +661,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>> tType = new TupleTypeInfo<Tuple8<T0, T1, T2, T3, T4, T5, T6, T7>>(fTypes);
 
@@ -665,9 +669,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -678,7 +682,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type7 The class of field '7' of the result tuples.
 		 * @param type8 The class of field '8' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -687,7 +691,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>> tType = new TupleTypeInfo<Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8>>(fTypes);
 
@@ -695,9 +699,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -709,7 +713,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type8 The class of field '8' of the result tuples.
 		 * @param type9 The class of field '9' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -718,7 +722,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>> tType = new TupleTypeInfo<Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>(fTypes);
 
@@ -726,9 +730,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -741,7 +745,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type9 The class of field '9' of the result tuples.
 		 * @param type10 The class of field '10' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -750,7 +754,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> tType = new TupleTypeInfo<Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>(fTypes);
 
@@ -758,9 +762,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -774,7 +778,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type10 The class of field '10' of the result tuples.
 		 * @param type11 The class of field '11' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -783,7 +787,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> tType = new TupleTypeInfo<Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>(fTypes);
 
@@ -791,9 +795,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -808,7 +812,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type11 The class of field '11' of the result tuples.
 		 * @param type12 The class of field '12' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -817,7 +821,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> tType = new TupleTypeInfo<Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>(fTypes);
 
@@ -825,9 +829,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -843,7 +847,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type12 The class of field '12' of the result tuples.
 		 * @param type13 The class of field '13' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -852,7 +856,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> tType = new TupleTypeInfo<Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>(fTypes);
 
@@ -860,9 +864,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -879,7 +883,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type13 The class of field '13' of the result tuples.
 		 * @param type14 The class of field '14' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -888,7 +892,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> tType = new TupleTypeInfo<Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>(fTypes);
 
@@ -896,9 +900,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -916,7 +920,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type14 The class of field '14' of the result tuples.
 		 * @param type15 The class of field '15' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -925,7 +929,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> tType = new TupleTypeInfo<Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>(fTypes);
 
@@ -933,9 +937,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -954,7 +958,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type15 The class of field '15' of the result tuples.
 		 * @param type16 The class of field '16' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -963,7 +967,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> tType = new TupleTypeInfo<Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>>(fTypes);
 
@@ -971,9 +975,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -993,7 +997,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type16 The class of field '16' of the result tuples.
 		 * @param type17 The class of field '17' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -1002,7 +1006,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> tType = new TupleTypeInfo<Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>>(fTypes);
 
@@ -1010,9 +1014,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -1033,7 +1037,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type17 The class of field '17' of the result tuples.
 		 * @param type18 The class of field '18' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -1042,7 +1046,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> tType = new TupleTypeInfo<Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>>(fTypes);
 
@@ -1050,9 +1054,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -1074,7 +1078,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type18 The class of field '18' of the result tuples.
 		 * @param type19 The class of field '19' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -1083,7 +1087,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> tType = new TupleTypeInfo<Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>>(fTypes);
 
@@ -1091,9 +1095,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -1116,7 +1120,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type19 The class of field '19' of the result tuples.
 		 * @param type20 The class of field '20' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -1125,7 +1129,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> tType = new TupleTypeInfo<Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>>(fTypes);
 
@@ -1133,9 +1137,9 @@ public class CrossOperator<I1, I2, OUT>
 		}
 
 		/**
-		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields. 
-		 * Requires the classes of the fields of the resulting tuples. 
-		 * 
+		 * Projects a pair of crossed elements to a {@link Tuple} with the previously selected fields.
+		 * Requires the classes of the fields of the resulting tuples.
+		 *
 		 * @param type0 The class of field '0' of the result tuples.
 		 * @param type1 The class of field '1' of the result tuples.
 		 * @param type2 The class of field '2' of the result tuples.
@@ -1159,7 +1163,7 @@ public class CrossOperator<I1, I2, OUT>
 		 * @param type20 The class of field '20' of the result tuples.
 		 * @param type21 The class of field '21' of the result tuples.
 		 * @return The projected data set.
-		 * 
+		 *
 		 * @see Tuple
 		 * @see DataSet
 		 */
@@ -1168,7 +1172,7 @@ public class CrossOperator<I1, I2, OUT>
 			if(types.length != this.fieldIndexes.length) {
 				throw new IllegalArgumentException("Numbers of projected fields and types do not match.");
 			}
-			
+
 			TypeInformation<?>[] fTypes = extractFieldTypes(fieldIndexes, types);
 			TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> tType = new TupleTypeInfo<Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>>(fTypes);
 
@@ -1209,11 +1213,11 @@ public class CrossOperator<I1, I2, OUT>
 			return fieldTypes;
 		}
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//  default join functions
 	// --------------------------------------------------------------------------------------------
-	
+
 	public static final class DefaultCrossFunction<T1, T2> extends CrossFunction<T1, T2, Tuple2<T1, T2>> {
 
 		private static final long serialVersionUID = 1L;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceGroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/ReduceGroupOperator.java
@@ -34,134 +34,142 @@ import eu.stratosphere.api.java.typeutils.TypeInformation;
  * @param <OUT> The type of the data set created by the operator.
  */
 public class ReduceGroupOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, ReduceGroupOperator<IN, OUT>> {
-	
+
 	private final GroupReduceFunction<IN, OUT> function;
-	
+
 	private final Grouping<IN> grouper;
-	
+
 	private boolean combinable;
-	
-	
+
+
 	public ReduceGroupOperator(DataSet<IN> input, GroupReduceFunction<IN, OUT> function) {
 		super(input, TypeExtractor.getGroupReduceReturnTypes(function, input.getType()));
-		
+
 		if (function == null) {
 			throw new NullPointerException("GroupReduce function must not be null.");
 		}
-		
+
 		this.function = function;
 		this.grouper = null;
 	}
-	
+
 	public ReduceGroupOperator(Grouping<IN> input, GroupReduceFunction<IN, OUT> function) {
 		super(input != null ? input.getDataSet() : null, TypeExtractor.getGroupReduceReturnTypes(function, input.getDataSet().getType()));
-		
+
 		if (function == null) {
 			throw new NullPointerException("GroupReduce function must not be null.");
 		}
-		
+
 		this.function = function;
 		this.grouper = input;
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	//  Properties
 	// --------------------------------------------------------------------------------------------
-	
+
 	public boolean isCombinable() {
 		return combinable;
 	}
-	
+
 	public void setCombinable(boolean combinable) {
 		this.combinable = combinable;
 	}
-	
+
 	@Override
 	protected Operator translateToDataFlow(Operator input) {
-		
+
 		String name = getName() != null ? getName() : function.getClass().getName();
-		
+
 		// distinguish between grouped reduce and non-grouped reduce
 		if (grouper == null) {
 			// non grouped reduce
-			PlanGroupReduceOperator<IN, OUT> po = 
+			PlanGroupReduceOperator<IN, OUT> po =
 					new PlanGroupReduceOperator<IN, OUT>(function, new int[0], name, getInputType(), getResultType());
 			// set input
 			po.setInput(input);
+			//set semantic properties
+			if (this.getSematicProperties() != null) {
+				po.setSemanticProperties(this.getSematicProperties());
+			}
 			// set dop
 			po.setDegreeOfParallelism(this.getParallelism());
-			
+
 			return po;
 		}
-	
+
 		if (grouper.getKeys() instanceof Keys.SelectorFunctionKeys) {
-		
+
 			@SuppressWarnings("unchecked")
 			Keys.SelectorFunctionKeys<IN, ?> selectorKeys = (Keys.SelectorFunctionKeys<IN, ?>) grouper.getKeys();
-			
-			PlanUnwrappingReduceGroupOperator<IN, OUT, ?> po = 
+
+			PlanUnwrappingReduceGroupOperator<IN, OUT, ?> po =
 					translateSelectorFunctionReducer(selectorKeys, function, getInputType(),getResultType(), name, input);
-			
+
 			// set dop
 			po.setDegreeOfParallelism(this.getParallelism());
-			
+
 			return po;
 		}
 		else if (grouper.getKeys() instanceof Keys.FieldPositionKeys) {
 
 			int[] logicalKeyPositions = grouper.getKeys().computeLogicalKeyPositions();
-			PlanGroupReduceOperator<IN, OUT> po = 
+			PlanGroupReduceOperator<IN, OUT> po =
 					new PlanGroupReduceOperator<IN, OUT>(function, logicalKeyPositions, name, getInputType(), getResultType());
-			
+
 			// set input
 			po.setInput(input);
+			//set semantic properties
+			if (this.getSematicProperties() != null) {
+				po.setSemanticProperties(this.getSematicProperties());
+			}
 			// set dop
 			po.setDegreeOfParallelism(this.getParallelism());
-			
+
 			// set group order
 			if(grouper.getGroupSortKeyPositions() != null) {
-								
+
 				int[] sortKeyPositions = grouper.getGroupSortKeyPositions();
 				Order[] sortOrders = grouper.getGroupSortOrders();
-				
+
 				Ordering o = new Ordering();
 				for(int i=0; i < sortKeyPositions.length; i++) {
 					o.appendOrdering(sortKeyPositions[i], null, sortOrders[i]);
 				}
 				po.setGroupOrder(o);
 			}
-			
+
 			return po;
 		}
 		else {
 			throw new UnsupportedOperationException("Unrecognized key type.");
 		}
-		
+
 	}
-	
-	
+
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	private static <IN, OUT, K> PlanUnwrappingReduceGroupOperator<IN, OUT, K> translateSelectorFunctionReducer(
 			Keys.SelectorFunctionKeys<IN, ?> rawKeys,
 			GroupReduceFunction<IN, OUT> function, TypeInformation<IN> inputType, TypeInformation<OUT> outputType, String name, Operator input)
 	{
 		@SuppressWarnings("unchecked")
 		final Keys.SelectorFunctionKeys<IN, K> keys = (Keys.SelectorFunctionKeys<IN, K>) rawKeys;
-		
+
 		TypeInformation<Tuple2<K, IN>> typeInfoWithKey = new TupleTypeInfo<Tuple2<K, IN>>(keys.getKeyType(), inputType);
-		
+
 		KeyExtractingMapper<IN, K> extractor = new KeyExtractingMapper<IN, K>(keys.getKeyExtractor());
-		
+
 		PlanUnwrappingReduceGroupOperator<IN, OUT, K> reducer = new PlanUnwrappingReduceGroupOperator<IN, OUT, K>(function, keys, name, inputType, outputType, typeInfoWithKey);
-		
+
 		PlanMapOperator<IN, Tuple2<K, IN>> mapper = new PlanMapOperator<IN, Tuple2<K, IN>>(extractor, "Key Extractor", inputType, typeInfoWithKey);
 
 		reducer.setInput(mapper);
 		mapper.setInput(input);
 		// set dop
 		mapper.setDegreeOfParallelism(input.getDegreeOfParallelism());
-		
+
 		return reducer;
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/SingleInputUdfOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/SingleInputUdfOperator.java
@@ -20,15 +20,16 @@ import java.util.Map;
 
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 import eu.stratosphere.configuration.Configuration;
 
 /**
- * The <tt>SingleInputUdfOperator</tt> is the base class of all unary operators that execute 
+ * The <tt>SingleInputUdfOperator</tt> is the base class of all unary operators that execute
  * user-defined functions (UDFs). The UDFs encapsulated by this operator are naturally UDFs that
  * have one input (such as {@link MapFunction} or {@link ReduceFunction}).
  * <p>
- * This class encapsulates utilities for the UDFs, such as broadcast variables, parameterization 
+ * This class encapsulates utilities for the UDFs, such as broadcast variables, parameterization
  * through configuration objects, and semantic properties.
  * @param <IN> The data type of the input data set.
  * @param <OUT> The data type of the returned data set.
@@ -37,77 +38,83 @@ public abstract class SingleInputUdfOperator<IN, OUT, O extends SingleInputUdfOp
 	extends SingleInputOperator<IN, OUT, O> implements UdfOperator<O>
 {
 	private Configuration parameters;
-	
+
 	private Map<String, DataSet<?>> broadcastVariables;
-	
+
 	private SingleInputSemanticProperties udfSemantics;
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Creates a new operators with the given data set as input. The given result type
-	 * describes the data type of the elements in the data set produced by the operator. 
-	 * 
+	 * describes the data type of the elements in the data set produced by the operator.
+	 *
 	 * @param input The data set that is the input to the operator.
 	 * @param resultType The type of the elements in the resulting data set.
 	 */
 	protected SingleInputUdfOperator(DataSet<IN> input, TypeInformation<OUT> resultType) {
 		super(input, resultType);
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	// Fluent API methods
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
 	public O withParameters(Configuration parameters) {
 		this.parameters = parameters;
-		
+
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
 		return returnType;
 	}
-	
+
 	@Override
 	public O withBroadcastSet(DataSet<?> data, String name) {
 		if (this.broadcastVariables == null) {
 			this.broadcastVariables = new HashMap<String, DataSet<?>>();
 		}
-		
+
 		this.broadcastVariables.put(name, data);
-		
+
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
 		return returnType;
 	}
-	
-	
+
+	public O withProperties(String[] constantSet, String constantSetExcept, String readSet) {
+		SingleInputSemanticProperties props = SemanticPropUtil.getSemanticPropsSingleFromString(constantSet, constantSetExcept, readSet, this.getInputType(), this.getResultType());
+		this.setSemanticProperties(props);
+		O returnType = (O) this;
+		return returnType;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Accessors
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
 	public Map<String, DataSet<?>> getBroadcastSets() {
 		return this.broadcastVariables == null ?
 				Collections.<String, DataSet<?>>emptyMap() :
 				Collections.unmodifiableMap(this.broadcastVariables);
 	}
-	
+
 	@Override
 	public Configuration getParameters() {
 		return this.parameters;
 	}
-	
+
 	@Override
 	public SingleInputSemanticProperties getSematicProperties() {
 		return this.udfSemantics;
 	}
-	
+
 	/**
 	 * Sets the semantic properties for the user-defined function (UDF). The semantic properties
 	 * define how fields of tuples and other objects are modified or preserved through this UDF.
 	 * The configured properties can be retrieved via {@link UdfOperator#getSematicProperties()}.
-	 * 
+	 *
 	 * @param properties The semantic properties for the UDF.
 	 * @see UdfOperator#getSematicProperties()
 	 */

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/TwoInputUdfOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/TwoInputUdfOperator.java
@@ -20,15 +20,16 @@ import java.util.Map;
 
 import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.java.DataSet;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 import eu.stratosphere.configuration.Configuration;
 
 /**
- * The <tt>TwoInputUdfOperator</tt> is the base class of all binary operators that execute 
+ * The <tt>TwoInputUdfOperator</tt> is the base class of all binary operators that execute
  * user-defined functions (UDFs). The UDFs encapsulated by this operator are naturally UDFs that
  * have two inputs (such as {@link JoinFunction} or {@link CoGroupFunction}).
  * <p>
- * This class encapsulates utilities for the UDFs, such as broadcast variables, parameterization 
+ * This class encapsulates utilities for the UDFs, such as broadcast variables, parameterization
  * through configuration objects, and semantic properties.
  *
  * @param <IN1> The data type of the first input data set.
@@ -39,17 +40,17 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 	extends TwoInputOperator<IN1, IN2, OUT, O> implements UdfOperator<O>
 {
 	private Configuration parameters;
-	
+
 	private Map<String, DataSet<?>> broadcastVariables;
-	
+
 	private DualInputSemanticProperties udfSemantics;
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Creates a new operators with the two given data sets as inputs. The given result type
-	 * describes the data type of the elements in the data set produced by the operator. 
-	 * 
+	 * describes the data type of the elements in the data set produced by the operator.
+	 *
 	 * @param input1 The data set for the first input.
 	 * @param input2 The data set for the second input.
 	 * @param resultType The type of the elements in the resulting data set.
@@ -57,59 +58,71 @@ public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOp
 	protected TwoInputUdfOperator(DataSet<IN1> input1, DataSet<IN2> input2, TypeInformation<OUT> resultType) {
 		super(input1, input2, resultType);
 	}
-	
+
 	// --------------------------------------------------------------------------------------------
 	// Fluent API methods
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
 	public O withParameters(Configuration parameters) {
 		this.parameters = parameters;
-		
+
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
 		return returnType;
 	}
-	
+
 	@Override
 	public O withBroadcastSet(DataSet<?> data, String name) {
 		if (this.broadcastVariables == null) {
 			this.broadcastVariables = new HashMap<String, DataSet<?>>();
 		}
-		
+
 		this.broadcastVariables.put(name, data);
-		
+
 		@SuppressWarnings("unchecked")
 		O returnType = (O) this;
 		return returnType;
 	}
-	
+
+	/*
+	Allows to give specifications about constant sets directly in the code. Null values are allowed for not specified sets.
+	 */
+	public O withProperties(String[] constantSetFirst, String[] constantSetSecond, String constExceptFirst, String constExceptSecond, String readSetFirst, String readSetSecond) {
+		DualInputSemanticProperties dsp = SemanticPropUtil.getSemanticPropsDualFromString(constantSetFirst, constantSetSecond,
+				constExceptFirst, constExceptSecond, readSetFirst, readSetSecond, this.getInput1Type(), this.getInput2Type(), this.getResultType());
+		this.setSemanticProperties(dsp);
+
+		O returnType = (O) this;
+		return returnType;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Accessors
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
 	public Map<String, DataSet<?>> getBroadcastSets() {
 		return this.broadcastVariables == null ?
 				Collections.<String, DataSet<?>>emptyMap() :
 				Collections.unmodifiableMap(this.broadcastVariables);
 	}
-	
+
 	@Override
 	public Configuration getParameters() {
 		return this.parameters;
 	}
-	
+
 	@Override
 	public DualInputSemanticProperties getSematicProperties() {
 		return this.udfSemantics;
 	}
-	
+
 	/**
 	 * Sets the semantic properties for the user-defined function (UDF). The semantic properties
 	 * define how fields of tuples and other objects are modified or preserved through this UDF.
 	 * The configured properties can be retrieved via {@link UdfOperator#getSematicProperties()}.
-	 * 
+	 *
 	 * @param properties The semantic properties for the UDF.
 	 * @see UdfOperator#getSematicProperties()
 	 */

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCogroupOperator.java
@@ -15,14 +15,20 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCoGrouper;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CoGroupOperatorBase;
 import eu.stratosphere.api.java.functions.CoGroupFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
-public class PlanCogroupOperator<IN1, IN2, OUT> 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+public class PlanCogroupOperator<IN1, IN2, OUT>
 	extends CoGroupOperatorBase<GenericCoGrouper<IN1, IN2, OUT>>
 	implements BinaryJavaPlanNode<IN1, IN2, OUT> {
-	
+
 	private final TypeInformation<IN1> inType1;
 	private final TypeInformation<IN2> inType2;
 	private final TypeInformation<OUT> outType;
@@ -31,10 +37,14 @@ public class PlanCogroupOperator<IN1, IN2, OUT>
 			CoGroupFunction<IN1, IN2, OUT> udf,
 			int[] keyPositions1, int[] keyPositions2, String name, TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType) {
 		super(udf, keyPositions1, keyPositions2, name);
-		
+
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
+
+		Set<Annotation> annotations = FunctionAnnotation.readDualConstantAnnotations(this.getUserCodeWrapper());
+		DualInputSemanticProperties dsp = SemanticPropUtil.getSemanticPropsDual(annotations, this.getInputType1(), this.getInputType2(), this.getReturnType());
+		this.setSemanticProperties(dsp);
 	}
 
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanCrossOperator.java
@@ -15,31 +15,41 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericCrosser;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.CrossOperatorBase;
 import eu.stratosphere.api.java.functions.CrossFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
-public class PlanCrossOperator<IN1, IN2, OUT> 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+public class PlanCrossOperator<IN1, IN2, OUT>
 	extends CrossOperatorBase<GenericCrosser<IN1, IN2, OUT>>
 	implements BinaryJavaPlanNode<IN1, IN2, OUT>{
-	
+
 	private final TypeInformation<IN1> inType1;
 	private final TypeInformation<IN2> inType2;
 	private final TypeInformation<OUT> outType;
-	
+
 
 	public PlanCrossOperator(
 			CrossFunction<IN1, IN2, OUT> udf,
 			String name,
 			TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType) {
 		super(udf, name);
-		
+
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
-		
+
+		Set<Annotation> annotations = FunctionAnnotation.readDualConstantAnnotations(this.getUserCodeWrapper());
+		DualInputSemanticProperties dsp = SemanticPropUtil.getSemanticPropsDual(annotations, this.getInputType1(), this.getInputType2(), this.getReturnType());
+		this.setSemanticProperties(dsp);
+
 	}
-	
+
 	@Override
 	public TypeInformation<OUT> getReturnType() {
 		return this.outType;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -18,10 +18,12 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import eu.stratosphere.api.common.functions.GenericFlatMap;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFields;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
 
@@ -39,7 +41,8 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 		this.outType = outType;
 		
 		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper());
-		System.out.println(annotations);
+
+        SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingle(annotations, this.inType, this.outType);
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -14,37 +14,36 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.operators.translation;
 
-import java.lang.annotation.Annotation;
-import java.util.Set;
-
 import eu.stratosphere.api.common.functions.GenericFlatMap;
 import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
 import eu.stratosphere.api.java.functions.FunctionAnnotation;
-import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFields;
 import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
 
 
 public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMap<T, O>>
 	implements UnaryJavaPlanNode<T, O>
 {
 	private final TypeInformation<T> inType;
-	
+
 	private final TypeInformation<O> outType;
-	
-	
+
+
 	public PlanFlatMapOperator(FlatMapFunction<T, O> udf, String name, TypeInformation<T> inType, TypeInformation<O> outType) {
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
-		
-		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper());
 
-        SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingle(annotations, this.inType, this.outType);
+		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper());
+		SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingle(annotations, this.getInputType(), this.getReturnType());
+		setSemanticProperties(sp);
 	}
-	
+
 	@Override
 	public TypeInformation<O> getReturnType() {
 		return this.outType;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanFlatMapOperator.java
@@ -14,14 +14,17 @@
  **********************************************************************************************************************/
 package eu.stratosphere.api.java.operators.translation;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 import eu.stratosphere.api.common.functions.GenericFlatMap;
 import eu.stratosphere.api.common.operators.base.FlatMapOperatorBase;
 import eu.stratosphere.api.java.functions.FlatMapFunction;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
+import eu.stratosphere.api.java.functions.FunctionAnnotation.ConstantFields;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
-/**
- *
- */
+
 public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMap<T, O>>
 	implements UnaryJavaPlanNode<T, O>
 {
@@ -34,6 +37,9 @@ public class PlanFlatMapOperator<T, O> extends FlatMapOperatorBase<GenericFlatMa
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
+		
+		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper());
+		System.out.println(annotations);
 	}
 	
 	@Override

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanGroupReduceOperator.java
@@ -15,10 +15,16 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.GroupReduceFunction;
 import eu.stratosphere.api.java.functions.GroupReduceFunction.Combinable;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
 
 /**
  *
@@ -28,20 +34,24 @@ public class PlanGroupReduceOperator<IN, OUT> extends GroupReduceOperatorBase<Ge
 {
 
 	private final TypeInformation<IN> inType;
-	
+
 	private final TypeInformation<OUT> outType;
-	
-	
-	public PlanGroupReduceOperator(GroupReduceFunction<IN, OUT> udf, int[] logicalGroupingFields, String name, 
+
+
+	public PlanGroupReduceOperator(GroupReduceFunction<IN, OUT> udf, int[] logicalGroupingFields, String name,
 				TypeInformation<IN> inputType, TypeInformation<OUT> outputType)
 	{
 		super(udf, logicalGroupingFields, name);
-		
+
 		this.inType = inputType;
 		this.outType = outputType;
 		super.setCombinable(getUserCodeWrapper().getUserCodeAnnotation(Combinable.class) != null);
+
+		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper());
+		SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingle(annotations, this.inType, this.outType);
+		setSemanticProperties(sp);
 	}
-	
+
 	@Override
 	public TypeInformation<OUT> getReturnType() {
 		return this.outType;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanJoinOperator.java
@@ -15,14 +15,20 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericJoiner;
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.JoinOperatorBase;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.JoinFunction;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
 
-public class PlanJoinOperator<IN1, IN2, OUT> 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+public class PlanJoinOperator<IN1, IN2, OUT>
 	extends JoinOperatorBase<GenericJoiner<IN1, IN2, OUT>>
 	implements BinaryJavaPlanNode<IN1, IN2, OUT> {
-	
+
 	private final TypeInformation<IN1> inType1;
 	private final TypeInformation<IN2> inType2;
 	private final TypeInformation<OUT> outType;
@@ -31,12 +37,16 @@ public class PlanJoinOperator<IN1, IN2, OUT>
 			JoinFunction<IN1, IN2, OUT> udf,
 			int[] keyPositions1, int[] keyPositions2, String name, TypeInformation<IN1> inType1, TypeInformation<IN2> inType2, TypeInformation<OUT> outType) {
 		super(udf, keyPositions1, keyPositions2, name);
-		
+
 		this.inType1 = inType1;
 		this.inType2 = inType2;
 		this.outType = outType;
+
+		Set<Annotation> annotations = FunctionAnnotation.readDualConstantAnnotations(this.getUserCodeWrapper());
+		DualInputSemanticProperties dsp = SemanticPropUtil.getSemanticPropsDual(annotations, this.getInputType1(), this.getInputType2(), this.getReturnType());
+		this.setSemanticProperties(dsp);
 	}
-	
+
 	@Override
 	public TypeInformation<OUT> getReturnType() {
 		return this.outType;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanMapOperator.java
@@ -15,9 +15,15 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericMap;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.PlainMapOperatorBase;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
 
 /**
  *
@@ -27,16 +33,20 @@ public class PlanMapOperator<T, O> extends PlainMapOperatorBase<GenericMap<T, O>
 {
 
 	private final TypeInformation<T> inType;
-	
+
 	private final TypeInformation<O> outType;
-	
-	
+
+
 	public PlanMapOperator(MapFunction<T, O> udf, String name, TypeInformation<T> inType, TypeInformation<O> outType) {
 		super(udf, name);
 		this.inType = inType;
 		this.outType = outType;
+
+		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper());
+		SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingle(annotations, this.inType, this.outType);
+		setSemanticProperties(sp);
 	}
-	
+
 	@Override
 	public TypeInformation<O> getReturnType() {
 		return this.outType;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/operators/translation/PlanReduceOperator.java
@@ -15,9 +15,15 @@
 package eu.stratosphere.api.java.operators.translation;
 
 import eu.stratosphere.api.common.functions.GenericGroupReduce;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
 import eu.stratosphere.api.common.operators.base.GroupReduceOperatorBase;
+import eu.stratosphere.api.java.functions.FunctionAnnotation;
 import eu.stratosphere.api.java.functions.ReduceFunction;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
 import eu.stratosphere.api.java.typeutils.TypeInformation;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
 
 /**
  *
@@ -27,14 +33,18 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 {
 
 	private final TypeInformation<T> type;
-	
-	
+
+
 	public PlanReduceOperator(ReduceFunction<T> udf, int[] logicalGroupingFields, String name, TypeInformation<T> type) {
 		super(udf, logicalGroupingFields, name);
 		this.type = type;
+
+		Set<Annotation> annotations = FunctionAnnotation.readSingleConstantAnnotations(this.getUserCodeWrapper());
+		SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingle(annotations, this.getInputType(), this.getReturnType());
+		setSemanticProperties(sp);
 	}
-	
-	
+
+
 	@Override
 	public TypeInformation<T> getReturnType() {
 		return this.type;
@@ -44,5 +54,5 @@ public class PlanReduceOperator<T> extends GroupReduceOperatorBase<GenericGroupR
 	public TypeInformation<T> getInputType() {
 		return this.type;
 	}
-	
+
 }

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/semanticprops/SemanticPropUtilTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/semanticprops/SemanticPropUtilTest.java
@@ -43,6 +43,42 @@ public class SemanticPropUtilTest {
         Assert.assertTrue(fs.contains(3));
     }
 
+	@Test
+    public void testSimpleCaseWildCard() {
+        String[] constantFields = {"*"};
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingleFromString(constantFields, null, null,type, type);
+
+        FieldSet fs = sp.getForwardedField(1);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(1));
+
+        fs = sp.getForwardedField(2);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(2));
+
+        fs = sp.getForwardedField(0);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(0));
+    }
+
+	@Test
+	public void testSimpleCaseWildCard2() {
+		String[] constantFields = {"1->*"};
+
+		TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+		SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingleFromString(constantFields, null, null,type, type);
+
+		FieldSet fs = sp.getForwardedField(1);
+		Assert.assertTrue(fs.size() == 3);
+		Assert.assertTrue(fs.contains(0));
+		Assert.assertTrue(fs.contains(1));
+		Assert.assertTrue(fs.contains(2));
+		Assert.assertTrue(sp.getForwardedField(0) == null);
+		Assert.assertTrue(sp.getForwardedField(2) == null);
+	}
+
     @Test
     public void testConstantFieldsExcept() {
         String constantFieldsExcept = "1";

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/semanticprops/SemanticPropUtilTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/semanticprops/SemanticPropUtilTest.java
@@ -1,0 +1,151 @@
+/***********************************************************************************************************************
+ * Copyright (C) 2010-2013 by the Stratosphere project (http://stratosphere.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ **********************************************************************************************************************/
+
+package eu.stratosphere.test.semanticprops;
+
+import eu.stratosphere.api.common.operators.DualInputSemanticProperties;
+import eu.stratosphere.api.common.operators.SingleInputSemanticProperties;
+import eu.stratosphere.api.common.operators.util.FieldSet;
+import eu.stratosphere.api.java.functions.SemanticPropUtil;
+import eu.stratosphere.api.java.tuple.Tuple3;
+import eu.stratosphere.api.java.typeutils.BasicTypeInfo;
+import eu.stratosphere.api.java.typeutils.TupleTypeInfo;
+import eu.stratosphere.api.java.typeutils.TypeInformation;
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class SemanticPropUtilTest {
+
+    @Test
+    public void testSimpleCase() {
+        String[] constantFields = {"1->1,2", "2->3"};
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingleFromString(constantFields, null, null,type, type);
+
+        FieldSet fs = sp.getForwardedField(1);
+        Assert.assertTrue(fs.size() == 2);
+        Assert.assertTrue(fs.contains(1));
+        Assert.assertTrue(fs.contains(2));
+
+        fs = sp.getForwardedField(2);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(3));
+    }
+
+    @Test
+    public void testConstantFieldsExcept() {
+        String constantFieldsExcept = "1";
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingleFromString(null, constantFieldsExcept, null,type, type);
+
+        FieldSet fs = sp.getForwardedField(0);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(0));
+
+        fs = sp.getForwardedField(1);
+        Assert.assertTrue(fs == null);
+
+        fs = sp.getForwardedField(2);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(2));
+    }
+
+    @Test
+    public void testReadFields() {
+        String readFields = "1, 2";
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingleFromString(null, null, readFields,type, type);
+
+        FieldSet fs = sp.getReadFields();
+        Assert.assertTrue(fs.size() == 2);
+        Assert.assertTrue(fs.contains(2));
+        Assert.assertTrue(fs.contains(1));
+    }
+
+    @Test
+    public void testSimpleCaseDual() {
+        String[] constantFieldsFirst = {"1->1,2", "2->3"};
+        String[] constantFieldsSecond = {"1->1,2", "2->3"};
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        DualInputSemanticProperties dsp = SemanticPropUtil.getSemanticPropsDualFromString(constantFieldsFirst, constantFieldsSecond, null, null, null, null, type, type, type);
+
+        FieldSet fs = dsp.getForwardedField1(1);
+        Assert.assertTrue(fs.size() == 2);
+        Assert.assertTrue(fs.contains(1));
+        Assert.assertTrue(fs.contains(2));
+
+        fs = dsp.getForwardedField1(2);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(3));
+    }
+
+    @Test
+    public void testFieldsExceptDual() {
+        String constantFieldsFirstExcept = "1,2";
+        String[] constantFieldsSecond = {"0->1"};
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        DualInputSemanticProperties dsp = SemanticPropUtil.getSemanticPropsDualFromString(null, constantFieldsSecond, constantFieldsFirstExcept, null, null, null, type, type, type);
+
+        FieldSet fs = dsp.getForwardedField1(0);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(0));
+
+        fs = dsp.getForwardedField1(1);
+        Assert.assertTrue(fs == null);
+
+        fs = dsp.getForwardedField1(2);
+        Assert.assertTrue(fs == null);
+
+        fs = dsp.getForwardedField2(0);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(1));
+    }
+
+    @Test
+    public void testStringParse1() {
+        String[] constantFields = {"  1-> 1 , 2", "2 ->3"};
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingleFromString(constantFields, null, null,type, type);
+
+        FieldSet fs = sp.getForwardedField(1);
+        Assert.assertTrue(fs.size() == 2);
+        Assert.assertTrue(fs.contains(1));
+        Assert.assertTrue(fs.contains(2));
+
+        fs = sp.getForwardedField(2);
+        Assert.assertTrue(fs.size() == 1);
+        Assert.assertTrue(fs.contains(3));
+    }
+
+    @Test
+    public void testStringParse2() {
+        String[] constantFields = {"notValid"};
+
+        TypeInformation<?> type = new TupleTypeInfo<Tuple3<Integer, Integer, Integer>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+
+        try {
+            SingleInputSemanticProperties sp = SemanticPropUtil.getSemanticPropsSingleFromString(constantFields, null, null, type, type);
+        } catch (Exception e) {
+            return;
+        }
+        Assert.fail();
+    }
+
+
+}


### PR DESCRIPTION
This PR contains the new String Annotations. Constant sets are not annotated with a string array. 
The parsing is done in the new SemanticPropUtil class. There is also a test case for this class.

What is left is additional functionality like a \* operator. Also it would be nice to be able to add the annotation strings to the operators via functions.
Example:
@ConstantFields({"1->2", "2->3,4,5"})
