### PR TITLE
Integration of the CachedBuildSideMatchDriver

### DIFF
--- a/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/DriverStrategy.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/pact/runtime/task/DriverStrategy.java
@@ -54,6 +54,10 @@ public enum DriverStrategy {
 	HYBRIDHASH_BUILD_FIRST(MatchDriver.class, null, FULL_DAM, MATERIALIZING, true),
 	// the second input is build side, the first side is probe side of a hybrid hash table
 	HYBRIDHASH_BUILD_SECOND(MatchDriver.class, null, MATERIALIZING, FULL_DAM, true),
+	// a cached variant of HYBRIDHASH_BUILD_FIRST, that can only be used inside of iterations
+	HYBRIDHASH_BUILD_FIRST_CACHED(BuildFirstCachedMatchDriver.class, null, FULL_DAM, MATERIALIZING, true),
+	//  cached variant of HYBRIDHASH_BUILD_SECOND, that can only be used inside of iterations
+	HYBRIDHASH_BUILD_SECOND_CACHED(BuildSecondCachedMatchDriver.class, null, MATERIALIZING, FULL_DAM, true),
 	// the second input is inner loop, the first input is outer loop and block-wise processed
 	NESTEDLOOP_BLOCKED_OUTER_FIRST(CrossDriver.class, null, MATERIALIZING, MATERIALIZING, false),
 	// the first input is inner loop, the second input is outer loop and block-wise processed


### PR DESCRIPTION
This is a first version of integrating the CachedBuildSideMatchDriver into the Compiler.
In the current implementation it switches a regular hybrid hash join inside of iterations to the cached variant. The switching is done after the optimization in the NepheleJobGraphGenerator.

I debugged myself through a few of the example iterative algorithms we have and in many cases this implementation correctly switches the driver. But there are some cases where the optimizer decides to use a merge join and that can not so easily be replaced.

All in all I don't like this implementation very much. It is quite hacky and I think we should integrate the cached variant at an earlier point inside the optimization. But that would probably require a few extensions to the cost model. I created an issue to discuss this further:  #795
