### PR TITLE
Fix windows line endings#791 - Windows delimiter is accepted as standard 

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
@@ -528,41 +528,10 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 			int count = 0;
 
 			while (this.readPos < this.limit && i < this.delimiter.length) {
-				if ((this.readBuffer[this.readPos]) == this.delimiter[i]) {
-					
-					/*
-					 * Fix for accessing files with windows line endings \r\n
-					 * When \r\n is found replace the \r with space.			 
-					 */
-					
-					//Check if delimiter is set to exactly \n 
-					if(this.delimiter[0] == "\n".getBytes(Charsets.UTF_8)[0] && this.delimiter.length == 1){
-						//check if preceding byte equals \r
-						
-						if(this.readPos -1 >= startPos) {// Check array bounds
-							//check for preceding \r
-							if( this.readBuffer[this.readPos -1] == "\r".getBytes(Charsets.UTF_8)[0] ) {
-								// replace \r with space
-								this.readBuffer[this.readPos -1] = "\n".getBytes(Charsets.UTF_8)[0];
-								this.readBuffer[this.readPos] = " ".getBytes(Charsets.UTF_8)[0];
-							}
-						}
-						
-					}//if
-					
-					/*
-					 * Fix END
-					 */
-					
-					//increase number of found delimiter characters
+				if ((this.readBuffer[this.readPos++]) == this.delimiter[i]) {
 					i++;
-					//increase read position
-					this.readPos++;
 				} else {
-					//no delimiter found
 					i = 0;
-					//increase read position
-					this.readPos++;
 				}
 
 			}

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
@@ -526,7 +526,6 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 
 			int startPos = this.readPos;
 			int count = 0;
-			boolean standardDelimiterButWindowsFile = false;
 
 			while (this.readPos < this.limit && i < this.delimiter.length) {
 				if ((this.readBuffer[this.readPos]) == this.delimiter[i]) {
@@ -546,13 +545,6 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 								// replace \r with space
 								this.readBuffer[this.readPos -1] = "\n".getBytes(Charsets.UTF_8)[0];
 								this.readBuffer[this.readPos] = " ".getBytes(Charsets.UTF_8)[0];
-								
-								//the delimiter "\r" was found - so set length(i) to 1.
-								//the increase for the \n will occur later (at the end of this if)
-								i = 1;
-								//set a marker to succeed the test why it stopped
-								standardDelimiterButWindowsFile = true;
-								//but break here
 							}
 						}
 						
@@ -575,11 +567,10 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 
 			}
 
-			// check why we dropped out - delimiter found or windows delimiter found but standard
-			if (i == this.delimiter.length 
-					|| i  == this.delimiter.length + 1 && standardDelimiterButWindowsFile == true) {
+			// check why we dropped out
+			if (i == this.delimiter.length) {
 				// line end
-				count = this.readPos - startPos - i; // i is the delimiter length. 
+				count = this.readPos - startPos - this.delimiter.length;
 
 				// copy to byte array
 				if (countInWrapBuffer > 0) {

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
@@ -528,10 +528,41 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 			int count = 0;
 
 			while (this.readPos < this.limit && i < this.delimiter.length) {
-				if ((this.readBuffer[this.readPos++]) == this.delimiter[i]) {
+				if ((this.readBuffer[this.readPos]) == this.delimiter[i]) {
+					
+					/*
+					 * Fix for accessing files with windows line endings \r\n
+					 * When \r\n is found replace the \r with space.			 
+					 */
+					
+					//Check if delimiter is set to exactly \n 
+					if(this.delimiter[0] == "\n".getBytes(Charsets.UTF_8)[0] && this.delimiter.length == 1){
+						//check if preceding byte equals \r
+						
+						if(this.readPos -1 >= startPos) {// Check array bounds
+							//check for preceding \r
+							if( this.readBuffer[this.readPos -1] == "\r".getBytes(Charsets.UTF_8)[0] ) {
+								// replace \r with space
+								this.readBuffer[this.readPos -1] = "\n".getBytes(Charsets.UTF_8)[0];
+								this.readBuffer[this.readPos] = " ".getBytes(Charsets.UTF_8)[0];
+							}
+						}
+						
+					}//if
+					
+					/*
+					 * Fix END
+					 */
+					
+					//increase number of found delimiter characters
 					i++;
+					//increase read position
+					this.readPos++;
 				} else {
+					//no delimiter found
 					i = 0;
+					//increase read position
+					this.readPos++;
 				}
 
 			}

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/io/DelimitedInputFormat.java
@@ -526,6 +526,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 
 			int startPos = this.readPos;
 			int count = 0;
+			boolean standardDelimiterButWindowsFile = false;
 
 			while (this.readPos < this.limit && i < this.delimiter.length) {
 				if ((this.readBuffer[this.readPos]) == this.delimiter[i]) {
@@ -545,6 +546,13 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 								// replace \r with space
 								this.readBuffer[this.readPos -1] = "\n".getBytes(Charsets.UTF_8)[0];
 								this.readBuffer[this.readPos] = " ".getBytes(Charsets.UTF_8)[0];
+								
+								//the delimiter "\r" was found - so set length(i) to 1.
+								//the increase for the \n will occur later (at the end of this if)
+								i = 1;
+								//set a marker to succeed the test why it stopped
+								standardDelimiterButWindowsFile = true;
+								//but break here
 							}
 						}
 						
@@ -567,10 +575,11 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> {
 
 			}
 
-			// check why we dropped out
-			if (i == this.delimiter.length) {
+			// check why we dropped out - delimiter found or windows delimiter found but standard
+			if (i == this.delimiter.length 
+					|| i  == this.delimiter.length + 1 && standardDelimiterButWindowsFile == true) {
 				// line end
-				count = this.readPos - startPos - this.delimiter.length;
+				count = this.readPos - startPos - i; // i is the delimiter length. 
 
 				// copy to byte array
 				if (countInWrapBuffer > 0) {

--- a/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/relational/TPCHQuery3.java
+++ b/stratosphere-examples/stratosphere-java-examples/src/main/java/eu/stratosphere/example/java/relational/TPCHQuery3.java
@@ -173,7 +173,7 @@ public class TPCHQuery3 {
 		final String lineitemPath = args[0];
 		final String customerPath = args[1];
 		final String ordersPath = args[2];
-		final String resultPath = args.length >= 4 ? args[4] : null;
+		final String resultPath = args.length >= 4 ? args[3] : null;
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
 import eu.stratosphere.api.common.io.GenericCsvInputFormat;

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
@@ -93,6 +93,10 @@ public class CsvInputFormat<OUT extends Tuple> extends GenericCsvInputFormat<OUT
 		@SuppressWarnings("unchecked")
 		FieldParser<Object>[] fieldParsers = (FieldParser<Object>[]) getFieldParsers();
 		
+		//throw exception if no field parsers are available
+		if(fieldParsers.length == 0)
+			throw new IOException("CsvInputFormat.open(FileInputSplit split) - no field parsers to parse input");
+		
 		// create the value holders
 		this.parsedValues = new Object[fieldParsers.length];
 		for (int i = 0; i < fieldParsers.length; i++) {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
@@ -117,17 +117,22 @@ public class CsvInputFormat<OUT extends Tuple> extends GenericCsvInputFormat<OUT
 
 	@Override
 	public OUT readRecord(OUT reuse, byte[] bytes, int offset, int numBytes) {
+		/*
+		 * Fix to support windows line endings in CSVInputFiles with standard delimiter setup = \n
+		 */
+		//Find windows end line, so find chariage return before the newline 
+		if(this.lineDelimiterIsLinebreak == true && bytes[offset + numBytes -1] == "\r".getBytes(Charsets.UTF_8)[0]) {
+			//reduce the number of bytes so that the Carriage return is not taken as data
+			numBytes--;
+		}
+		
 		if (parseRecord(parsedValues, bytes, offset, numBytes)) {
 			// valid parse, map values into pact record
 			for (int i = 0; i < parsedValues.length; i++) {
 				reuse.setField(parsedValues[i], i);
 			}
 			
-			//Find windows end line character
-			if(this.lineDelimiterIsLinebreak == true && bytes[offset + numBytes] == "\r".getBytes(Charsets.UTF_8)[0]) {
-				//reduce the number of bytes so that the Carriage return is not taken as data
-				numBytes--;
-			}
+			
 			
 			return reuse;
 		} else {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
@@ -94,8 +94,9 @@ public class CsvInputFormat<OUT extends Tuple> extends GenericCsvInputFormat<OUT
 		FieldParser<Object>[] fieldParsers = (FieldParser<Object>[]) getFieldParsers();
 		
 		//throw exception if no field parsers are available
-		if(fieldParsers.length == 0)
+		if(fieldParsers.length == 0) {
 			throw new IOException("CsvInputFormat.open(FileInputSplit split) - no field parsers to parse input");
+		}
 		
 		// create the value holders
 		this.parsedValues = new Object[fieldParsers.length];

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
@@ -111,7 +111,7 @@ public class CsvInputFormat<OUT extends Tuple> extends GenericCsvInputFormat<OUT
 		
 		//left to right evaluation makes access [0] okay
 		//this marker is used to fasten up readRecord, so that it doesn't have to check each call if the line ending is set to default
-		if(this.getDelimiter().length == 1 && this.getDelimiter()[0] == "\n".getBytes(Charsets.UTF_8)[0] ) {
+		if(this.getDelimiter().length == 1 && this.getDelimiter()[0] == '\n' ) {
 			this.lineDelimiterIsLinebreak = true;
 		}
 	}
@@ -122,7 +122,7 @@ public class CsvInputFormat<OUT extends Tuple> extends GenericCsvInputFormat<OUT
 		 * Fix to support windows line endings in CSVInputFiles with standard delimiter setup = \n
 		 */
 		//Find windows end line, so find chariage return before the newline 
-		if(this.lineDelimiterIsLinebreak == true && bytes[offset + numBytes -1] == "\r".getBytes(Charsets.UTF_8)[0]) {
+		if(this.lineDelimiterIsLinebreak == true && bytes[offset + numBytes -1] == '\r' ) {
 			//reduce the number of bytes so that the Carriage return is not taken as data
 			numBytes--;
 		}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/io/CsvInputFormat.java
@@ -41,7 +41,8 @@ public class CsvInputFormat<OUT extends Tuple> extends GenericCsvInputFormat<OUT
 
 	private transient Object[] parsedValues;
 	
-	//to speed up readRecord processing. Used to find windows line endings
+	//To speed up readRecord processing. Used to find windows line endings.
+	//It is set when open so that readRecord does not have to evaluate it
 	private boolean lineDelimiterIsLinebreak = false;
 	
 	

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/CsvInputFormat.java
@@ -15,6 +15,7 @@ package eu.stratosphere.api.java.record.io;
 
 import java.io.IOException;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
 import eu.stratosphere.api.common.io.GenericCsvInputFormat;
@@ -58,6 +59,10 @@ public class CsvInputFormat extends GenericCsvInputFormat<Record> {
 	private int[] targetPositions = new int[0];
 
 	private boolean configured = false;
+	
+	//To speed up readRecord processing. Used to find windows line endings.
+	//It is set when open so that readRecord does not have to evaluate it
+	private boolean lineDelimiterIsLinebreak = false;
 	
 	// --------------------------------------------------------------------------------------------
 	//  Constructors and getters/setters for the configurable parameters
@@ -237,10 +242,25 @@ public class CsvInputFormat extends GenericCsvInputFormat<Record> {
 		for (int i = 0; i < fieldParsers.length; i++) {
 			this.parsedValues[i] = fieldParsers[i].createValue();
 		}
+		
+		//left to right evaluation makes access [0] okay
+		//this marker is used to fasten up readRecord, so that it doesn't have to check each call if the line ending is set to default
+		if(this.getDelimiter().length == 1 && this.getDelimiter()[0] == '\n' ) {
+					this.lineDelimiterIsLinebreak = true;
+		}
 	}
 	
 	@Override
 	public Record readRecord(Record reuse, byte[] bytes, int offset, int numBytes) throws ParseException {
+		/*
+		 * Fix to support windows line endings in CSVInputFiles with standard delimiter setup = \n
+		 */
+		//Find windows end line, so find chariage return before the newline 
+		if(this.lineDelimiterIsLinebreak == true && bytes[offset + numBytes -1] == '\r') {
+			//reduce the number of bytes so that the Carriage return is not taken as data
+			numBytes--;
+		}
+		
 		if (parseRecord(parsedValues, bytes, offset, numBytes)) {
 			// valid parse, map values into pact record
 			for (int i = 0; i < parsedValues.length; i++) {

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/CsvInputFormat.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/record/io/CsvInputFormat.java
@@ -15,7 +15,6 @@ package eu.stratosphere.api.java.record.io;
 
 import java.io.IOException;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 
 import eu.stratosphere.api.common.io.GenericCsvInputFormat;

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CsvInputFormatTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CsvInputFormatTest.java
@@ -20,13 +20,16 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 
 import org.apache.log4j.Level;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import eu.stratosphere.api.java.tuple.Tuple1;
 import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.api.java.tuple.Tuple3;
 import eu.stratosphere.api.java.tuple.Tuple5;
@@ -38,6 +41,15 @@ import eu.stratosphere.util.LogUtils;
 public class CsvInputFormatTest {
 	
 	private static final Path PATH = new Path("an/ignored/file/");
+	
+	//Static variables for testing the removal of \r\n to \n
+	private static final String FIRST_PART_1 = "That is";
+	private static final String FIRST_PART_2 =" the first part";
+	private static final String FIRST_PART = "That is the first part";
+	
+	private static final String SECOND_PART_1 = "That is";
+	private static final String SECOND_PART_2 = " the second part";
+	private static final String SECOND_PART = "That is the second part";
 	
 	
 	@BeforeClass
@@ -351,6 +363,69 @@ public class CsvInputFormatTest {
 		wrt.close();
 			
 		return new FileInputSplit(0, new Path(tempFile.toURI().toString()), 0, tempFile.length(), new String[] {"localhost"});
+	}
+	
+	@Test
+	public void testWindowsLineEndRemoval() {
+		
+		//Check typical use case -- linux file is correct and it is set up to linuc(\n)
+		this.testRemovingTrailingCR("\n", "\n");
+		
+		//Check typical windows case -- windows file endings and file has windows file endings set up
+		this.testRemovingTrailingCR("\r\n", "\r\n");
+		
+		//Check problematic case windows file -- windows file endings(\r\n) but linux line endings (\n) set up
+		this.testRemovingTrailingCR("\r\n", "\n");
+		
+		//Check problematic case linux file -- linux file endings (\n) but windows file endings set up (\r\n)
+		//Specific setup for windows line endings will expect \r\n because it has to be set up and is not standard.
+	}
+	
+	private void testRemovingTrailingCR(String lineBreakerInFile, String lineBreakerSetup) {
+		File tempFile=null;
+		
+		String fileContent = CsvInputFormatTest.FIRST_PART + lineBreakerInFile + CsvInputFormatTest.SECOND_PART + lineBreakerInFile;
+		
+		try {
+			// create input file
+			tempFile = File.createTempFile("CsvInputFormatTest", "tmp");
+			tempFile.deleteOnExit();
+			tempFile.setWritable(true);
+			
+			OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
+			wrt.write(fileContent);
+			wrt.close();
+			
+			CsvInputFormat<Tuple1<String>> inputFormat = new CsvInputFormat<Tuple1<String>>(new Path(tempFile.toURI().toString()),String.class);
+			
+			Configuration parameters = new Configuration(); 
+			inputFormat.configure(parameters);
+			
+			inputFormat.setDelimiter(lineBreakerSetup);
+			
+			FileInputSplit[] splits = inputFormat.createInputSplits(1);
+						
+			inputFormat.open(splits[0]);
+			
+			Tuple1<String> result = inputFormat.nextRecord(new Tuple1<String>());
+			
+			assertNotNull("Expecting to not return null", result);
+			
+			
+			
+			assertEquals(FIRST_PART, result.f0);
+			
+			result = inputFormat.nextRecord(result);
+			
+			assertNotNull("Expecting to not return null", result);
+			assertEquals(SECOND_PART, result.f0);
+			
+		}
+		catch (Throwable t) {
+			System.err.println("test failed with exception: " + t.getMessage());
+			t.printStackTrace(System.err);
+			fail("Test erroneous");
+		}
 	}
 
 }

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CsvInputFormatTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/io/CsvInputFormatTest.java
@@ -43,12 +43,8 @@ public class CsvInputFormatTest {
 	private static final Path PATH = new Path("an/ignored/file/");
 	
 	//Static variables for testing the removal of \r\n to \n
-	private static final String FIRST_PART_1 = "That is";
-	private static final String FIRST_PART_2 =" the first part";
 	private static final String FIRST_PART = "That is the first part";
 	
-	private static final String SECOND_PART_1 = "That is";
-	private static final String SECOND_PART_2 = " the second part";
 	private static final String SECOND_PART = "That is the second part";
 	
 	


### PR DESCRIPTION
This is a fix for issue: #791 

If the standard delimiter is \n, a \r\n is accepted as well. Therefore a
marker was introduced to indicate that specific case. The delimiter
length is variably set to the windows delimiter size then. To prevent
failing in reading input with windows line endings.
The DelimitedInputFormat.open() method did not check if it has parsers
registered. Added throwing an exception when no parser is registered
when calling open. CsvInputFormat does now accept windows line endings
with standards settings. The |\r\n" will be replaced by "\n_"( _ is a
space)... To prevent from errors the returned length is set to the
space. So that this byte is known as parsed and will not get interpreted
anymore.
