### PR TITLE
Fixes an issue when generating a type erasure exception in TypeExtractor.

### DIFF
--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TypeExtractor.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/TypeExtractor.java
@@ -413,9 +413,11 @@ public class TypeExtractor {
 					
 					// variable could not be determined
 					if (tupleSubTypes[i] == null) {
-						throw new InvalidTypesException("Type of TypeVariable '" + ((TypeVariable<?>) t).getName() + "' in '"
-								+ ((TypeVariable<?>) t).getGenericDeclaration()
-								+ "' could not be determined. This is most likely a type erasure problem.");
+						throw new InvalidTypesException("Type of TypeVariable '" + ((TypeVariable<?>) subtypes[i]).getName() + "' in '"
+								+ ((TypeVariable<?>) subtypes[i]).getGenericDeclaration()
+								+ "' could not be determined. This is most likely a type erasure problem."
+								+ "The type extraction currently supports types with generic variables only in cases where "
+								+ "all variables in the return type can be deduced from the input type(s).");
 					}
 				} else {
 					tupleSubTypes[i] = createTypeInfoWithTypeHierarchy(new ArrayList<Type>(typeHierarchy), subtypes[i], in1Type, in2Type);
@@ -449,7 +451,7 @@ public class TypeExtractor {
 					return typeInfo;
 				} else {
 					throw new InvalidTypesException("Type of TypeVariable '" + ((TypeVariable<?>) t).getName() + "' in '"
-							+ ((TypeVariable<?>) t).getGenericDeclaration() + "' could not be determined. "
+							+ ((TypeVariable<?>) t).getGenericDeclaration() + "' could not be determined. This is most likely a type erasure problem."
 							+ "The type extraction currently supports types with generic variables only in cases where "
 							+ "all variables in the return type can be deduced from the input type(s).");
 				}

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/type/extractor/TypeExtractorTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/type/extractor/TypeExtractorTest.java
@@ -1320,7 +1320,7 @@ public class TypeExtractorTest {
 	public void testTypeErasureException() {
 		try {
 			TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
-					(TypeInformation) TypeInformation.parse("Tuple2<String, Integer>"));
+					(TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"));
 			Assert.fail("exception expected");
 		}
 		catch (InvalidTypesException e) {

--- a/stratosphere-java/src/test/java/eu/stratosphere/api/java/type/extractor/TypeExtractorTest.java
+++ b/stratosphere-java/src/test/java/eu/stratosphere/api/java/type/extractor/TypeExtractorTest.java
@@ -1304,4 +1304,27 @@ public class TypeExtractorTest {
 			// right
 		}
 	}
+	
+	public static class DummyFlatMapFunction<A,B,C,D> extends FlatMapFunction<Tuple2<A,B>, Tuple2<C,D>> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void flatMap(Tuple2<A, B> value, Collector<Tuple2<C, D>> out) throws Exception {
+			
+		}
+		
+	}
+	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testTypeErasureException() {
+		try {
+			TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
+					(TypeInformation) TypeInformation.parse("Tuple2<String, Integer>"));
+			Assert.fail("exception expected");
+		}
+		catch (InvalidTypesException e) {
+			// right
+		}
+	}
 }


### PR DESCRIPTION
The bug has been mentioned in #842.

A additional test case tests the fix.
