### PR TITLE
Aligned the Scala KMeans with the Java KMeans example.

### DIFF
--- a/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/datamining/KMeans.scala
+++ b/stratosphere-examples/stratosphere-scala-examples/src/main/scala/eu/stratosphere/examples/scala/datamining/KMeans.scala
@@ -25,55 +25,65 @@ import eu.stratosphere.api.scala.operators._
 
 class KMeans extends Program with ProgramDescription with Serializable {
 
-  case class Point(x: Double, y: Double, z: Double) {
-    
-    def +(other: Point) = { Point(x + other.x, y + other.y, z + other.z) }
-    
-    def /(div: Int) = { Point(x / div, y / div, z / div) }
-    
-    def computeEuclidianDistance(other: Point) = {
-      math.sqrt(math.pow(x - other.x, 2) + math.pow(y - other.y, 2) + math.pow(z - other.z, 2))
+  case class Point(x: Double, y: Double) {
+
+    def +(other: Point) = { Point(x + other.x, y + other.y) }
+
+    def /(div: Int) = { Point(x / div, y / div) }
+
+    def euclidianDistance(other: Point) = {
+      math.sqrt(math.pow(x - other.x, 2) + math.pow(y - other.y, 2))
     }
   }
 
-  case class Distance(dataPoint: Point, clusterId: Int, distance: Double)
-  
-  def formatCenterOutput = ((cid: Int, p: Point) => "%d|%.1f|%.1f|%.1f|".format(cid, p.x, p.y, p.z)).tupled
+  def formatCenterOutput = ((p: Point, cid: Int, d: Double) => "%d,%.1f,%.1f".format(cid, p.x, p.y)).tupled
 
 
-  def getScalaPlan(dop: Int, dataPointInput: String, clusterInput: String, clusterOutput: String, numIterations: Int) = {
+  def getScalaPlan(dataPointInput: String, clusterInput: String, clusterOutput: String, numIterations: Int) = {
     
-    val dataPoints = DataSource(dataPointInput, CsvInputFormat[(Int, Double, Double, Double)]("\n", '|')) 
-                       .map { case (id, x, y, z) => (id, Point(x, y, z)) }
+    val dataPoints = DataSource(dataPointInput, CsvInputFormat[(Double, Double)]("\n", ' '))
+                       .map { case (x, y) => Point(x, y) }
   
-    val clusterPoints = DataSource(clusterInput, CsvInputFormat[(Int, Double, Double, Double)]("\n", '|'))
-                       .map { case (id, x, y, z) => (id, Point(x, y, z)) }
+    val clusterPoints = DataSource(clusterInput, CsvInputFormat[(Int, Double, Double)]("\n", ' '))
+                       .map { case (id, x, y) => (id, Point(x, y)) }
 
 
     // iterate the K-Means function, starting with the initial cluster points
-    val finalCenters = clusterPoints.iterate(numIterations, { centers =>
+    val finalCenters = clusterPoints.iterate(numIterations, { clusterPoints =>
 
         // compute the distance between each point and all current centroids
-        val distances = dataPoints cross centers map { (point, center) =>
-            val ((pid, dataPoint), (cid, clusterPoint)) = (point, center)
-            val distToCluster = dataPoint.computeEuclidianDistance(clusterPoint)
-            (pid, Distance(dataPoint, cid, distToCluster))
+        val distances = dataPoints cross clusterPoints map { (point, center) =>
+            val (dataPoint, (cid, clusterPoint)) = (point, center)
+            val distToCluster = dataPoint euclidianDistance clusterPoint
+            (dataPoint, cid, distToCluster)
         }
       
         // pick for each point the closest centroid
-        val nearestCenters = distances groupBy { case (pid, _) => pid } reduceGroup { ds => ds.minBy(_._2.distance) }
+        val nearestCenters = distances groupBy { case (point, _, _) => point} reduceGroup { ds => ds.minBy(_._3)}
         
         // for each centroid, average among all data points that have chosen it as the closest one
         // the average is computed as sum, count, finalized as sum/count
-        nearestCenters
-              .map { case (_, Distance(dataPoint, cid, _)) => (cid, dataPoint, 1) }
-              .groupBy {_._1} .reduce { (a, b) => (a._1, a._2 + b._2, a._3 + b._3) }
-              .map { case (cid, centerPoint, num) => (cid, centerPoint / num) }
+        val nextClusterPoints = nearestCenters
+            .map { case (dataPoint, cid, _) => (cid, dataPoint, 1)}
+            .groupBy { _._1 }.reduce { (a, b) => (a._1, a._2 + b._2, a._3 + b._3)}
+            .map { case (cid, centerPoint, num) => (cid, centerPoint / num)}
+
+        nextClusterPoints
     })
 
-    val output = finalCenters.write(clusterOutput, DelimitedOutputFormat(formatCenterOutput))
+    // compute the final distances between each point and all current centroids
+    val finalDistances = dataPoints cross finalCenters map { (point, center) =>
+        val (dataPoint, (cid, clusterPoint)) = (point, center)
+        val distToCluster = dataPoint euclidianDistance clusterPoint
+        (dataPoint, cid, distToCluster)
+    }
 
-    new ScalaPlan(Seq(output), "KMeans Iteration")
+    // pick for each point the final closest centroid
+    val finalNearestCenters = finalDistances groupBy { case (point, _, _) => point} reduceGroup { ds => ds.minBy(_._3)}
+
+    val output = finalNearestCenters.write(clusterOutput, DelimitedOutputFormat(formatCenterOutput))
+
+    new ScalaPlan(Seq(output), "KMeans Example")
   }
 
   
@@ -85,11 +95,11 @@ class KMeans extends Program with ProgramDescription with Serializable {
    * @return The program plan of the kmeans example program.
    */
   override def getPlan(args: String*) = {
-    getScalaPlan(args(0).toInt, args(1), args(2), args(3), args(4).toInt)
+    getScalaPlan(args(0), args(1), args(2), args(3).toInt)
   }
     
   override def getDescription() = {
-    "Parameters: <numSubStasks> <dataPoints> <clusterCenters> <output> <numIterations>"
+    "Parameters: <dataPoints> <clusterCenters> <output> <numIterations>"
   }
 }
 
@@ -100,11 +110,11 @@ object RunKMeans {
 
   def main(args: Array[String]) {
     val km = new KMeans
-    if (args.size < 5) {
+    if (args.size < 4) {
       println(km.getDescription)
       return
     }
-    val plan = km.getScalaPlan(args(0).toInt, args(1), args(2), args(3), args(4).toInt)
+    val plan = km.getScalaPlan(args(0), args(1), args(2), args(3).toInt)
     LocalExecutor.execute(plan)
   }
 }


### PR DESCRIPTION
Some fixes in the Scala KMeans example to unify the Scala with the Java example so both behave the same. This should avoid unnecessary confusion when people try the [Quick Start Guide](http://stratosphere.eu/quickstart/example.html) with the Scala version instead.

PS. I'm not sure whether the Scala KMeans job is currenly used for integration testing. If yes, the IT test cases should be adapted before merge as well.
