### PR TITLE
Some generic changes to have an error free IDE with Java 8.

### DIFF
--- a/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/examples/SpargelConnectedComponents.java
+++ b/stratosphere-addons/spargel/src/main/java/eu/stratosphere/spargel/java/examples/SpargelConnectedComponents.java
@@ -15,6 +15,7 @@ package eu.stratosphere.spargel.java.examples;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.operators.CustomUnaryOperation;
 import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.spargel.java.MessageIterator;
 import eu.stratosphere.spargel.java.MessagingFunction;
@@ -34,7 +35,7 @@ public class SpargelConnectedComponents {
 		
 		DataSet<Tuple2<Long, Long>> initialVertices = vertexIds.map(new IdAssigner());
 		
-		DataSet<Tuple2<Long, Long>> result = initialVertices.runOperation(VertexCentricIteration.withPlainEdges(edges, new CCUpdater(), new CCMessager(), 100));
+		DataSet<Tuple2<Long, Long>> result = initialVertices.runOperation((CustomUnaryOperation<Tuple2<Long, Long>, Tuple2<Long, Long>>) VertexCentricIteration.withPlainEdges(edges, new CCUpdater(), new CCMessager(), 100));
 		
 		result.print();
 		env.execute("Spargel Connected Components");

--- a/stratosphere-addons/spargel/src/test/java/eu/stratosphere/test/spargel/SpargelConnectedComponentsITCase.java
+++ b/stratosphere-addons/spargel/src/test/java/eu/stratosphere/test/spargel/SpargelConnectedComponentsITCase.java
@@ -18,6 +18,7 @@ import java.io.BufferedReader;
 import eu.stratosphere.api.java.DataSet;
 import eu.stratosphere.api.java.ExecutionEnvironment;
 import eu.stratosphere.api.java.functions.MapFunction;
+import eu.stratosphere.api.java.operators.CustomUnaryOperation;
 import eu.stratosphere.api.java.tuple.Tuple2;
 import eu.stratosphere.spargel.java.VertexCentricIteration;
 import eu.stratosphere.spargel.java.examples.SpargelConnectedComponents.CCMessager;
@@ -53,7 +54,7 @@ public class SpargelConnectedComponentsITCase extends JavaProgramTestBase {
 		DataSet<Tuple2<Long, Long>> edges = edgeString.map(new EdgeParser());
 		
 		DataSet<Tuple2<Long, Long>> initialVertices = vertexIds.map(new IdAssigner());
-		DataSet<Tuple2<Long, Long>> result = initialVertices.runOperation(VertexCentricIteration.withPlainEdges(edges, new CCUpdater(), new CCMessager(), 100));
+		DataSet<Tuple2<Long, Long>> result = initialVertices.runOperation((CustomUnaryOperation<Tuple2<Long, Long>, Tuple2<Long, Long>>) VertexCentricIteration.withPlainEdges(edges, new CCUpdater(), new CCMessager(), 100));
 		
 		result.writeAsCsv(resultPath, "\n", " ");
 		env.execute("Spargel Connected Components");

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/DualInputOperator.java
@@ -218,7 +218,7 @@ public abstract class DualInputOperator<IN1, IN2, OUT, FT extends Function> exte
 	@Deprecated
 	@SuppressWarnings("unchecked")
 	public void addFirstInputs(List<Operator<IN1>> inputs) {
-		this.input1 = Operator.createUnionCascade(this.input1, inputs.toArray(new Operator[inputs.size()]));
+		this.input1 = Operator.<IN1>createUnionCascade(this.input1, inputs.toArray(new Operator[inputs.size()]));
 	}
 
 	/**
@@ -230,7 +230,7 @@ public abstract class DualInputOperator<IN1, IN2, OUT, FT extends Function> exte
 	@Deprecated
 	@SuppressWarnings("unchecked")
 	public void addSecondInputs(List<Operator<IN2>> inputs) {
-		this.input2 = Operator.createUnionCascade(this.input2, inputs.toArray(new Operator[inputs.size()]));
+		this.input2 = Operator.<IN2>createUnionCascade(this.input2, inputs.toArray(new Operator[inputs.size()]));
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/SingleInputOperator.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/operators/SingleInputOperator.java
@@ -125,7 +125,7 @@ public abstract class SingleInputOperator<IN, OUT, FT extends Function> extends 
 	@Deprecated
 	@SuppressWarnings("unchecked")
 	public void setInputs(List<Operator<IN>> inputs) {
-		this.input = Operator.createUnionCascade(null, inputs.toArray(new Operator[inputs.size()]));
+		this.input = Operator.<IN>createUnionCascade(null, inputs.toArray(new Operator[inputs.size()]));
 	}
 
 	/**
@@ -148,7 +148,7 @@ public abstract class SingleInputOperator<IN, OUT, FT extends Function> extends 
 	@Deprecated
 	@SuppressWarnings("unchecked")
 	public void addInput(List<Operator<IN>> inputs) {
-		this.input = Operator.createUnionCascade(this.input, inputs.toArray(new Operator[inputs.size()]));
+		this.input = Operator.<IN>createUnionCascade(this.input, inputs.toArray(new Operator[inputs.size()]));
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/ValueTypeInfo.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/ValueTypeInfo.java
@@ -67,11 +67,11 @@ public class ValueTypeInfo<T extends Value> extends TypeInformation<T> implement
 		return Comparable.class.isAssignableFrom(type);
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
-	@SuppressWarnings("unchecked")
 	public TypeSerializer<T> createSerializer() {
 		if (CopyableValue.class.isAssignableFrom(type)) {
-			return (TypeSerializer<T>) createCopyableValueSerializer(type.asSubclass(CopyableValue.class));
+			return (TypeSerializer<T>) createCopyableValueSerializer(type.<CopyableValue>asSubclass(CopyableValue.class));
 		}
 		else {
 			return new ValueSerializer<T>(type);

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleComparator.java
@@ -231,7 +231,7 @@ public final class TupleComparator<T extends Tuple> extends TypeComparator<T> im
 		try {
 			for (; i < keyPositions.length; i++) {
 				int keyPos = keyPositions[i];
-				int cmp = comparators[i].compare(first.getField(keyPos), second.getField(keyPos));
+				int cmp = comparators[i].compare((Object) first.getField(keyPos), (Object) second.getField(keyPos));
 				if (cmp != 0) {
 					return cmp;
 				}

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/typeutils/runtime/TupleSerializer.java
@@ -84,7 +84,7 @@ public final class TupleSerializer<T extends Tuple> extends TypeSerializer<T> {
 	@Override
 	public T copy(T from, T reuse) {
 		for (int i = 0; i < arity; i++) {
-			Object copy = fieldSerializers[i].copy(from.getField(i), reuse.getField(i));
+			Object copy = fieldSerializers[i].copy((Object) from.getField(i), (Object) reuse.getField(i));
 			reuse.setField(copy, i);
 		}
 		


### PR DESCRIPTION
I changed my Eclipse IDE to JDK 8 and had some issues with generics. If others also have this issues, here is a generics fix for it.
