### PR TITLE
DistCache: executable flag, directories

### DIFF
--- a/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plantranslate/NepheleJobGraphGenerator.java
+++ b/stratosphere-compiler/src/main/java/eu/stratosphere/compiler/plantranslate/NepheleJobGraphGenerator.java
@@ -30,6 +30,7 @@ import eu.stratosphere.api.common.aggregators.AggregatorWithName;
 import eu.stratosphere.api.common.aggregators.ConvergenceCriterion;
 import eu.stratosphere.api.common.aggregators.LongSumAggregator;
 import eu.stratosphere.api.common.cache.DistributedCache;
+import eu.stratosphere.api.common.cache.DistributedCache.DistributedCacheEntry;
 import eu.stratosphere.api.common.distributions.DataDistribution;
 import eu.stratosphere.api.common.typeutils.TypeSerializerFactory;
 import eu.stratosphere.compiler.CompilerException;
@@ -205,8 +206,8 @@ public class NepheleJobGraphGenerator implements Visitor<PlanNode> {
 		}
 
 		// add registered cache file into job configuration
-		for (Entry<String, String> e: program.getOriginalPactPlan().getCachedFiles()) {
-			DistributedCache.addCachedFile(e.getKey(), e.getValue(), this.jobGraph.getJobConfiguration());
+		for (Entry<String, DistributedCacheEntry> e : program.getOriginalPactPlan().getCachedFiles()) {
+			DistributedCache.writeFileInfoToConfig(e.getKey(), e.getValue(), this.jobGraph.getJobConfiguration());
 		}
 		JobGraph graph = this.jobGraph;
 

--- a/stratosphere-core/src/main/java/eu/stratosphere/api/common/Plan.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/api/common/Plan.java
@@ -15,6 +15,7 @@ package eu.stratosphere.api.common;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import eu.stratosphere.api.common.cache.DistributedCache.DistributedCacheEntry;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -66,7 +67,7 @@ public class Plan implements Visitable<Operator<?>> {
 	 */
 	protected int maxNumberMachines;
 
-	protected HashMap<String, String> cacheFile = new HashMap<String, String>();
+	protected HashMap<String, DistributedCacheEntry> cacheFile = new HashMap();
 
 	// ------------------------------------------------------------------------
 
@@ -301,28 +302,28 @@ public class Plan implements Visitable<Operator<?>> {
 	
 	/**
 	 *  register cache files in program level
-	 * @param filePath The files must be stored in a place that can be accessed from all workers (most commonly HDFS)
+	 * @param entry contains all relevant information
 	 * @param name user defined name of that file
 	 * @throws java.io.IOException
 	 */
-	public void registerCachedFile(String filePath, String name) throws RuntimeException, IOException {
+	public void registerCachedFile(String name, DistributedCacheEntry entry) throws IOException {
 		if (!this.cacheFile.containsKey(name)) {
 			try {
-				URI u = new URI(filePath);
+				URI u = new URI(entry.filePath);
 				if (!u.getPath().startsWith("/")) {
-					u = new URI(new File(filePath).getAbsolutePath());
+					u = new File(entry.filePath).toURI();
 				}
 				FileSystem fs = FileSystem.get(u);
 				if (fs.exists(new Path(u.getPath()))) {
-					this.cacheFile.put(name, u.toString());
+					this.cacheFile.put(name, new DistributedCacheEntry(u.toString(), entry.isExecutable));
 				} else {
-					throw new RuntimeException("File " + u.toString() + " doesn't exist.");
+					throw new IOException("File " + u.toString() + " doesn't exist.");
 				}
 			} catch (URISyntaxException ex) {
-				throw new RuntimeException("Invalid path: " + filePath, ex);
+				throw new IOException("Invalid path: " + entry.filePath, ex);
 			}
 		} else {
-			throw new RuntimeException("cache file " + name + "already exists!");
+			throw new IOException("cache file " + name + "already exists!");
 		}
 	}
 
@@ -330,7 +331,7 @@ public class Plan implements Visitable<Operator<?>> {
 	 * return the registered caches files
 	 * @return Set of (name, filePath) pairs
 	 */
-	public Set<Entry<String,String>> getCachedFiles() {
+	public Set<Entry<String,DistributedCacheEntry>> getCachedFiles() {
 		return this.cacheFile.entrySet();
 	}
 }

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -579,7 +579,7 @@ public abstract class ExecutionEnvironment {
 	 * @param executable flag indicating whether the file should be executable
 	 */
 	public void registerCachedFile(String filePath, String name, boolean executable){
-		this.cacheFile.add(new Tuple2(name, new DistributedCacheEntry(name, executable)));
+		this.cacheFile.add(new Tuple2(name, new DistributedCacheEntry(filePath, executable)));
 	}
 	
 	/**

--- a/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
+++ b/stratosphere-java/src/main/java/eu/stratosphere/api/java/ExecutionEnvironment.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.Validate;
 import eu.stratosphere.api.common.InvalidProgramException;
 import eu.stratosphere.api.common.JobExecutionResult;
 import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.cache.DistributedCache.DistributedCacheEntry;
 import eu.stratosphere.api.common.io.InputFormat;
 import eu.stratosphere.api.java.io.CollectionInputFormat;
 import eu.stratosphere.api.java.io.CsvReader;
@@ -87,7 +88,7 @@ public abstract class ExecutionEnvironment {
 	
 	private final List<DataSink<?>> sinks = new ArrayList<DataSink<?>>();
 	
-	private final List<Tuple2<String, String>> cacheFile = new ArrayList<Tuple2<String, String>>();
+	private final List<Tuple2<String, DistributedCacheEntry>> cacheFile = new ArrayList();
 
 	private int degreeOfParallelism = -1;
 	
@@ -547,8 +548,8 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files, or files in a distributed file system. The runtime will copy the files
-	 * temporarily to a local cache, if needed.
+	 * may be local files (as long as all relevant workers have access to it), or files in a distributed file system.
+	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 * <p>
 	 * The {@link eu.stratosphere.api.common.functions.RuntimeContext} can be obtained inside UDFs via
 	 * {@link eu.stratosphere.api.common.functions.Function#getRuntimeContext()} and provides access 
@@ -559,7 +560,26 @@ public abstract class ExecutionEnvironment {
 	 * @param name The name under which the file is registered.
 	 */
 	public void registerCachedFile(String filePath, String name){
-		this.cacheFile.add(new Tuple2<String, String>(filePath, name));
+		registerCachedFile(filePath, name, false);
+	}
+	
+	/**
+	 * Registers a file at the distributed cache under the given name. The file will be accessible
+	 * from any user-defined function in the (distributed) runtime under a local path. Files
+	 * may be local files (as long as all relevant workers have access to it), or files in a distributed file system. 
+	 * The runtime will copy the files temporarily to a local cache, if needed.
+	 * <p>
+	 * The {@link eu.stratosphere.api.common.functions.RuntimeContext} can be obtained inside UDFs via
+	 * {@link eu.stratosphere.api.common.functions.Function#getRuntimeContext()} and provides access 
+	 * {@link eu.stratosphere.api.common.cache.DistributedCache} via 
+	 * {@link eu.stratosphere.api.common.functions.RuntimeContext#getDistributedCache()}.
+	 * 
+	 * @param filePath The path of the file, as a URI (e.g. "file:///some/path" or "hdfs://host:port/and/path")
+	 * @param name The name under which the file is registered.
+	 * @param executable flag indicating whether the file should be executable
+	 */
+	public void registerCachedFile(String filePath, String name, boolean executable){
+		this.cacheFile.add(new Tuple2(name, new DistributedCacheEntry(name, executable)));
 	}
 	
 	/**
@@ -570,7 +590,7 @@ public abstract class ExecutionEnvironment {
 	 * @throws IOException Thrown if checks for existence and sanity fail.
 	 */
 	protected void registerCachedFilesWithPlan(Plan p) throws IOException {
-		for (Tuple2<String, String> entry : cacheFile) {
+		for (Tuple2<String, DistributedCacheEntry> entry : cacheFile) {
 			p.registerCachedFile(entry.f0, entry.f1);
 		}
 	}

--- a/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
+++ b/stratosphere-runtime/src/main/java/eu/stratosphere/nephele/taskmanager/TaskManager.java
@@ -50,6 +50,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import eu.stratosphere.api.common.cache.DistributedCache;
+import eu.stratosphere.api.common.cache.DistributedCache.DistributedCacheEntry;
 import eu.stratosphere.configuration.ConfigConstants;
 import eu.stratosphere.configuration.Configuration;
 import eu.stratosphere.configuration.GlobalConfiguration;
@@ -643,7 +644,7 @@ public class TaskManager implements TaskOperationProtocol {
 
 			// retrieve the registered cache files from job configuration and create the local tmp file.
 			Map<String, FutureTask<Path>> cpTasks = new HashMap<String, FutureTask<Path>>();
-			for (Entry<String, String> e: DistributedCache.getCachedFile(tdd.getJobConfiguration())) {
+			for (Entry<String, DistributedCacheEntry> e : DistributedCache.readFileInfoFromConfig(tdd.getJobConfiguration())) {
 				FutureTask<Path> cp = this.fileCache.createTmpFile(e.getKey(), e.getValue(), jobID);
 				cpTasks.put(e.getKey(), cp);
 			}
@@ -782,8 +783,8 @@ public class TaskManager implements TaskOperationProtocol {
 			}
 
 			// remove the local tmp file for unregistered tasks.
-			for (Entry<String, String> e: DistributedCache.getCachedFile(task.getEnvironment().getJobConfiguration())) {
-				this.fileCache.deleteTmpFile(e.getKey(), task.getJobID());
+			for (Entry<String, DistributedCacheEntry> e: DistributedCache.readFileInfoFromConfig(task.getEnvironment().getJobConfiguration())) {
+				this.fileCache.deleteTmpFile(e.getKey(), e.getValue(), task.getJobID());
 			}
 			// Unregister task from the byte buffered channel manager
 			this.byteBufferedChannelManager.unregister(id, task);

--- a/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/cache/FileCacheDeleteValidationTest.java
+++ b/stratosphere-runtime/src/test/java/eu/stratosphere/pact/runtime/cache/FileCacheDeleteValidationTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
+import eu.stratosphere.api.common.cache.DistributedCache.DistributedCacheEntry;
 
-import eu.stratosphere.core.fs.Path;
 import eu.stratosphere.core.fs.local.LocalFileSystem;
 import eu.stratosphere.nephele.jobgraph.JobID;
 
@@ -67,13 +67,13 @@ public class FileCacheDeleteValidationTest {
 	public void testFileReuseForNextTask() {
 		JobID jobID = new JobID();
 		String filePath = f.toURI().toString();
-		fileCache.createTmpFile("test_file", filePath, jobID);
+		fileCache.createTmpFile("test_file", new DistributedCacheEntry(filePath, false), jobID);
 		try {
 			Thread.sleep(1000);
 		} catch (InterruptedException e) {
 			throw new RuntimeException("Interrupted error", e);
 		}
-		fileCache.deleteTmpFile("test_file", jobID);
+		fileCache.deleteTmpFile("test_file", new DistributedCacheEntry(filePath, false), jobID);
 		try {
 			Thread.sleep(1000);
 		} catch (InterruptedException e) {
@@ -81,17 +81,17 @@ public class FileCacheDeleteValidationTest {
 		}
 		//new task comes after 1 second
 		try {
-			Assert.assertTrue("Local cache file should not be deleted when another task comes in 5 seconds!", lfs.exists(fileCache.getTempDir(jobID, "test_file")));
+			Assert.assertTrue("Local cache file should not be deleted when another task comes in 5 seconds!", lfs.exists(fileCache.getTempDir(jobID, "cacheFile")));
 		} catch (IOException e) {
 			throw new RuntimeException("Interrupted error", e);
 		}
-		fileCache.createTmpFile("test_file", filePath, jobID);
+		fileCache.createTmpFile("test_file", new DistributedCacheEntry(filePath, false), jobID);
 		try {
 			Thread.sleep(1000);
 		} catch (InterruptedException e) {
 			throw new RuntimeException("Interrupted error", e);
 		}
-		fileCache.deleteTmpFile("test_file", jobID);
+		fileCache.deleteTmpFile("test_file", new DistributedCacheEntry(filePath, false), jobID);
 		try {
 			Thread.sleep(7000);
 		} catch (InterruptedException e) {
@@ -99,7 +99,7 @@ public class FileCacheDeleteValidationTest {
 		}
 		//no task comes in 7 seconds
 		try {
-			Assert.assertTrue("Local cache file should be deleted when no task comes in 5 seconds!", !lfs.exists(fileCache.getTempDir(jobID, "test_file")));
+			Assert.assertTrue("Local cache file should be deleted when no task comes in 5 seconds!", !lfs.exists(fileCache.getTempDir(jobID, "cacheFile")));
 		} catch (IOException e) {
 			throw new RuntimeException("Interrupted error", e);
 		}

--- a/stratosphere-tests/src/test/java/eu/stratosphere/test/distributedCache/DistributedCacheTest.java
+++ b/stratosphere-tests/src/test/java/eu/stratosphere/test/distributedCache/DistributedCacheTest.java
@@ -14,6 +14,7 @@
 package eu.stratosphere.test.distributedCache;
 
 import eu.stratosphere.api.common.Plan;
+import eu.stratosphere.api.common.cache.DistributedCache.DistributedCacheEntry;
 import eu.stratosphere.api.java.record.operators.FileDataSink;
 import eu.stratosphere.api.java.record.operators.FileDataSource;
 import eu.stratosphere.api.java.record.functions.MapFunction;
@@ -134,7 +135,7 @@ public class DistributedCacheTest extends RecordAPITestBase {
 	protected Plan getTestJob() {
 		Plan plan =  getPlan(1 , textPath, resultPath);
 		try {
-			plan.registerCachedFile(cachePath, "cache_test");
+			plan.registerCachedFile("cache_test", new DistributedCacheEntry(cachePath, false));
 		} catch (IOException ex) {
 			throw new RuntimeException(ex);
 		}		


### PR DESCRIPTION
new features:
- you can now distribute whole directories (this copies all files tracked by `listStatus` recursively)
- when distributing single files they can be tagged as executable (automatically checked for local files)

other changes:
- the name/path scheme was changed to preserve the original name. all files are now stored in a job-specific folder, instead of having a job/identifier specific name.
- the arguments passed when registering a file are abstracted away in its own data structure, making it easier to expand the DC the future. (there is no reason why one should have to change `NepheleJobGraphGenerator` or `TaskManager` for this)
- reworded/expanded some javadocs, and made it clear that local files can only be used when they are accessible form all workers

sidenotes:
- `FileCache.CopyProcess.create()` is basically a copy function. i think we could add this as a static method to `FileSystem` as `copy(URI sourcePath, URI targetPath)`.
- the code will be tested with the python interface
