### PR TITLE
Potential bug due to unnecessary cast from long to int

### DIFF
--- a/stratosphere-addons/avro/src/main/java/eu/stratosphere/api/avro/FSDataInputStreamWrapper.java
+++ b/stratosphere-addons/avro/src/main/java/eu/stratosphere/api/avro/FSDataInputStreamWrapper.java
@@ -31,7 +31,7 @@ public class FSDataInputStreamWrapper implements Closeable, SeekableInput {
 	private final long len;
 	private long pos;
 
-	public FSDataInputStreamWrapper(final FSDataInputStream stream, final int len) {
+	public FSDataInputStreamWrapper(FSDataInputStream stream, long len) {
 		this.stream = stream;
 		this.len = len;
 		this.pos = 0;


### PR DESCRIPTION
The `FSDataInputStreamWrapper`  accepts an int, but the length is a long (and all methods passing the length are passing long.
