### PR TITLE
fix method

### DIFF
--- a/stratosphere-core/src/main/java/eu/stratosphere/util/StringUtils.java
+++ b/stratosphere-core/src/main/java/eu/stratosphere/util/StringUtils.java
@@ -285,7 +285,7 @@ public final class StringUtils {
 	 * @param maxValue The maximum character value to occur.
 	 * @return A random String.
 	 */
-	public static String getRandomString(Random rnd, int minLength, int maxLength, char minValue, char maxValue) {
+	public static String getRandomString(Random rnd, int minLength, int maxLength, char minValue, char maxValue) throws IllegalArgumentException{
 		int len = rnd.nextInt(maxLength - minLength + 1) + minLength;
 		
 		char[] data = new char[len];


### PR DESCRIPTION
Hello, When we call the getRandomString method under the
stratosphere-core/src/main/java/eu/stratosphere/util/StringUtils.java file,
the input minValue and maxValue may have opposite parameters due to no input validation,
and then this method throws java.lang.IllegalArgumentException.

We think that this method has a problem with its robustness. Either you need to add an if judgement or try catch module. Here is our test code

public class StringUtils {

 public static String getRandomString(Random rnd, int minLength, int maxLength, char minValue, char maxValue) {
        int len = rnd.nextInt(maxLength - minLength + 1) + minLength;

        char[] data = new char[len];
        int diff = maxValue - minValue + 1;

        for (int i = 0; i < data.length; i++) {
            data[i] = (char) (rnd.nextInt(diff) + minValue);
        }
        return new String(data);
    }

    public static void main(String[] args) {
        Random random = new Random();
        String randomString = StringUtils.getRandomString(random, 0, 2,'a','A');
        System.out.println(randomString);
    }

}